### PR TITLE
generate-compose-files: check the right files for existence

### DIFF
--- a/generate-compose-files.sh
+++ b/generate-compose-files.sh
@@ -9,7 +9,7 @@ fi
 
 # Generate housekeeping & pairing keypairs
 for f in "housekeeping" "pairing"; do
-	if [ ! -f ./compose/astarte-certs/$f.crt ] ; then
+	if [ ! -f ./compose/astarte-keys/$f.pub ] ; then
 		cd compose/astarte-keys/
 		openssl genrsa -out $f.key 2048
 		openssl rsa -in $f.key -out $f.pub -pubout


### PR DESCRIPTION
The script was still checking for the old generated files so it
regenerated keys every time