### PR TITLE
housekeeping: use explicit keyspace in queries when creating a realm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0] - Unreleased
 ### Fixed
 - [appengine_api] Handle server owned datetime values correctly
+- [housekeeping] Fix a bug preventing the public key of newly created realms to be correctly
+  inserted to the realm (see #294).
 - [data_updater_plant] Fix a bug that was preventing volatile triggers (specifically, the ones
   targeting the `*` interface) to be loaded immediately.
 

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/queries.ex
@@ -90,18 +90,18 @@ defmodule Astarte.Housekeeping.Queries do
     Xandra.Cluster.run(:xandra, [timeout: 60_000], fn conn ->
       with :ok <- validate_realm_name(realm_name),
            :ok <- create_realm_keyspace(conn, realm_name, replication_map_str),
-           :ok <- use_realm(conn, realm_name),
-           :ok <- create_realm_kv_store(conn),
-           :ok <- create_names_table(conn),
-           :ok <- create_devices_table(conn),
-           :ok <- create_endpoints_table(conn),
-           :ok <- create_interfaces_table(conn),
-           :ok <- create_individual_properties_table(conn),
-           :ok <- create_simple_triggers_table(conn),
-           :ok <- create_grouped_devices_table(conn),
-           :ok <- insert_realm_public_key(conn, public_key_pem),
-           :ok <- insert_realm_astarte_schema_version(conn),
-           :ok <- insert_realm(conn, realm_name) do
+           {:ok, realm_conn} <- build_realm_conn(conn, realm_name),
+           :ok <- create_realm_kv_store(realm_conn),
+           :ok <- create_names_table(realm_conn),
+           :ok <- create_devices_table(realm_conn),
+           :ok <- create_endpoints_table(realm_conn),
+           :ok <- create_interfaces_table(realm_conn),
+           :ok <- create_individual_properties_table(realm_conn),
+           :ok <- create_simple_triggers_table(realm_conn),
+           :ok <- create_grouped_devices_table(realm_conn),
+           :ok <- insert_realm_public_key(realm_conn, public_key_pem),
+           :ok <- insert_realm_astarte_schema_version(realm_conn),
+           :ok <- insert_realm(realm_conn) do
         :ok
       else
         {:error, reason} ->
@@ -116,27 +116,15 @@ defmodule Astarte.Housekeeping.Queries do
     end)
   end
 
-  defp use_realm(conn, realm_name) do
-    with :ok <- validate_realm_name(realm_name),
-         {:ok, %Xandra.SetKeyspace{}} <- Xandra.execute(conn, "USE #{realm_name}") do
-      :ok
-    else
-      {:error, %Xandra.Error{} = err} ->
-        _ = Logger.warn("Database error: #{inspect(err)}.", tag: "database_error")
-        {:error, :database_error}
-
-      {:error, %Xandra.ConnectionError{} = err} ->
-        _ =
-          Logger.warn("Database connection error: #{inspect(err)}.",
-            tag: "database_connection_error"
-          )
-
-        {:error, :database_connection_error}
+  defp build_realm_conn(conn, realm_name) do
+    case validate_realm_name(realm_name) do
+      :ok ->
+        {:ok, {conn, realm_name}}
 
       {:error, reason} ->
         _ =
-          Logger.warn("Cannot USE realm: #{inspect(reason)}.",
-            tag: "use_realm_error",
+          Logger.warn("Cannot build realm conn: #{inspect(reason)}.",
+            tag: "build_realm_conn_error",
             realm: realm_name
           )
 
@@ -169,9 +157,9 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp create_realm_kv_store(realm_conn) do
+  defp create_realm_kv_store({conn, realm}) do
     query = """
-    CREATE TABLE kv_store (
+    CREATE TABLE #{realm}.kv_store (
       group varchar,
       key varchar,
       value blob,
@@ -181,7 +169,7 @@ defmodule Astarte.Housekeeping.Queries do
     """
 
     with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -198,9 +186,9 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp create_names_table(realm_conn) do
+  defp create_names_table({conn, realm}) do
     query = """
-    CREATE TABLE names (
+    CREATE TABLE #{realm}.names (
       object_name varchar,
       object_type int,
       object_uuid uuid,
@@ -209,7 +197,7 @@ defmodule Astarte.Housekeeping.Queries do
     """
 
     with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -226,9 +214,9 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp create_devices_table(realm_conn) do
+  defp create_devices_table({conn, realm}) do
     query = """
-    CREATE TABLE devices (
+    CREATE TABLE #{realm}.devices (
       device_id uuid,
       aliases map<ascii, varchar>,
       introspection map<ascii, int>,
@@ -259,7 +247,7 @@ defmodule Astarte.Housekeeping.Queries do
     """
 
     with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -276,9 +264,9 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp create_endpoints_table(realm_conn) do
+  defp create_endpoints_table({conn, realm}) do
     query = """
-    CREATE TABLE endpoints (
+    CREATE TABLE #{realm}.endpoints (
       interface_id uuid,
       endpoint_id uuid,
       interface_name ascii,
@@ -302,7 +290,7 @@ defmodule Astarte.Housekeeping.Queries do
     """
 
     with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -319,9 +307,9 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp create_interfaces_table(realm_conn) do
+  defp create_interfaces_table({conn, realm}) do
     query = """
-    CREATE TABLE interfaces (
+    CREATE TABLE #{realm}.interfaces (
       name ascii,
       major_version int,
       minor_version int,
@@ -341,7 +329,7 @@ defmodule Astarte.Housekeeping.Queries do
     """
 
     with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -358,9 +346,9 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp create_individual_properties_table(realm_conn) do
+  defp create_individual_properties_table({conn, realm}) do
     query = """
-    CREATE TABLE individual_properties (
+    CREATE TABLE #{realm}.individual_properties (
       device_id uuid,
       interface_id uuid,
       endpoint_id uuid,
@@ -388,7 +376,7 @@ defmodule Astarte.Housekeeping.Queries do
     """
 
     with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -405,9 +393,9 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp create_simple_triggers_table(realm_conn) do
+  defp create_simple_triggers_table({conn, realm}) do
     query = """
-    CREATE TABLE simple_triggers (
+    CREATE TABLE #{realm}.simple_triggers (
       object_id uuid,
       object_type int,
       parent_trigger_id uuid,
@@ -420,7 +408,7 @@ defmodule Astarte.Housekeeping.Queries do
     """
 
     with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -437,9 +425,9 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp create_grouped_devices_table(realm_conn) do
+  defp create_grouped_devices_table({conn, realm}) do
     query = """
-    CREATE TABLE grouped_devices (
+    CREATE TABLE #{realm}.grouped_devices (
       group_name varchar,
       insertion_uuid timeuuid,
       device_id uuid,
@@ -449,7 +437,7 @@ defmodule Astarte.Housekeeping.Queries do
     """
 
     with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -466,17 +454,17 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp insert_realm_public_key(realm_conn, public_key_pem) do
+  defp insert_realm_public_key({conn, realm}, public_key_pem) do
     query = """
-    INSERT INTO kv_store (group, key, value)
+    INSERT INTO #{realm}.kv_store (group, key, value)
     VALUES ('auth', 'jwt_public_key_pem', varcharAsBlob(:public_key_pem));
     """
 
     params = %{"public_key_pem" => public_key_pem}
 
-    with {:ok, prepared} <- Xandra.prepare(realm_conn, query),
+    with {:ok, prepared} <- Xandra.prepare(conn, query),
          {:ok, %Xandra.Void{}} <-
-           Xandra.execute(realm_conn, prepared, params, consistency: :each_quorum) do
+           Xandra.execute(conn, prepared, params, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -493,15 +481,15 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp insert_realm_astarte_schema_version(realm_conn) do
+  defp insert_realm_astarte_schema_version({conn, realm}) do
     query = """
-    INSERT INTO kv_store
+    INSERT INTO #{realm}.kv_store
     (group, key, value)
     VALUES ('astarte', 'schema_version', bigintAsBlob(#{Migrator.latest_realm_schema_version()}));
     """
 
     with {:ok, %Xandra.Void{}} <-
-           Xandra.execute(realm_conn, query, %{}, consistency: :each_quorum) do
+           Xandra.execute(conn, query, %{}, consistency: :each_quorum) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -518,7 +506,7 @@ defmodule Astarte.Housekeeping.Queries do
     end
   end
 
-  defp insert_realm(conn, realm_name) do
+  defp insert_realm({conn, realm_name}) do
     query = """
     INSERT INTO astarte.realms (realm_name)
     VALUES (:realm_name);

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/queries_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/queries_test.exs
@@ -21,8 +21,10 @@ defmodule Astarte.Housekeeping.QueriesTest do
   doctest Astarte.Housekeeping.Queries
 
   alias Astarte.Housekeeping.DatabaseTestHelper
+  alias Astarte.Housekeeping.Queries
 
-  @realm "test"
+  @realm1 "test1"
+  @realm2 "test2"
 
   setup_all do
     DatabaseTestHelper.wait_and_initialize()
@@ -35,12 +37,28 @@ defmodule Astarte.Housekeeping.QueriesTest do
   setup [:realm_cleanup]
 
   test "realm creation" do
-    assert Astarte.Housekeeping.Queries.create_realm(@realm, "testpublickey", 1, []) == :ok
+    assert Queries.create_realm(@realm1, "test1publickey", 1, []) == :ok
+    assert Queries.create_realm(@realm2, "test2publickey", 1, []) == :ok
+
+    assert %{
+             realm_name: @realm1,
+             jwt_public_key_pem: "test1publickey",
+             replication_class: "SimpleStrategy",
+             replication_factor: 1
+           } = Queries.get_realm(@realm1)
+
+    assert %{
+             realm_name: @realm2,
+             jwt_public_key_pem: "test2publickey",
+             replication_class: "SimpleStrategy",
+             replication_factor: 1
+           } = Queries.get_realm(@realm2)
   end
 
   defp realm_cleanup(_context) do
     on_exit(fn ->
-      DatabaseTestHelper.realm_cleanup(@realm)
+      DatabaseTestHelper.realm_cleanup(@realm1)
+      DatabaseTestHelper.realm_cleanup(@realm2)
     end)
 
     :ok


### PR DESCRIPTION
This is a work-around for https://github.com/lexhide/xandra/issues/179 to avoid
that the public key of a newly created realm gets written to another one.

Fix #294

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>