### PR TITLE
doc: use org.astarte-platform.genericsensors.Values

### DIFF
--- a/doc/pages/architecture/060-triggers.md
+++ b/doc/pages/architecture/060-triggers.md
@@ -27,9 +27,9 @@ This is a JSON representation of an example trigger:
     {
       "type": "data_trigger",
       "on": "incoming_data",
-      "interface_name": "org.astarteplatform.Values",
+      "interface_name": "org.astarte-platform.genericsensors.Values",
       "interface_major": 0,
-      "match_path": "/realValue",
+      "match_path": "/streamTest/value",
       "value_match_operator": ">",
       "known_value": 0.4
     }
@@ -42,7 +42,7 @@ only a single entry in the `simple_triggers` array, but support for multiple sim
 different ways to combine them) is planned for future releases.
 
 The `condition` in the example specifies that when data is received on the
-`org.astarteplatform.Values` interface on `/realValue` path, if the value of said data is `> 0.4`,
+`org.astarte-platform.genericsensors.Values` interface on `/streamTest/value` path, if the value of said data is `> 0.4`,
 then the trigger is activated. For more information about all the possible conditions, check out the
 [Conditions section](#conditions)
 
@@ -55,8 +55,8 @@ The `action` object describes what the result of the trigger will be. In this sp
   "device_id": "<device_id>",
   "event": {
     "type": "incoming_data",
-    "interface": "org.astarteplatform.Values",
-    "path": "/realValue",
+    "interface": "org.astarte-platform.genericsensors.Values",
+    "path": "/streamTest/value",
     "value": <some_value>
   }
 }

--- a/doc/pages/tutorials/010-astarte_in_5_minutes.md
+++ b/doc/pages/tutorials/010-astarte_in_5_minutes.md
@@ -60,13 +60,13 @@ $ astartectl housekeeping realms ls --housekeeping-url http://localhost:4001/ -k
 
 ## Install an interface
 
