### PR TITLE
rooms_channel_test: add stub to test

### DIFF
--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/channels/rooms_channel_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/channels/rooms_channel_test.exs
@@ -298,6 +298,9 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
 
         {:ok, @encoded_generic_ok_reply}
       end)
+      |> stub(:rpc_call, fn _serialized_call, @dup_rpc_destination ->
+        {:ok, @encoded_generic_ok_reply}
+      end)
 
       watch_payload = %{
         "device_id" => @device_id,


### PR DESCRIPTION
The test was sometimes failing due to a missing Mox stub. Fix this.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>