### PR TITLE
docker-compose: Persist CFSSL storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ## [0.10.0-beta.3] - Unreleased
+### Fixed
+- docker-compose: Ensure CFSSL persists the CA when no external CA is provided.
 
 ## [0.10.0-beta.2] - 2018-10-19
 ### Added

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
       - "postgresql"
     volumes:
       - ./compose/cfssl-config:/config
+      - cfssl-data:/data
     # Ensure we wait for pg
     command: wait-for postgresql:5432 -t 90 -- cfssl serve -address=0.0.0.0 -ca=/data/ca.pem -ca-key=/data/ca-key.pem -port=8080 -config=/etc/cfssl/ca_root_config.json -db-config=/etc/cfssl/db_config.json
     # Restart if we fail
@@ -118,3 +119,4 @@ volumes:
   postgresql-data:
   cassandra-data:
   vernemq-data:
+  cfssl-data:


### PR DESCRIPTION
If this isn't done and no external CA is set, everytime cfssl restarts a new CA will be created, invalidating all existing device certificates and causing inevitable flooding in Pairing.

Fixes #55