### PR TITLE
workflows: Add Labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,26 @@
+app:appengine_api:
+  - apps/astarte_appengine_api/**
+
+app:data_updater_plant:
+  - apps/astarte_data_updater_plant/**
+
+app:housekeeping:
+  - apps/astarte_housekeeping/**
+
+app:housekeeping_api:
+  - apps/astarte_housekeeping_api/**
+
+app:pairing:
+  - apps/astarte_pairing/**
+
+app:pairing_api:
+  - apps/astarte_pairing_api/**
+
+app:realm_management:
+  - apps/astarte_realm_management/**
+
+app:realm_management_api:
+  - apps/astarte_realm_management_api/**
+
+app:trigger_engine:
+  - apps/astarte_trigger_engine/**

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -1,0 +1,17 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler/blob/master/README.md
+
+name: Labeler
+on: [pull_request]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Set up standard GitHub Actions workflow for labeling PRs automatically based on Paths.