### PR TITLE
standard-interfaces: add missing explicit_timestamp

### DIFF
--- a/standard-interfaces/org.astarte-platform.genericsensors.Values.json
+++ b/standard-interfaces/org.astarte-platform.genericsensors.Values.json
@@ -10,6 +10,7 @@
         {
             "endpoint": "/%{sensor_id}/value",
             "type": "double",
+            "explicit_timestamp": true,
             "description": "Sampled real value.",
             "doc": "Datastream of sampled real values."
         }


### PR DESCRIPTION
Set org.astarte-platform.genericsensors.Values.json/%{sensor_id}/value
explicit_timestamp to true.