### PR TITLE
Default max certificate chain length to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [data_updater_plant] Handle device hearbeat sent by VerneMQ plugin.
 - [data_updater_plant] Deactivate Data Updaters when they don't receive messages for some time,
   freeing up resources.
+- [appengine_api] Support SSL connections to RabbitMQ.
+- [data_updater_plant] Support SSL connections to RabbitMQ.
+- [trigger_engine] Support SSL connections to RabbitMQ.
+- Default max certificate chain length to 10.
 
 ### Removed
 - [appengine_api] Remove deprecated not versioned socket route.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/config.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/config.ex
@@ -150,6 +150,7 @@ defmodule Astarte.AppEngine.API.Config do
           {:cacertfile, String.t()}
           | {:verify, :verify_peer}
           | {:server_name_indication, :disable | charlist()}
+          | {:depth, integer()}
   @type ssl_options :: :none | [ssl_option]
 
   @type options ::
@@ -184,7 +185,8 @@ defmodule Astarte.AppEngine.API.Config do
   defp build_ssl_options() do
     [
       cacertfile: rooms_amqp_client_ssl_ca_file!() || CAStore.file_path(),
-      verify: :verify_peer
+      verify: :verify_peer,
+      depth: 10
     ]
     |> populate_sni()
   end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -28,6 +28,7 @@ defmodule Astarte.DataUpdaterPlant.Config do
           {:cacertfile, String.t()}
           | {:verify, :verify_peer}
           | {:server_name_indication, charlist() | :disable}
+          | {:depth, integer()}
   @type ssl_options :: :none | [ssl_option]
 
   @type amqp_options ::
@@ -246,7 +247,8 @@ defmodule Astarte.DataUpdaterPlant.Config do
   defp build_consumer_ssl_options() do
     [
       cacertfile: amqp_consumer_ssl_ca_file!() || CAStore.file_path(),
-      verify: :verify_peer
+      verify: :verify_peer,
+      depth: 10
     ]
     |> populate_consumer_sni()
   end
@@ -354,7 +356,8 @@ defmodule Astarte.DataUpdaterPlant.Config do
     [
       cacertfile:
         amqp_producer_ssl_ca_file!() || amqp_consumer_ssl_ca_file!() || CAStore.file_path(),
-      verify: :verify_peer
+      verify: :verify_peer,
+      depth: 10
     ]
     |> populate_producer_sni()
   end

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/config.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/config.ex
@@ -115,6 +115,7 @@ defmodule Astarte.TriggerEngine.Config do
           {:cacertfile, String.t()}
           | {:verify, :verify_peer}
           | {:server_name_indication, charlist() | :disable}
+          | {:depth, integer()}
   @type ssl_options :: :none | [ssl_option]
 
   @type options ::
@@ -149,7 +150,8 @@ defmodule Astarte.TriggerEngine.Config do
   defp build_ssl_options() do
     [
       cacertfile: amqp_consumer_ssl_ca_file!() || CAStore.file_path(),
-      verify: :verify_peer
+      verify: :verify_peer,
+      depth: 10
     ]
     |> populate_sni()
   end


### PR DESCRIPTION
The erlang default of 1 is too strict. Increase the default value to 10
to make it coincident to OpenSSL default.