### PR TITLE
compose: remove /v1 prefix from dashboard configuration

### DIFF
--- a/compose/astarte-dashboard/config.json
+++ b/compose/astarte-dashboard/config.json
@@ -1,7 +1,7 @@
 {
     "secure_connection": false,
-    "appengine_api_url": "http://localhost:4002/v1",
-    "realm_management_api_url": "http://localhost:4000/v1",
+    "appengine_api_url": "http://localhost:4002",
+    "realm_management_api_url": "http://localhost:4000",
     "default_auth": "token",
     "auth": [
         {


### PR DESCRIPTION
It is not needed anymore

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>