### PR TITLE
Handle TTL for server owned interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [appengine_api] Export specific metrics with telemetry.
 - [all] Make Elixir logger handle OTP requests: print stack traces only when needed.
 - [appengine_api] Handle aggregated server owned interfaces.
+- [appengine-api] Handle TTL for server owned interfaces.
 
 ## [0.11.0-beta.2] - 2020-01-24
 ### Added

--- a/apps/astarte_appengine_api/test/support/database_test_helper.exs
+++ b/apps/astarte_appengine_api/test/support/database_test_helper.exs
@@ -851,6 +851,36 @@ defmodule Astarte.AppEngine.API.DatabaseTestHelper do
     DatabaseQuery.call!(client, query)
   end
 
+  def set_realm_ttl(ttl_s) do
+    set_realm_ttl_statement = """
+      INSERT INTO autotestrealm.kv_store (group, key, value)
+      VALUES ('realm_config', 'datastream_maximum_storage_retention', intAsBlob(:ttl_s))
+    """
+
+    {:ok, client} = Database.connect()
+
+    query =
+      DatabaseQuery.new()
+      |> DatabaseQuery.statement(set_realm_ttl_statement)
+      |> DatabaseQuery.put(:ttl_s, ttl_s)
+
+    DatabaseQuery.call!(client, query)
+  end
+
+  def unset_realm_ttl do
+    unset_realm_ttl_statement = """
+      DELETE FROM autotestrealm.kv_store WHERE group='realm_config' AND key='datastream_maximum_storage_retention'
+    """
+
+    {:ok, client} = Database.connect()
+
+    query =
+      DatabaseQuery.new()
+      |> DatabaseQuery.statement(unset_realm_ttl_statement)
+
+    DatabaseQuery.call!(client, query)
+  end
+
   def devices_count do
     length(@devices_list)
   end


### PR DESCRIPTION
Use realm wide or interface TTL while inserting values into the database. Fix #239
