### PR TITLE
Fix any_interface triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0-beta.2] - Unreleased
 ### Changed
 - [realm_management] Handle hyphens in `interface_name`. ([#96](https://github.com/astarte-platform/astarte/issues/96))
+- [realm_management] Restrict the use of `*` as `interface_name` only to `incoming_data` data
+  triggers.
+
+### Fixed
+- [data_updater_plant] Load `incoming_data` triggers targeting `any_interface`.
+  ([#139](https://github.com/astarte-platform/astarte/issues/139))
 
 ## [0.11.0-beta.1] - 2019-12-26
 ### Added

--- a/apps/astarte_data_updater_plant/test/support/database_test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/support/database_test_helper.exs
@@ -474,47 +474,6 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
         simple_trigger_data =
           %SimpleTriggerContainer{
             simple_trigger: {
-              :introspection_trigger,
-              %IntrospectionTrigger{
-                change_type: :INTERFACE_ADDED
-              }
-            }
-          }
-          |> SimpleTriggerContainer.encode()
-
-        trigger_target_data =
-          %TriggerTargetContainer{
-            trigger_target: {
-              :amqp_trigger_target,
-              %AMQPTriggerTarget{
-                routing_key: AMQPTestHelper.events_routing_key()
-              }
-            }
-          }
-          |> TriggerTargetContainer.encode()
-
-        # object_id f7ee3cf3-b8af-ec2b-19f2-7e5bfd8d1177 means ':any_interface'
-        query =
-          DatabaseQuery.new()
-          |> DatabaseQuery.statement(@insert_into_simple_triggers)
-          |> DatabaseQuery.put(
-            :object_id,
-            :uuid.string_to_uuid("f7ee3cf3-b8af-ec2b-19f2-7e5bfd8d1177")
-          )
-          |> DatabaseQuery.put(
-            :object_type,
-            SimpleTriggersProtobufUtils.object_type_to_int!(:any_interface)
-          )
-          |> DatabaseQuery.put(:simple_trigger_id, interface_added_trigger_id())
-          |> DatabaseQuery.put(:parent_trigger_id, fake_parent_trigger_id())
-          |> DatabaseQuery.put(:trigger_data, simple_trigger_data)
-          |> DatabaseQuery.put(:trigger_target, trigger_target_data)
-
-        DatabaseQuery.call!(client, query)
-
-        simple_trigger_data =
-          %SimpleTriggerContainer{
-            simple_trigger: {
               :device_trigger,
               %DeviceTrigger{
                 device_event_type: :DEVICE_CONNECTED


### PR DESCRIPTION
Load triggers targeting interface `*`, while limiting them to `incoming_data` triggers.