### PR TITLE
doc: remove "Installation with Standalone components" page

### DIFF
--- a/doc/pages/administrator/050-installation_standalone.md
+++ b/doc/pages/administrator/050-installation_standalone.md
@@ -1,1 +1,0 @@
-# Installation with Standalone components


### PR DESCRIPTION
Installation with Standalone components is not supported right now, so
remove it from documentation.

Signed-off-by: Davide Bettio <davide.bettio@ispirata.com>