### PR TITLE
workflows: Fix labeler workflow

### DIFF
--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -6,7 +6,9 @@
 # https://github.com/actions/labeler/blob/master/README.md
 
 name: Labeler
-on: [pull_request]
+on:
+  schedule:
+  - cron:  '*/15 * * * *'
 
 jobs:
   label:


### PR DESCRIPTION
Due to the secrets.GITHUB_TOKEN current fiasco, on: [pull_request] doesn't cut it.
Switch to cron until there is a solution to this.