### PR TITLE
Force update of :re2 in all apps that have it as a dependency

### DIFF
--- a/apps/astarte_appengine_api/mix.exs
+++ b/apps/astarte_appengine_api/mix.exs
@@ -92,6 +92,8 @@ defmodule Astarte.AppEngine.API.Mixfile do
       {:cqerl,
        github: "matehat/cqerl", ref: "6e44b42df1cb0fcf82d8ab4df032c2e7cacb96f9", override: true},
       {:cqex, github: "matehat/cqex", ref: "a2c45667108f9b1e8a9c73c5250a04020bf72a30"},
+      # TODO: remove this when cqex is removed
+      {:re2, "~> 1.9.4", override: true},
       {:cors_plug, "~> 1.5"},
       {:ex_lttb, "~> 0.3"},
       {:cyanide, github: "ispirata/cyanide"},

--- a/apps/astarte_appengine_api/mix.lock
+++ b/apps/astarte_appengine_api/mix.lock
@@ -59,7 +59,7 @@
   "quickrand": {:hex, :quickrand, "1.7.5", "e3086a153eb13a057fc19192d05e2d4c6bb2bdbb55746a699beae9847ac17ca8", [:rebar3], [], "hexpm", "6a1da81fe098c0dfcfb55c5e35c20be430128e88bbfa03d18fcf9e0ee8e342d7"},
   "rabbit_common": {:hex, :rabbit_common, "3.7.15", "fd44d795b905fd55cddb126524a74ef17a3127f2224b958fb19e0979e0aa238c", [:make, :rebar3], [{:jsx, "2.9.0", [hex: :jsx, repo: "hexpm", optional: false]}, {:lager, "3.6.10", [hex: :lager, repo: "hexpm", optional: false]}, {:ranch, "1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}, {:recon, "2.5.0", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "28c8db59dd94f4502d2d2c94db799270a3f76a5de72376446641c352ed0d0968"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
-  "re2": {:git, "https://github.com/tuncer/re2.git", "2471e06ed7e548ca1af522e95b16867135afdfdc", [tag: "v1.7.5"]},
+  "re2": {:hex, :re2, "1.9.4", "f6a47b915aac354f5dc9105182eeb740b9ded9e7f56948885b9795479831f9f2", [:rebar3], [], "hexpm", "95ea70b3ff30844ccacf695445052891c3629f516dcd275c7023243717687287"},
   "recon": {:hex, :recon, "2.5.0", "2f7fcbec2c35034bade2f9717f77059dc54eb4e929a3049ca7ba6775c0bd66cd", [:mix, :rebar3], [], "hexpm", "72f3840fedd94f06315c523f6cecf5b4827233bed7ae3fe135b2a0ebeab5e196"},
   "semver": {:git, "https://github.com/nebularis/semver.git", "c7d509f38298ec6594be4efdcd8a8f2322760039", [ref: "c7d509"]},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif.git", "4e3b8611b6a1ff85a417b0f2fad8886c9485810e", [ref: "4e3b861"]},

--- a/apps/astarte_data_updater_plant/mix.exs
+++ b/apps/astarte_data_updater_plant/mix.exs
@@ -76,6 +76,8 @@ defmodule Astarte.DataUpdaterPlant.Mixfile do
       {:cqerl,
        github: "matehat/cqerl", ref: "6e44b42df1cb0fcf82d8ab4df032c2e7cacb96f9", override: true},
       {:cqex, github: "matehat/cqex", ref: "a2c45667108f9b1e8a9c73c5250a04020bf72a30"},
+      # TODO: remove this when cqex is removed
+      {:re2, "~> 1.9.4", override: true},
       {:cyanide, github: "ispirata/cyanide"},
       {:conform, "== 2.5.2"},
       {:distillery, "~> 1.5", runtime: false},

--- a/apps/astarte_data_updater_plant/mix.lock
+++ b/apps/astarte_data_updater_plant/mix.lock
@@ -46,7 +46,7 @@
   "quickrand": {:hex, :quickrand, "1.7.5", "e3086a153eb13a057fc19192d05e2d4c6bb2bdbb55746a699beae9847ac17ca8", [:rebar3], [], "hexpm", "6a1da81fe098c0dfcfb55c5e35c20be430128e88bbfa03d18fcf9e0ee8e342d7"},
   "rabbit_common": {:hex, :rabbit_common, "3.7.15", "fd44d795b905fd55cddb126524a74ef17a3127f2224b958fb19e0979e0aa238c", [:make, :rebar3], [{:jsx, "2.9.0", [hex: :jsx, repo: "hexpm", optional: false]}, {:lager, "3.6.10", [hex: :lager, repo: "hexpm", optional: false]}, {:ranch, "1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}, {:recon, "2.5.0", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "28c8db59dd94f4502d2d2c94db799270a3f76a5de72376446641c352ed0d0968"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
-  "re2": {:git, "https://github.com/tuncer/re2.git", "2471e06ed7e548ca1af522e95b16867135afdfdc", [tag: "v1.7.5"]},
+  "re2": {:hex, :re2, "1.9.4", "f6a47b915aac354f5dc9105182eeb740b9ded9e7f56948885b9795479831f9f2", [:rebar3], [], "hexpm", "95ea70b3ff30844ccacf695445052891c3629f516dcd275c7023243717687287"},
   "recon": {:hex, :recon, "2.5.0", "2f7fcbec2c35034bade2f9717f77059dc54eb4e929a3049ca7ba6775c0bd66cd", [:mix, :rebar3], [], "hexpm", "72f3840fedd94f06315c523f6cecf5b4827233bed7ae3fe135b2a0ebeab5e196"},
   "semver": {:git, "https://github.com/nebularis/semver.git", "c7d509f38298ec6594be4efdcd8a8f2322760039", [ref: "c7d509"]},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif.git", "4e3b8611b6a1ff85a417b0f2fad8886c9485810e", [ref: "4e3b861"]},

--- a/apps/astarte_pairing/mix.exs
+++ b/apps/astarte_pairing/mix.exs
@@ -80,6 +80,8 @@ defmodule Astarte.Pairing.Mixfile do
       {:cqerl,
        github: "matehat/cqerl", ref: "6e44b42df1cb0fcf82d8ab4df032c2e7cacb96f9", override: true},
       {:cqex, github: "matehat/cqex", ref: "a2c45667108f9b1e8a9c73c5250a04020bf72a30"},
+      # TODO: remove this when cqex is removed
+      {:re2, "~> 1.9.4", override: true},
       {:cfxxl, "~> 0.3"},
       {:conform, "== 2.5.2"},
       {:bcrypt_elixir, "~> 1.0"},

--- a/apps/astarte_pairing/mix.lock
+++ b/apps/astarte_pairing/mix.lock
@@ -51,7 +51,7 @@
   "quickrand": {:hex, :quickrand, "1.7.5", "e3086a153eb13a057fc19192d05e2d4c6bb2bdbb55746a699beae9847ac17ca8", [:rebar3], [], "hexpm", "6a1da81fe098c0dfcfb55c5e35c20be430128e88bbfa03d18fcf9e0ee8e342d7"},
   "rabbit_common": {:hex, :rabbit_common, "3.7.15", "fd44d795b905fd55cddb126524a74ef17a3127f2224b958fb19e0979e0aa238c", [:make, :rebar3], [{:jsx, "2.9.0", [hex: :jsx, repo: "hexpm", optional: false]}, {:lager, "3.6.10", [hex: :lager, repo: "hexpm", optional: false]}, {:ranch, "1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}, {:recon, "2.5.0", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "28c8db59dd94f4502d2d2c94db799270a3f76a5de72376446641c352ed0d0968"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
-  "re2": {:git, "https://github.com/tuncer/re2.git", "2471e06ed7e548ca1af522e95b16867135afdfdc", [tag: "v1.7.5"]},
+  "re2": {:hex, :re2, "1.9.4", "f6a47b915aac354f5dc9105182eeb740b9ded9e7f56948885b9795479831f9f2", [:rebar3], [], "hexpm", "95ea70b3ff30844ccacf695445052891c3629f516dcd275c7023243717687287"},
   "recon": {:hex, :recon, "2.5.0", "2f7fcbec2c35034bade2f9717f77059dc54eb4e929a3049ca7ba6775c0bd66cd", [:mix, :rebar3], [], "hexpm", "72f3840fedd94f06315c523f6cecf5b4827233bed7ae3fe135b2a0ebeab5e196"},
   "semver": {:git, "https://github.com/nebularis/semver.git", "c7d509f38298ec6594be4efdcd8a8f2322760039", [ref: "c7d509"]},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif.git", "4e3b8611b6a1ff85a417b0f2fad8886c9485810e", [ref: "4e3b861"]},

--- a/apps/astarte_realm_management/mix.exs
+++ b/apps/astarte_realm_management/mix.exs
@@ -75,6 +75,8 @@ defmodule Astarte.RealmManagement.Mixfile do
       {:cqerl,
        github: "matehat/cqerl", ref: "6e44b42df1cb0fcf82d8ab4df032c2e7cacb96f9", override: true},
       {:cqex, github: "matehat/cqex", ref: "a2c45667108f9b1e8a9c73c5250a04020bf72a30"},
+      # TODO: remove this when cqex is removed
+      {:re2, "~> 1.9.4", override: true},
       {:conform, "== 2.5.2"},
       {:distillery, "~> 1.5", runtime: false},
       {:excoveralls, "~> 0.11", only: :test},

--- a/apps/astarte_realm_management/mix.lock
+++ b/apps/astarte_realm_management/mix.lock
@@ -46,7 +46,7 @@
   "quickrand": {:hex, :quickrand, "1.7.5", "e3086a153eb13a057fc19192d05e2d4c6bb2bdbb55746a699beae9847ac17ca8", [:rebar3], [], "hexpm", "6a1da81fe098c0dfcfb55c5e35c20be430128e88bbfa03d18fcf9e0ee8e342d7"},
   "rabbit_common": {:hex, :rabbit_common, "3.7.15", "fd44d795b905fd55cddb126524a74ef17a3127f2224b958fb19e0979e0aa238c", [:make, :rebar3], [{:jsx, "2.9.0", [hex: :jsx, repo: "hexpm", optional: false]}, {:lager, "3.6.10", [hex: :lager, repo: "hexpm", optional: false]}, {:ranch, "1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}, {:recon, "2.5.0", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "28c8db59dd94f4502d2d2c94db799270a3f76a5de72376446641c352ed0d0968"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
-  "re2": {:git, "https://github.com/tuncer/re2.git", "2471e06ed7e548ca1af522e95b16867135afdfdc", [tag: "v1.7.5"]},
+  "re2": {:hex, :re2, "1.9.4", "f6a47b915aac354f5dc9105182eeb740b9ded9e7f56948885b9795479831f9f2", [:rebar3], [], "hexpm", "95ea70b3ff30844ccacf695445052891c3629f516dcd275c7023243717687287"},
   "recon": {:hex, :recon, "2.5.0", "2f7fcbec2c35034bade2f9717f77059dc54eb4e929a3049ca7ba6775c0bd66cd", [:mix, :rebar3], [], "hexpm", "72f3840fedd94f06315c523f6cecf5b4827233bed7ae3fe135b2a0ebeab5e196"},
   "semver": {:git, "https://github.com/nebularis/semver.git", "c7d509f38298ec6594be4efdcd8a8f2322760039", [ref: "c7d509"]},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif.git", "4e3b8611b6a1ff85a417b0f2fad8886c9485810e", [ref: "4e3b861"]},

--- a/apps/astarte_trigger_engine/mix.exs
+++ b/apps/astarte_trigger_engine/mix.exs
@@ -79,6 +79,8 @@ defmodule Astarte.TriggerEngine.Mixfile do
       {:conform, "== 2.5.2"},
       {:cyanide, github: "ispirata/cyanide"},
       {:cqex, github: "matehat/cqex", ref: "a2c45667108f9b1e8a9c73c5250a04020bf72a30"},
+      # TODO: remove this when cqex is removed
+      {:re2, "~> 1.9.4", override: true},
       {:cqerl,
        github: "matehat/cqerl", ref: "6e44b42df1cb0fcf82d8ab4df032c2e7cacb96f9", override: true},
       {:httpoison, "~> 1.1"},

--- a/apps/astarte_trigger_engine/mix.lock
+++ b/apps/astarte_trigger_engine/mix.lock
@@ -48,7 +48,7 @@
   "quickrand": {:hex, :quickrand, "1.7.5", "e3086a153eb13a057fc19192d05e2d4c6bb2bdbb55746a699beae9847ac17ca8", [:rebar3], [], "hexpm", "6a1da81fe098c0dfcfb55c5e35c20be430128e88bbfa03d18fcf9e0ee8e342d7"},
   "rabbit_common": {:hex, :rabbit_common, "3.7.15", "fd44d795b905fd55cddb126524a74ef17a3127f2224b958fb19e0979e0aa238c", [:make, :rebar3], [{:jsx, "2.9.0", [hex: :jsx, repo: "hexpm", optional: false]}, {:lager, "3.6.10", [hex: :lager, repo: "hexpm", optional: false]}, {:ranch, "1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}, {:recon, "2.5.0", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "28c8db59dd94f4502d2d2c94db799270a3f76a5de72376446641c352ed0d0968"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm", "451d8527787df716d99dc36162fca05934915db0b6141bbdac2ea8d3c7afc7d7"},
-  "re2": {:git, "https://github.com/tuncer/re2.git", "2471e06ed7e548ca1af522e95b16867135afdfdc", [tag: "v1.7.5"]},
+  "re2": {:hex, :re2, "1.9.4", "f6a47b915aac354f5dc9105182eeb740b9ded9e7f56948885b9795479831f9f2", [:rebar3], [], "hexpm", "95ea70b3ff30844ccacf695445052891c3629f516dcd275c7023243717687287"},
   "recon": {:hex, :recon, "2.5.0", "2f7fcbec2c35034bade2f9717f77059dc54eb4e929a3049ca7ba6775c0bd66cd", [:mix, :rebar3], [], "hexpm", "72f3840fedd94f06315c523f6cecf5b4827233bed7ae3fe135b2a0ebeab5e196"},
   "semver": {:git, "https://github.com/nebularis/semver.git", "c7d509f38298ec6594be4efdcd8a8f2322760039", [ref: "c7d509"]},
   "snappy": {:git, "https://github.com/fdmanana/snappy-erlang-nif.git", "4e3b8611b6a1ff85a417b0f2fad8886c9485810e", [ref: "4e3b861"]},


### PR DESCRIPTION
Fix a problem preventing re2_nif.so from being compiled and consequently
blocking all applications from starting up

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>