### PR TITLE
docker-compose.yml: switch vernemq to 0.10.0-rc.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
 
   # VerneMQ
   vernemq:
-    image: astarte/vernemq:0.10.0-rc.0
+    image: astarte/vernemq:0.10.0-rc.1
     env_file:
      - ./compose.env
     environment:


### PR DESCRIPTION
VerneMQ docker image had a bug and a new release candidate has been released.