### PR TITLE
Make ports configurable for each service

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/endpoint.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/endpoint.ex
@@ -62,19 +62,4 @@ defmodule Astarte.AppEngine.APIWeb.Endpoint do
 
   plug CORSPlug
   plug Astarte.AppEngine.APIWeb.Router
-
-  @doc """
-  Callback invoked for dynamically configuring the endpoint.
-
-  It receives the endpoint configuration and checks if
-  configuration should be loaded from the system environment.
-  """
-  def init(_key, config) do
-    if config[:load_from_system_env] do
-      port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-      {:ok, Keyword.put(config, :http, [:inet6, port: port])}
-    else
-      {:ok, config}
-    end
-  end
 end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/config.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/config.ex
@@ -31,7 +31,7 @@ defmodule Astarte.Housekeeping.Config do
 
   @envdoc "The port where the housekeeping metrics endpoint will be exposed."
   app_env :port, :astarte_housekeeping, :port,
-    os_env: "PORT",
+    os_env: "HOUSEKEEPING_PORT",
     type: :integer,
     default: 4008
 

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/config.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/config.ex
@@ -21,12 +21,6 @@ defmodule Astarte.Housekeeping.API.Config do
 
   use Skogsra
 
-  @envdoc "The port used from the Phoenix server."
-  app_env :port, :astarte_housekeeping_api, :port,
-    os_env: "HOUSEKEEPING_API_PORT",
-    type: :integer,
-    default: 4001
-
   @envdoc "The bind address for the Phoenix server."
   app_env :bind_address, :astarte_housekeeping_api, :bind_address,
     os_env: "HOUSEKEEPING_API_BIND_ADDRESS",

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/endpoint.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/endpoint.ex
@@ -64,15 +64,4 @@ defmodule Astarte.Housekeeping.APIWeb.Endpoint do
 
   plug CORSPlug
   plug Astarte.Housekeeping.APIWeb.Router
-
-  @doc """
-  Dynamically loads configuration from the system environment
-  on startup.
-
-  It receives the endpoint configuration from the config files
-  and must return the updated configuration.
-  """
-  def load_from_system_env(config) do
-    {:ok, Keyword.put(config, :http, [:inet6, port: Config.port!()])}
-  end
 end

--- a/apps/astarte_pairing/lib/astarte_pairing/config.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/config.ex
@@ -26,6 +26,12 @@ defmodule Astarte.Pairing.Config do
   alias Astarte.Pairing.CFSSLCredentials
   alias Astarte.DataAccess.Config, as: DataAccessConfig
 
+  @envdoc "The port where Pairing metrics will be exposed."
+  app_env :port, :astarte_pairing, :port,
+    os_env: "PAIRING_PORT",
+    type: :integer,
+    default: 4005
+
   @envdoc "The external broker URL which should be used by devices."
   app_env :broker_url, :astarte_pairing, :broker_url,
     os_env: "PAIRING_BROKER_URL",

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api/config.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api/config.ex
@@ -23,12 +23,6 @@ defmodule Astarte.Pairing.API.Config do
 
   use Skogsra
 
-  @envdoc "The port used from the Phoenix server."
-  app_env :port, :astarte_pairing_api, :port,
-    os_env: "PAIRING_API_PORT",
-    type: :integer,
-    default: 4003
-
   @envdoc """
   Disables JWT authentication for agent's endpoints. CHANGING IT TO TRUE IS GENERALLY A REALLY BAD IDEA IN A PRODUCTION ENVIRONMENT, IF YOU DON'T KNOW WHAT YOU ARE DOING.
   """

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/endpoint.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/endpoint.ex
@@ -64,19 +64,4 @@ defmodule Astarte.Pairing.APIWeb.Endpoint do
 
   plug CORSPlug
   plug Astarte.Pairing.APIWeb.Router
-
-  @doc """
-  Callback invoked for dynamically configuring the endpoint.
-
-  It receives the endpoint configuration and checks if
-  configuration should be loaded from the system environment.
-  """
-  def init(_key, config) do
-    if config[:load_from_system_env] do
-      port = System.get_env("PORT") || raise "expected the PORT environment variable to be set"
-      {:ok, Keyword.put(config, :http, [:inet6, port: port])}
-    else
-      {:ok, config}
-    end
-  end
 end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/config.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/config.ex
@@ -24,6 +24,12 @@ defmodule Astarte.RealmManagement.Config do
   use Skogsra
   alias Astarte.DataAccess.Config, as: DataAccessConfig
 
+  @envdoc "The port where Realm Management metrics will be exposed."
+  app_env :port, :astarte_realm_management, :port,
+    os_env: "REALM_MANAGEMENT_PORT",
+    type: :integer,
+    default: 4006
+
   @doc """
   Returns Cassandra nodes formatted in the Xandra format.
   """

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/config.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/config.ex
@@ -23,12 +23,6 @@ defmodule Astarte.RealmManagement.API.Config do
 
   use Skogsra
 
-  @envdoc "The port used by the Phoenix server."
-  app_env :port, :astarte_realm_management_api, :port,
-    os_env: "REALM_MANAGEMENT_API_PORT",
-    type: :integer,
-    default: 4000
-
   @envdoc """
   "Disables the authentication. CHANGING IT TO TRUE IS GENERALLY A REALLY BAD IDEA IN A PRODUCTION ENVIRONMENT, IF YOU DON'T KNOW WHAT YOU ARE DOING.
   """

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/endpoint.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/endpoint.ex
@@ -64,16 +64,4 @@ defmodule Astarte.RealmManagement.APIWeb.Endpoint do
 
   plug CORSPlug
   plug Astarte.RealmManagement.APIWeb.Router
-
-  @doc """
-  Dynamically loads configuration from the system environment
-  on startup.
-
-  It receives the endpoint configuration from the config files
-  and must return the updated configuration.
-  """
-  def load_from_system_env(config) do
-    port = Config.port!()
-    {:ok, Keyword.put(config, :http, [:inet6, port: port])}
-  end
 end

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/config.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/config.ex
@@ -75,7 +75,7 @@ defmodule Astarte.TriggerEngine.Config do
 
   @envdoc "The port where Trigger Engine metrics will be exposed."
   app_env :port, :astarte_trigger_engine, :port,
-    os_env: "PORT",
+    os_env: "TRIGGER_ENGINE_PORT",
     type: :integer,
     default: 4007
 


### PR DESCRIPTION
+ Allow to configure the ports for each service
+ All the services with an API allow the port configuration in a single point (i.e. releases.exs)
+ Adopt a coherent naming for port env (i.e. <SERVICE_NAME>_PORT)