### PR TITLE
Add Dashboard to Docker Compose

### DIFF
--- a/compose/astarte-dashboard/config.json
+++ b/compose/astarte-dashboard/config.json
@@ -1,0 +1,9 @@
+{
+    "realm_management_api_url": "http://localhost:4000/v1/",
+    "default_auth": "token",
+    "auth": [
+        {
+            "type": "token"
+        }
+    ]
+}

--- a/doc/pages/tutorials/010-astarte_in_5_minutes.md
+++ b/doc/pages/tutorials/010-astarte_in_5_minutes.md
@@ -158,7 +158,9 @@ $ curl -X GET "http://localhost:4002/v1/test/devices/<your device id>/interfaces
 
 If you get a meaningful value, congratulations - you have a working Astarte installation with your first `datastream` coming in!
 
-From here on, you can use all of Astarte's APIs and features from your own installations. You can add devices, experiment with interfaces, or develop your own applications on top of Astarte's triggers or AppEngine's APIs. And have a lot of fun!
+Moreover, Astarte's Docker Compose also installs [Astarte Dashboard](https://github.com/astarte-platform/astarte-dashboard), from which you can manage your Realms and install Triggers, Interfaces and more from a Web UI. It is accessible by default at `http://localhost:4040/` - remember that if you are not exposing Astarte from `localhost`, you have to change Realm Management API's URL in Dashboard's configuration file, to be found in `compose/astarte-dashboard/config.json` in Astarte's repository. You can generate a token for Astarte Dashboard, as usual, through `./generate-astarte-credentials -t realm -p test_realm.key`. Grant a longer expiration by using the `-e` parameter to avoid being logged out too quickly.
+
+From here on, you can use all of Astarte's APIs and features from your own installation. You can add devices, experiment with interfaces, or develop your own applications on top of Astarte's triggers or AppEngine's APIs. And have a lot of fun!
 
 ## Cleaning up
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,15 @@ services:
       - "vernemq"
     # We don't wait for anything, as supervisord will restart stuff until it hits.
 
+  astarte-dashboard:
+    image: astarte/astarte-dashboard:snapshot
+    ports:
+      - "4040:80"
+    volumes:
+      - ./compose/astarte-dashboard/config.json:/usr/share/nginx/html/user-config/config.json
+    depends_on:
+      - "astarte-standalone"
+
   # RabbitMQ
   rabbitmq:
     image: rabbitmq:3.7


### PR DESCRIPTION
This PR adds Astarte Dashboard to our default Docker Compose installation, in a dedicated container.