### PR TITLE
Dockerfile/docker-compose.yml: switch back to 0.10-snapshot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mix local.hex --force && \
 
 
 WORKDIR /build
-ARG BUILD_BRANCH=v0.10.1
+ARG BUILD_BRANCH=release-0.10
 ENV MIX_ENV prod
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
   # Astarte main services
   astarte-standalone:
-    image: astarte/astarte:0.10.1
+    image: astarte/astarte:0.10-snapshot
     env_file:
      - ./compose.env
     environment:
@@ -35,7 +35,7 @@ services:
     # We don't wait for anything, as supervisord will restart stuff until it hits.
 
   astarte-dashboard:
-    image: astarte/astarte-dashboard:0.10.1
+    image: astarte/astarte-dashboard:0.10-snapshot
     ports:
       - "4040:80"
     volumes:
@@ -44,7 +44,7 @@ services:
       - "astarte-standalone"
 
   astarte-grafana:
-    image: astarte/grafana:0.10.1
+    image: astarte/grafana:0.10-snapshot
     ports:
       - "3000:3000"
     depends_on:
@@ -84,7 +84,7 @@ services:
 
   # VerneMQ
   vernemq:
-    image: astarte/vernemq:0.10.1
+    image: astarte/vernemq:0.10-snapshot
     env_file:
      - ./compose.env
     environment:


### PR DESCRIPTION
0.10.1 release has been tagged, now Dockerfile and docker-compose.yml
can be switched back to release-0.10 branch/0.10-snapshot builds.