-We will use [Astarte's Qt5 Stream Generator](https://github.com/astarte-platform/stream-qt5-test) to feed data into Astarte. Clone the repository, as we will have to install its `org.astarteplatform.Values` interface into our new realm. To do that, we can use `astartectl` again:
+We will use [Astarte's Qt5 Stream Generator](https://github.com/astarte-platform/stream-qt5-test) to feed data into Astarte. However before starting, we will have to install `org.astarte-platform.genericsensors.Values` interface into our new realm. To do that, we can use `astartectl` again:
 
 ```sh
-$ astartectl realm-management interfaces install ../stream-qt5-test/interfaces/org.astarteplatform.Values.json --realm-management-url http://localhost:4000/ -r test -k test_private.pem
+$ astartectl realm-management interfaces install standard-interfaces/org.astarte-platform.genericsensors.Values.json --realm-management-url http://localhost:4000/ -r test -k test_private.pem
 ```
 
-Now `org.astarteplatform.Values` should show up among our available interfaces:
+Now `org.astarte-platform.genericsensors.Values` should show up among our available interfaces:
 
 ```sh
 $ astartectl realm-management interfaces ls --realm-management-url http://localhost:4000/ -r test -k test_private.pem
@@ -92,9 +92,9 @@ Replace `http://example.com` with your target URL in the command below, you can 
     {
       "type": "data_trigger",
       "on": "incoming_data",
-      "interface_name": "org.astarteplatform.Values",
+      "interface_name": "org.astarte-platform.genericsensors.Values",
       "interface_major": 0,
-      "match_path": "/realValue",
+      "match_path": "/streamTest/value",
       "value_match_operator": ">",
       "known_value": 0.6
     }
@@ -172,7 +172,7 @@ You can now run `stream-qt5-test` from your last build directory. Refer to its [
 Congratulations! Your devices or fake devices are now communicating with Astarte, and your tea should be ready by now. You can check if everything is working out by invoking AppEngine APIs to get some values. In case you are using `stream-qt5-test`, you can get the last sent value with `astartectl`:
 
 ```sh
-$ astartectl appengine devices get-samples <your device id> org.astarteplatform.Values /realValue --count 1 --appengine-url http://localhost:4002 -r test -k test_private.pem
+$ astartectl appengine devices get-samples <your device id> org.astarte-platform.genericsensors.Values /streamTest/value --count 1 --appengine-url http://localhost:4002 -r test -k test_private.pem
 ```
 
 If you get a meaningful value, congratulations - you have a working Astarte installation with your first `datastream` coming in!

--- a/doc/pages/user/052-using_channels.md
+++ b/doc/pages/user/052-using_channels.md
@@ -43,16 +43,16 @@ To install a Transient Trigger, one should issue a `watch` event in the Channel,
     "simple_trigger": {
         "type": "data_trigger",
         "on": "incoming_data",
-        "interface_name": "org.astarteplatform.Values",
+        "interface_name": "org.astarte-platform.genericsensors.Values",
         "interface_major": 0,
-        "match_path": "/realValue",
+        "match_path": "/streamTest/value",
         "value_match_operator": ">",
         "known_value": 0.6
     }
 }
 ```
 
-This installs in the Room a Transient Trigger which will trigger an event everytime a value higher than `0.6` is sent on the path `/realValue` of the `datastream` interface `org.astarteplatform.Values` by the device `f0VMRgIBAQAAAAAAAAAAAA`, and will be received by every user currently in the room. If a user isn't in the room at the time of the event, he will not get it, and there's no way he can retrieve it if he joined at a later time.
+This installs in the Room a Transient Trigger which will trigger an event everytime a value higher than `0.6` is sent on the path `/streamTest/value` of the `datastream` interface `org.astarte-platform.genericsensors.Values` by the device `f0VMRgIBAQAAAAAAAAAAAA`, and will be received by every user currently in the room. If a user isn't in the room at the time of the event, he will not get it, and there's no way he can retrieve it if he joined at a later time.
 
 Triggers can be uninstalled by issuing an `unwatch` event in the Channel. The payload of the event should be the name of the trigger which should be uninstalled.
 
@@ -70,4 +70,4 @@ The `JOIN` verb has the following semantic: `JOIN::<regex>`, where regex matches
 
 The `WATCH` verb allows a user to install a Trigger within a room. Its semantics define which kind of trigger, and upon which entities the user is allowed to act. Watch semantics are `WATCH::<regex>`, where `regex` is a regular expression which matches a device, path or interface (or a mixture of them) in almost very same fashion as the `a_aea` claim (which is used in AppEngine).
 
-Given different kind of triggers impact different Astarte entities, the Authorization claim implicitly defines which kind of triggers a user will be able to install. For example, `f0VMRgIBAQAAAAAAAAAAAA/org.astarteplatform.Values.*` will allow installing data triggers such as the one shown in the previous example, but won't let the user install device-wide triggers (such as connect/disconnect events). A claim such as `f0VMRgIBAQAAAAAAAAAAAA` or `f0VMRgIBAQAAAAAAAAAAAA.*`, instead, will allow device-level triggers to be installed.
+Given different kind of triggers impact different Astarte entities, the Authorization claim implicitly defines which kind of triggers a user will be able to install. For example, `f0VMRgIBAQAAAAAAAAAAAA/org.astarte-platform.genericsensors.Values.*` will allow installing data triggers such as the one shown in the previous example, but won't let the user install device-wide triggers (such as connect/disconnect events). A claim such as `f0VMRgIBAQAAAAAAAAAAAA` or `f0VMRgIBAQAAAAAAAAAAAA.*`, instead, will allow device-level triggers to be installed.

--- a/doc/pages/user/060-using_triggers.md
+++ b/doc/pages/user/060-using_triggers.md
@@ -57,7 +57,7 @@ Now, when a device connects, `<post-url>` will receive the following JSON payloa
 ## Data Trigger
 
 This trigger will send a `POST` request to `<post-url>` every time a device sends data to the
-`org.astarteplatform.Values` major version `0` interface on the `/realValue` path.
+`org.astarte-platform.genericsensors.Values` major version `0` interface on the `/streamTest/value` path.
 
 This is the JSON representation of the trigger
 ```json
@@ -70,9 +70,9 @@ This is the JSON representation of the trigger
         {
             "type": "data_trigger",
             "on": "incoming_data",
-            "interface_name": "org.astarteplatform.Values",
+            "interface_name": "org.astarte-platform.genericsensors.Values",
             "interface_major": 0,
-            "match_path": "/realValue",
+            "match_path": "/streamTest/value",
             "value_match_operator": "*"
         }
     ]
@@ -96,8 +96,8 @@ following JSON payload:
   "device_id": "<device_id>",
   "event": {
     "type": "incoming_data",
-    "interface": "org.astarteplatform.Values",
-    "path": "/realValue",
+    "interface": "org.astarte-platform.genericsensors.Values",
+    "path": "/streamTest/value",
     "value": <value>
   }
 }


### PR DESCRIPTION
stream-qt5-test doesn't use anymore org.astarteplatform.Values, use
org.astarte-platform.genericsensors.Values everywhere instead.