### PR TITLE
actions: Fix a number of issues related to caching

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -45,25 +45,25 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/deps
-        key: ${{ runner.os }}-mix-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
+        key: ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
-          ${{ runner.os }}-mix-${{ matrix.app }}-
-          ${{ runner.os }}-mix-
+          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
+          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/_build
-        key: ${{ runner.os }}-_build-${{ matrix.app }}-${{ github.sha }}
+        key: ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-_build-${{ matrix.app }}-
-          ${{ runner.os }}-_build-
+          ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/dialyzer_cache
-        key: ${{ runner.os }}-dialyzer_cache-${{ matrix.app }}-${{ github.sha }}
+        key: ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-dialyzer_cache-${{ matrix.app }}-
-          ${{ runner.os }}-dialyzer_cache-
+          ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/setup-elixir@v1.2.0
       with:
         otp-version: ${{ env.otp_version }}
@@ -124,18 +124,18 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/deps
-        key: ${{ runner.os }}-mix-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
+        key: ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
-          ${{ runner.os }}-mix-${{ matrix.app }}-
-          ${{ runner.os }}-mix-
+          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
+          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/_build
-        key: ${{ runner.os }}-_build-${{ matrix.app }}-${{ github.sha }}
+        key: ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-_build-${{ matrix.app }}-
-          ${{ runner.os }}-_build-
+          ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/setup-elixir@v1.2.0
       with:
         otp-version: ${{ env.otp_version }}

--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -48,21 +48,18 @@ jobs:
         key: ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
         restore-keys: |
           ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/_build
         key: ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/dialyzer_cache
         key: ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/setup-elixir@v1.2.0
       with:
         otp-version: ${{ env.otp_version }}
@@ -126,14 +123,12 @@ jobs:
         key: ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
         restore-keys: |
           ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/_build
         key: ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/setup-elixir@v1.2.0
       with:
         otp-version: ${{ env.otp_version }}

--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -45,18 +45,17 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/deps
-        key: ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
+        key: ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
-          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-
+          ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/_build
-        key: ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
+        key: ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-
+          ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/dialyzer_cache
@@ -124,18 +123,17 @@ jobs:
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/deps
-        key: ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
+        key: ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
-          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-mix-${{ env.otp_version }}-${{ env.elixir_version }}-
+          ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/cache@v1
       with:
         path: apps/${{ matrix.app }}/_build
-        key: ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
+        key: ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-          ${{ runner.os }}-_build-${{ env.otp_version }}-${{ env.elixir_version }}-
+          ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-
     - uses: actions/setup-elixir@v1.2.0
       with:
         otp-version: ${{ env.otp_version }}


### PR DESCRIPTION
Caching in our current actions workflows had three big issues:

1. Caching was done regardless of the Elixir/OTP version
2. Caches were potentially shared across dialyzer and build
3. Caches were potentially shared across different apps

This resulted in all sorts of flakes and incompatibilities across different release branches. This PR implements a way stricter approach to caching which should hopefully address all of these issues.