### PR TITLE
data_updater: serialize MessageTracker and DataUpdater.Server starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.11.1] - Unreleased
+### Added
+- [data_updater_plant] Add `DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_TOTAL_COUNT` environment variable,
+  this must be equal to the total number of queues in the Astarte instance.
+
 ### Fixed
 - Wait for schema_version agreement before applying any schema change (such as creating tables or a
   new realm). (see [#312](https://github.com/astarte-platform/astarte/issues/312).
 - [appengine_api] Fix the metric counting discarded channel events, it was not correctly increased.
 - [data_update_plant] Validate UTF8 strings coming from the broker (i.e. interface and path) to
   avoid passing invalid strings to the database.
+- [data_updater_plant] Fix a bug that was sometimes stalling a data updater queue process (see
+  [#375](https://github.com/astarte-platform/astarte/issues/375).
 
 ## [0.11.0] - 2020-04-13
 ### Fixed

--- a/apps/astarte_data_updater_plant/config/astarte_data_updater_plant.schema.exs
+++ b/apps/astarte_data_updater_plant/config/astarte_data_updater_plant.schema.exs
@@ -176,6 +176,17 @@ See the moduledoc for `Conform.Schema.Validator` for more details and examples.
       hidden: false,
       to: "astarte_data_updater_plant.data_queue_range_start"
     ],
+    data_queue_range_start: [
+      commented: true,
+      datatype: :integer,
+      required: false,
+      default: 1,
+      env_var: "DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_TOTAL_COUNT",
+      doc:
+        "Returns the total number of data queues in the whole Astarte cluster. This should have the same value of DATA_QUEUE_COUNT in the VerneMQ plugin",
+      hidden: false,
+      to: "astarte_data_updater_plant.data_queue_total_count"
+    ],
     data_queue_range_end: [
       commented: true,
       datatype: :integer,

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_data_consumer/supervisor.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_data_consumer/supervisor.ex
@@ -43,7 +43,7 @@ defmodule Astarte.DataUpdaterPlant.AMQPDataConsumer.Supervisor do
 
     for queue_index <- queue_range_start..queue_range_end do
       queue_name = "#{queue_prefix}#{queue_index}"
-      args = [queue_name: queue_name]
+      args = [queue_name: queue_name, queue_index: queue_index]
       Supervisor.child_spec({AMQPDataConsumer, args}, id: {AMQPDataConsumer, queue_index})
     end
   end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -71,6 +71,13 @@ defmodule Astarte.DataUpdaterPlant.Config do
   end
 
   @doc """
+  Returns the total number of data queues in all the Astarte cluster. Defaults to 1.
+  """
+  def data_queue_total_count do
+    Application.get_env(:astarte_data_updater_plant, :data_queue_total_count, 1)
+  end
+
+  @doc """
   Returns the AMQP consumer prefetch count for the consumer. Defaults to 300.
   """
   def amqp_consumer_prefetch_count do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/consumers_supervisor.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/consumers_supervisor.ex
@@ -32,6 +32,7 @@ defmodule Astarte.DataUpdaterPlant.ConsumersSupervisor do
     Logger.info("AMQPDataConsumer supervisor init.", tag: "data_consumer_sup_init")
 
     children = [
+      {Registry, [keys: :unique, name: Registry.AMQPDataConsumer]},
       {AMQPDataConsumer.ConnectionManager, amqp_opts: Config.amqp_consumer_options()},
       AMQPDataConsumer.Supervisor
     ]


### PR DESCRIPTION
Avoid stalling a Data Updater when it is started through an RPC call instead of
being started by AMQPDataConsumer.

Fix #375

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>