### PR TITLE
data_updater_plant: always immediately load triggers on success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.11.0] - Unreleased
 ### Fixed
 - [appengine_api] Handle server owned datetime values correctly
+- [data_updater_plant] Fix a bug that was preventing volatile triggers (specifically, the ones
+  targeting the `*` interface) to be loaded immediately.
 
 ## [0.11.0-rc.1] - 2020-03-26
 ### Fixed

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -1187,7 +1187,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     else
       case trigger do
         {:data_trigger, %ProtobufDataTrigger{interface_name: "*"}} ->
-          {:ok, new_state}
+          {:ok, load_trigger(new_state, trigger, target)}
 
         {:data_trigger,
          %ProtobufDataTrigger{
@@ -1198,7 +1198,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           with {:ok, db_client} <- Database.connect(state.realm),
                {:ok, %InterfaceDescriptor{aggregation: :individual}} <-
                  InterfaceQueries.fetch_interface_descriptor(db_client, interface_name, major) do
-            {:ok, new_state}
+            {:ok, load_trigger(new_state, trigger, target)}
           else
             {:ok, %InterfaceDescriptor{aggregation: :object}} ->
               {{:error, :unsupported_interface_aggregation}, state}
@@ -1218,7 +1218,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
                {:ok, %InterfaceDescriptor{automaton: automaton, aggregation: :individual}} <-
                  InterfaceQueries.fetch_interface_descriptor(db_client, interface_name, major),
                {:ok, _endpoint_id} <- EndpointsAutomaton.resolve_path(match_path, automaton) do
-            {:ok, new_state}
+            {:ok, load_trigger(new_state, trigger, target)}
           else
             {:error, :not_found} ->
               # State rollback here
@@ -1237,7 +1237,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           end
 
         {:introspection_trigger, _} ->
-          {:ok, new_state}
+          {:ok, load_trigger(new_state, trigger, target)}
 
         {:device_trigger, _} ->
           {:ok, load_trigger(new_state, trigger, target)}


### PR DESCRIPTION
Fix a bug that was preventing volatile triggers (specifically, the ones
targeting the * interface) to be loaded immediately.

Fix #300

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>