### PR TITLE
appengine_api: convert DateTime values to millisecond epoch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - Unreleased
+### Fixed
+- [appengine_api] Handle server owned datetime values correctly
+
 ## [0.11.0-rc.1] - 2020-03-26
 ### Fixed
 - [data_updater_plant] Discard unexpected object aggregated values on individual interfaces.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -570,6 +570,10 @@ defmodule Astarte.AppEngine.API.Device.Queries do
   end
 
   # TODO Copy&pasted from data updater plant, make it a library
+  defp to_db_friendly_type(%DateTime{} = datetime) do
+    DateTime.to_unix(datetime, :millisecond)
+  end
+
   defp to_db_friendly_type(value) do
     value
   end


### PR DESCRIPTION
CQEx does not support passing a DateTime as timestamp value in a query, fix that

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>