### PR TITLE
Temporarily force re2 to version 1.9.4 in all apps

### DIFF
--- a/apps/astarte_appengine_api/mix.exs
+++ b/apps/astarte_appengine_api/mix.exs
@@ -81,6 +81,9 @@ defmodule Astarte.AppEngine.API.Mixfile do
   # Type `mix help deps` for examples and options.
   defp deps do
     [
+      # TODO: remove this when astarte_data_access is updated to the version
+      # with re2 1.9.4
+      {:re2, "~> 1.9.4", override: true},
       {:phoenix, "~> 1.4"},
       {:phoenix_pubsub, "~> 1.1"},
       {:phoenix_ecto, "~> 4.0"},

--- a/apps/astarte_data_updater_plant/mix.exs
+++ b/apps/astarte_data_updater_plant/mix.exs
@@ -71,6 +71,9 @@ defmodule Astarte.DataUpdaterPlant.Mixfile do
 
   defp deps do
     [
+      # TODO: remove this when astarte_data_access is updated to the version
+      # with re2 1.9.4
+      {:re2, "~> 1.9.4", override: true},
       {:amqp, "~> 1.2"},
       {:cyanide, github: "ispirata/cyanide"},
       {:conform, "== 2.5.2"},

--- a/apps/astarte_housekeeping/mix.exs
+++ b/apps/astarte_housekeeping/mix.exs
@@ -79,6 +79,9 @@ defmodule Astarte.Housekeeping.Mixfile do
 
   defp deps do
     [
+      # TODO: remove this when astarte_data_access is updated to the version
+      # with re2 1.9.4
+      {:re2, "~> 1.9.4", override: true},
       {:xandra, "~> 0.13"},
       {:conform, "== 2.5.2"},
       {:distillery, "~> 1.5", runtime: false},

--- a/apps/astarte_pairing/mix.exs
+++ b/apps/astarte_pairing/mix.exs
@@ -76,6 +76,9 @@ defmodule Astarte.Pairing.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      # TODO: remove this when astarte_data_access is updated to the version
+      # with re2 1.9.4
+      {:re2, "~> 1.9.4", override: true},
       {:cfxxl, "~> 0.3"},
       {:conform, "== 2.5.2"},
       {:bcrypt_elixir, "~> 1.0"},

--- a/apps/astarte_realm_management/mix.exs
+++ b/apps/astarte_realm_management/mix.exs
@@ -71,6 +71,9 @@ defmodule Astarte.RealmManagement.Mixfile do
 
   defp deps do
     [
+      # TODO: remove this when astarte_data_access is updated to the version
+      # with re2 1.9.4
+      {:re2, "~> 1.9.4", override: true},
       {:conform, "== 2.5.2"},
       {:distillery, "~> 1.5", runtime: false},
       {:excoveralls, "~> 0.11", only: :test},

--- a/apps/astarte_trigger_engine/mix.exs
+++ b/apps/astarte_trigger_engine/mix.exs
@@ -73,6 +73,9 @@ defmodule Astarte.TriggerEngine.Mixfile do
 
   defp deps do
     [
+      # TODO: remove this when astarte_data_access is updated to the version
+      # with re2 1.9.4
+      {:re2, "~> 1.9.4", override: true},
       {:amqp, "~> 1.2.1"},
       {:bbmustache, "~> 1.5"},
       {:conform, "== 2.5.2"},


### PR DESCRIPTION
Temporary work around since astarte_data_access will be updated in the
Skogsra PR (#274) since its API changed

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>