### PR TITLE
appengine_instrumenter: use Counter.inc with :discarded_events_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Wait for schema_version agreement before applying any schema change (such as creating tables or a
   new realm). (see [#312](https://github.com/astarte-platform/astarte/issues/312).
+- [appengine_api] Fix the metric counting discarded channel events, it was not correctly increased.
 
 ## [0.11.0] - 2020-04-13
 ### Fixed

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/metrics/appengine_instrumenter.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/metrics/appengine_instrumenter.ex
@@ -115,6 +115,6 @@ defmodule Astarte.AppEngine.APIWeb.Metrics.AppEngineInstrumenter do
         %{realm: realm} = _metadata,
         _config
       ) do
-    Gauge.inc(name: :discarded_events_total, labels: [realm])
+    Counter.inc(name: :discarded_events_total, labels: [realm])
   end
 end


### PR DESCRIPTION
It's a Counter, not a Gauge

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>