### PR TITLE
appengine_api: prevent crashes when updating metadata or aliases

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
@@ -183,6 +183,20 @@ defmodule Astarte.AppEngine.APIWeb.FallbackController do
     |> render(:"404_mapping_not_found")
   end
 
+  def call(conn, {:error, :invalid_alias}) do
+    conn
+    |> put_status(:bad_request)
+    |> put_view(Astarte.AppEngine.APIWeb.ErrorView)
+    |> render(:"422_invalid_alias")
+  end
+
+  def call(conn, {:error, :invalid_metadata}) do
+    conn
+    |> put_status(:bad_request)
+    |> put_view(Astarte.AppEngine.APIWeb.ErrorView)
+    |> render(:"422_invalid_metadata")
+  end
+
   # This is called when no JWT token is present
   def auth_error(conn, {:unauthenticated, reason}, _opts) do
     _ =

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
@@ -82,6 +82,14 @@ defmodule Astarte.AppEngine.APIWeb.ErrorView do
     %{errors: %{detail: "Alias already in use"}}
   end
 
+  def render("422_invalid_alias.json", _assigns) do
+    %{errors: %{detail: "Invalid alias"}}
+  end
+
+  def render("422_invalid_metadata.json", _assigns) do
+    %{errors: %{detail: "Invalid metadata"}}
+  end
+
   def render("500.json", _assigns) do
     %{errors: %{detail: "Internal server error"}}
   end

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
@@ -1601,6 +1601,46 @@ defmodule Astarte.AppEngine.API.DeviceTest do
               Map.put(@expected_device_status, :metadata, %{"metadata_key" => "new_metadata"})}
   end
 
+  test "empty value is ok when updating device metadata using merge_device_status/3" do
+    params = %{"metadata" => %{"metadata_key" => ""}}
+
+    assert Device.merge_device_status(
+             "autotestrealm",
+             "f0VMRgIBAQAAAAAAAAAAAA",
+             params
+           ) == {:ok, Map.put(@expected_device_status, :metadata, %{"metadata_key" => ""})}
+  end
+
+  test "empty key returns an error when updating device metadata using merge_device_status/3" do
+    params = %{"metadata" => %{"" => "metadata_val"}}
+
+    assert Device.merge_device_status(
+             "autotestrealm",
+             "f0VMRgIBAQAAAAAAAAAAAA",
+             params
+           ) == {:error, :invalid_metadata}
+  end
+
+  test "empty key returns an error when updating device aliases using merge_device_status/3" do
+    params = %{"aliases" => %{"" => "alias_val"}}
+
+    assert Device.merge_device_status(
+             "autotestrealm",
+             "f0VMRgIBAQAAAAAAAAAAAA",
+             params
+           ) == {:error, :invalid_alias}
+  end
+
+  test "empty value leaves the status unchanged when updating device aliases using merge_device_status/3" do
+    params = %{"aliases" => %{"alias_key" => ""}}
+
+    assert Device.merge_device_status(
+             "autotestrealm",
+             "f0VMRgIBAQAAAAAAAAAAAA",
+             params
+           ) == {:error, :invalid_alias}
+  end
+
   test "delete metadata with existing key using merge_device_status" do
     modified_metadata = %{"metadata" => %{"metadata_key" => nil}}
 


### PR DESCRIPTION
+ Do not crash when using an empty string for aliases (either key or
value). 400 is returned instead.
+ Do not crash when using an empty string for metadata keyi. 400 is
returned instead.
+ Metadata values can be set to empty string.

Fix #357