### PR TITLE
data_updater_plant: add Data Updater deactivation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [trigger_egnine] Add optional support to custom http headers, such as
   `Authorization: Bearer ...` (see [#129](https://github.com/astarte-platform/astarte/issues/129)).
 - [data_updater_plant] Handle device hearbeat sent by VerneMQ plugin.
+- [data_updater_plant] Deactivate Data Updaters when they don't receive messages for some time,
+  freeing up resources.
 
 ### Removed
 - [appengine_api] Remove deprecated not versioned socket route.

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_data_consumer.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_data_consumer.ex
@@ -134,6 +134,15 @@ defmodule Astarte.DataUpdaterPlant.AMQPDataConsumer do
     {:noreply, chan}
   end
 
+  def handle_info(
+        {:DOWN, _, :process, pid, :normal},
+        %Channel{pid: chan_pid, conn: %Connection{pid: conn_pid}} = chan
+      )
+      when pid != chan_pid and pid != conn_pid do
+    # This is a Message Tracker deactivating itself normally, do nothing
+    {:noreply, chan}
+  end
+
   # Make sure to handle monitored message trackers exit messages
   # Under the hood DataUpdater calls Process.monitor so those monitor are leaked into this process.
   def handle_info({:DOWN, _, :process, _pid, reason}, state) do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -225,6 +225,10 @@ defmodule Astarte.DataUpdaterPlant.Config do
     ]
   end
 
+  def data_updater_deactivation_interval_ms! do
+    device_heartbeat_interval_ms!() * 3
+  end
+
   @doc """
   Returns Cassandra nodes formatted in the Xandra format.
   """

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -86,6 +86,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     |> Map.put(:datastream_maximum_storage_retention, ttl)
   end
 
+  def handle_deactivation(_state) do
+    Logger.info("Deactivated device process.", tag: "device_process_deactivated")
+
+    :ok
+  end
+
   def handle_connection(state, ip_address_string, message_id, timestamp) do
     {:ok, db_client} = Database.connect(realm: state.realm)
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/server.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/server.ex
@@ -18,6 +18,7 @@
 
 defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
   use GenServer
+  alias Astarte.DataUpdaterPlant.Config
   alias Astarte.DataUpdaterPlant.DataUpdater.Impl
   alias Astarte.DataUpdaterPlant.MessageTracker
 
@@ -26,25 +27,31 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
   end
 
   def init({realm, device_id, message_tracker}) do
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
     send(self(), {:initialize, realm, device_id, message_tracker})
-    {:ok, nil}
+    {:ok, nil, timeout}
   end
 
   def handle_cast({:handle_connection, ip_address, message_id, timestamp}, state) do
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
     if MessageTracker.can_process_message(state.message_tracker, message_id) do
       new_state = Impl.handle_connection(state, ip_address, message_id, timestamp)
-      {:noreply, new_state}
+      {:noreply, new_state, timeout}
     else
-      {:noreply, state}
+      {:noreply, state, timeout}
     end
   end
 
   def handle_cast({:handle_disconnection, message_id, timestamp}, state) do
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
     if MessageTracker.can_process_message(state.message_tracker, message_id) do
       new_state = Impl.handle_disconnection(state, message_id, timestamp)
-      {:noreply, new_state}
+      {:noreply, new_state, timeout}
     else
-      {:noreply, state}
+      {:noreply, state, timeout}
     end
   end
 
@@ -58,29 +65,35 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
   end
 
   def handle_cast({:handle_data, interface, path, payload, message_id, timestamp}, state) do
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
     if MessageTracker.can_process_message(state.message_tracker, message_id) do
       new_state = Impl.handle_data(state, interface, path, payload, message_id, timestamp)
-      {:noreply, new_state}
+      {:noreply, new_state, timeout}
     else
-      {:noreply, state}
+      {:noreply, state, timeout}
     end
   end
 
   def handle_cast({:handle_introspection, payload, message_id, timestamp}, state) do
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
     if MessageTracker.can_process_message(state.message_tracker, message_id) do
       new_state = Impl.handle_introspection(state, payload, message_id, timestamp)
-      {:noreply, new_state}
+      {:noreply, new_state, timeout}
     else
-      {:noreply, state}
+      {:noreply, state, timeout}
     end
   end
 
   def handle_cast({:handle_control, payload, path, message_id, timestamp}, state) do
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
     if MessageTracker.can_process_message(state.message_tracker, message_id) do
       new_state = Impl.handle_control(state, payload, path, message_id, timestamp)
       {:noreply, new_state}
     else
-      {:noreply, state}
+      {:noreply, state, timeout}
     end
   end
 
@@ -90,6 +103,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
         _from,
         state
       ) do
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
     {return_value, new_state} =
       Impl.handle_install_volatile_trigger(
         state,
@@ -101,21 +116,32 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
         trigger_target
       )
 
-    {:reply, return_value, new_state}
+    {:reply, return_value, new_state, timeout}
   end
 
   def handle_call({:handle_delete_volatile_trigger, trigger_id}, _from, state) do
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
     {result, new_state} = Impl.handle_delete_volatile_trigger(state, trigger_id)
 
-    {:reply, result, new_state}
+    {:reply, result, new_state, timeout}
   end
 
   def handle_call({:dump_state}, _from, state) do
-    {:reply, state, state}
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
+    {:reply, state, state, timeout}
   end
 
   def handle_info({:initialize, realm, device_id, message_tracker}, nil) do
-    {:noreply, Impl.init_state(realm, device_id, message_tracker)}
+    timeout = Config.data_updater_deactivation_interval_ms!()
+
+    {:noreply, Impl.init_state(realm, device_id, message_tracker), timeout}
+  end
+
+  def handle_info({:DOWN, _, :process, pid, :normal}, %{message_tracker: pid} = state) do
+    # This is a MessageTracker normally terminating due to deactivation
+    {:noreply, state}
   end
 
   def handle_info({:DOWN, _, :process, _pid, :shutdown}, state) do
@@ -124,5 +150,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
 
   def handle_info({:DOWN, _, :process, _pid, _reason}, state) do
     {:stop, :monitored_process_died, state}
+  end
+
+  def handle_info(:timeout, state) do
+    :ok = Impl.handle_deactivation(state)
+    :ok = MessageTracker.deactivate(state.message_tracker)
+
+    {:stop, :normal, state}
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/message_tracker.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/message_tracker.ex
@@ -43,4 +43,8 @@ defmodule Astarte.DataUpdaterPlant.MessageTracker do
   def discard(message_tracker, message_id) do
     GenServer.call(message_tracker, {:discard, message_id})
   end
+
+  def deactivate(message_tracker) do
+    GenServer.call(message_tracker, :deactivate, :infinity)
+  end
 end


### PR DESCRIPTION
Make a Data Updater deactivate if it doesn't receive any message for 3 times the
device heartbeat interval.

Fix #354

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>