### PR TITLE
DUP: an unexpected object aggregated value was crashing DUP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0-rc.1] - Unreleased
+### Fixed
+- [data_updater_plant] Discard unexpected object aggregated values on individual interfaces.
+
 ## [0.11.0-rc.0] - 2020-02-26
 - [realm_management] Correctly handle parametric endpoints regardless of the ordering, so that overlapping endpoints are always refused.
 - [pairing_api] Add health endpoint.

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -698,6 +698,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     end
   end
 
+  # TODO: We need tests for this function
   def validate_value_type(expected_type, %DateTime{} = value) do
     ValueType.validate_value(expected_type, value)
   end
@@ -707,7 +708,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     {:error, :unexpected_value_type}
   end
 
-  def validate_value_type(expected_types, %{} = object) do
+  def validate_value_type(%{} = expected_types, %{} = object) do
     Enum.reduce_while(object, :ok, fn {key, value}, _acc ->
       with {:ok, expected_type} <- Map.fetch(expected_types, key),
            :ok <- ValueType.validate_value(expected_type, value) do
@@ -720,6 +721,18 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           {:halt, {:error, :unexpected_object_key}}
       end
     end)
+  end
+
+  # TODO: we should test for this kind of unexpected messages
+  # We expected an individual value, but we received an aggregated
+  def validate_value_type(expected_types, %{} = object) do
+    {:error, :unexpected_value_type}
+  end
+
+  # TODO: we should test for this kind of unexpected messages
+  # We expected an aggregated, but we received an individual
+  def validate_value_type(%{} = expected_types, object) do
+    {:error, :unexpected_value_type}
   end
 
   def validate_value_type(expected_type, value) do


### PR DESCRIPTION
Ensure validate_value function discard any (map, not_map) or (not_map,
map) pair, otherwise Map.fetch would crash.