### PR TITLE
Fix exposed metrics

### DIFF
--- a/apps/astarte_appengine_api/config/config.exs
+++ b/apps/astarte_appengine_api/config/config.exs
@@ -85,7 +85,7 @@ config :prometheus, Astarte.AppEngine.APIWeb.Metrics.PhoenixInstrumenter,
   duration_unit: :microseconds
 
 config :prometheus, Astarte.AppEngine.APIWeb.Metrics.PipelineInstrumenter,
-  labels: [:status_class, :method, :host, :scheme, :request_path],
+  labels: [:status_class, :method, :host, :scheme],
   duration_buckets: [
     10,
     100,

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/metrics/pipeline_instrumenter.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/metrics/pipeline_instrumenter.ex
@@ -19,7 +19,10 @@
 defmodule Astarte.AppEngine.APIWeb.Metrics.PipelineInstrumenter do
   use Prometheus.PlugPipelineInstrumenter
 
-  def label_value(:request_path, conn) do
-    conn.request_path
-  end
+  # TODO enable label value. Currently it was suppressed as to limit the number
+  # of the different metrics which are generated.
+  # see issue #339
+  # def label_value(:request_path, conn) do
+  #   conn.request_path
+  # end
 end

--- a/apps/astarte_housekeeping_api/config/config.exs
+++ b/apps/astarte_housekeeping_api/config/config.exs
@@ -61,7 +61,7 @@ config :prometheus, Astarte.Housekeeping.APIWeb.Metrics.PhoenixInstrumenter,
   duration_unit: :microseconds
 
 config :prometheus, Astarte.Housekeeping.APIWeb.Metrics.PipelineInstrumenter,
-  labels: [:status_class, :method, :host, :scheme, :request_path],
+  labels: [:status_class, :method, :host, :scheme],
   duration_buckets: [
     10,
     100,

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/metrics/pipeline_instrumenter.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/metrics/pipeline_instrumenter.ex
@@ -19,7 +19,10 @@
 defmodule Astarte.Housekeeping.APIWeb.Metrics.PipelineInstrumenter do
   use Prometheus.PlugPipelineInstrumenter
 
-  def label_value(:request_path, conn) do
-    conn.request_path
-  end
+  # TODO enable label value. Currently it was suppressed as to limit the number
+  # of the different metrics which are generated.
+  # see issue #339
+  # def label_value(:request_path, conn) do
+  #   conn.request_path
+  # end
 end

--- a/apps/astarte_pairing_api/config/config.exs
+++ b/apps/astarte_pairing_api/config/config.exs
@@ -78,7 +78,7 @@ config :prometheus, Astarte.Pairing.APIWeb.Metrics.PhoenixInstrumenter,
   duration_unit: :microseconds
 
 config :prometheus, Astarte.Pairing.APIWeb.Metrics.PipelineInstrumenter,
-  labels: [:status_class, :method, :host, :scheme, :request_path],
+  labels: [:status_class, :method, :host, :scheme],
   duration_buckets: [
     10,
     100,

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/metrics/pipeline_instrumenter.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/metrics/pipeline_instrumenter.ex
@@ -19,7 +19,10 @@
 defmodule Astarte.Pairing.APIWeb.Metrics.PipelineInstrumenter do
   use Prometheus.PlugPipelineInstrumenter
 
-  def label_value(:request_path, conn) do
-    conn.request_path
-  end
+  # TODO enable label value. Currently it was suppressed as to limit the number
+  # of the different metrics which are generated.
+  # see issue #339
+  # def label_value(:request_path, conn) do
+  #   conn.request_path
+  # end
 end

--- a/apps/astarte_realm_management_api/config/config.exs
+++ b/apps/astarte_realm_management_api/config/config.exs
@@ -59,7 +59,7 @@ config :prometheus, Astarte.RealmManagement.APIWeb.Metrics.PhoenixInstrumenter,
   duration_unit: :microseconds
 
 config :prometheus, Astarte.RealmManagement.APIWeb.Metrics.PipelineInstrumenter,
-  labels: [:status_class, :method, :host, :scheme, :request_path],
+  labels: [:status_class, :method, :host, :scheme],
   duration_buckets: [
     10,
     100,

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/metrics/pipeline_instrumenter.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/metrics/pipeline_instrumenter.ex
@@ -19,7 +19,10 @@
 defmodule Astarte.RealmManagement.APIWeb.Metrics.PipelineInstrumenter do
   use Prometheus.PlugPipelineInstrumenter
 
-  def label_value(:request_path, conn) do
-    conn.request_path
-  end
+  # TODO enable label value. Currently it was suppressed as to limit the number
+  # of the different metrics which are generated.
+  # see issue #339
+  # def label_value(:request_path, conn) do
+  #   conn.request_path
+  # end
 end


### PR DESCRIPTION
Limit the number of different metrics which are generated. In particular, don't split metrics based on request_path`. See Issue #339
