### PR TITLE
migrator: handle {:error, reason} in execute_migrations

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/migrator.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/migrator.ex
@@ -280,6 +280,9 @@ defmodule Astarte.Housekeeping.Migrator do
           )
 
         {:error, :database_connection_error}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 


### PR DESCRIPTION
set_schema_version returns atom errors, handle them without crashing

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>