### PR TITLE
workflows: disable fail-fast

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -26,6 +26,7 @@ jobs:
     name: Check Dialyzer
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         app:
         - astarte_appengine_api
@@ -82,6 +83,7 @@ jobs:
     needs:
       - test-dialyzer
     strategy:
+      fail-fast: false
       matrix:
         app:
         - astarte_appengine_api

--- a/.github/workflows/pr-container-build-workflow.yaml
+++ b/.github/workflows/pr-container-build-workflow.yaml
@@ -12,6 +12,7 @@ jobs:
     name: Test Container Build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         app:
         - astarte_appengine_api


### PR DESCRIPTION
All Astarte apps should be tested regardless of failed tests.