### PR TITLE
generate-compose-files: use astartectl key filename

### DIFF
--- a/generate-compose-files.sh
+++ b/generate-compose-files.sh
@@ -8,7 +8,7 @@ if [ ! -f ./compose/cfssl-config/ca.pem ] || [ ! -f ./compose/cfssl-config/ca-ke
 fi
 
 # Generate housekeeping keypairs
-if [ ! -f ./compose/astarte-keys/housekeeping.pub ] ; then
+if [ ! -f ./compose/astarte-keys/housekeeping_public.pem ] ; then
     cd compose/astarte-keys/
     astartectl utils gen-keypair housekeeping
     cd -


### PR DESCRIPTION
Leftover from key generation rework

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>