### PR TITLE
Handle publish reply and ensure publishes towards the device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [trigger_engine] Support SSL connections to RabbitMQ.
 - Default max certificate chain length to 10.
 - AMQP trigger actions (publish to custom exchanges) as an alternative to http triggers actions.
+- Ensure data pushed towards the device is correctly delivered when using QoS > 0.
 
 ### Removed
 - [appengine_api] Remove deprecated not versioned socket route.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/data_transmitter.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/data_transmitter.ex
@@ -29,6 +29,9 @@ defmodule Astarte.AppEngine.API.DataTransmitter do
   @doc """
   Pushes a payload on a datastream interface.
 
+  Returns `{:ok, %{local_matches: local, remote_matches: remote}}` for a successful
+  publish, `{:error, reason}` otherwise.
+
   ## Options
   `opts` is a keyword list that can contain the following keys:
   * `timestamp`: a timestamp that is added in the BSON object inside the `t` key
@@ -61,6 +64,9 @@ defmodule Astarte.AppEngine.API.DataTransmitter do
   @doc """
   Pushes a payload on a properties interface.
 
+  Returns `{:ok, %{local_matches: local, remote_matches: remote}}` for a successful
+  publish, `{:error, reason}` otherwise.
+
   ## Options
   `opts` is a keyword list that can contain the following keys:
   * `timestamp`: a timestamp that is added in the BSON object inside the `t` key
@@ -91,6 +97,9 @@ defmodule Astarte.AppEngine.API.DataTransmitter do
 
   @doc """
   Pushes an unset message on a properties interface.
+
+  Returns `{:ok, %{local_matches: local, remote_matches: remote}}` for a successful
+  publish, `{:error, reason}` otherwise.
   """
   def unset_property(realm, device_id, interface, path) do
     topic = make_topic(realm, device_id, interface, path)

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rpc/vmq_plugin.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rpc/vmq_plugin.ex
@@ -29,6 +29,7 @@ defmodule Astarte.AppEngine.API.RPC.VMQPlugin do
     GenericErrorReply,
     GenericOkReply,
     Publish,
+    PublishReply,
     Reply
   }
 
@@ -81,10 +82,20 @@ defmodule Astarte.AppEngine.API.RPC.VMQPlugin do
     {:error, reason}
   end
 
+  defp extract_reply({:publish_reply, %PublishReply{} = reply}) do
+    _ = Logger.debug("Got publish reply from VMQ.")
+
+    {:ok, %{local_matches: reply.local_matches, remote_matches: reply.remote_matches}}
+  end
+
   defp extract_reply({:generic_ok_reply, %GenericOkReply{}}) do
     _ = Logger.debug("Got ok reply from VMQ.")
 
     :ok
+  end
+
+  defp extract_reply({:generic_error_reply, %GenericErrorReply{error_name: "session_not_found"}}) do
+    {:error, :session_not_found}
   end
 
   defp extract_reply({:generic_error_reply, error_struct = %GenericErrorReply{}}) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
@@ -46,6 +46,13 @@ defmodule Astarte.AppEngine.APIWeb.FallbackController do
     |> render(:"404_device")
   end
 
+  def call(conn, {:error, :cannot_push_to_device}) do
+    conn
+    |> put_status(:service_unavailable)
+    |> put_view(Astarte.AppEngine.APIWeb.ErrorView)
+    |> render(:"503_cannot_push_to_device")
+  end
+
   def call(conn, {:error, :endpoint_not_found}) do
     conn
     |> put_status(:bad_request)

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
@@ -102,6 +102,10 @@ defmodule Astarte.AppEngine.APIWeb.ErrorView do
     %{errors: %{detail: "Forbidden"}}
   end
 
+  def render("503_cannot_push_to_device.json", _assigns) do
+    %{errors: %{detail: "Cannot push to device"}}
+  end
+
   def render("503_degraded_health.json", _assigns) do
     %{errors: %{detail: "Service degraded"}}
   end

--- a/apps/astarte_appengine_api/mix.lock
+++ b/apps/astarte_appengine_api/mix.lock
@@ -4,7 +4,7 @@
   "amqp_client": {:hex, :amqp_client, "3.8.3", "11d4825d56e77bafb246631a5c68b5c245567f6cc6331c4ddaa3f55fa39c9e8a", [:make, :rebar3], [{:rabbit_common, "3.8.3", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "987124a9cf2373d16e0ce8143d8b167548a532826ce80e53ea7b8d959d6a0e5e"},
   "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "b0cd5e320bebcc914dc49374d47d2e1cce058c03", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "d32c08a9f672d0c0075c80cca64de33533b7df14", []},
-  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "186bd1c03f1bfedfe0c1f6dc3d4d3cb6c6f495de", []},
+  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "8400d76d938ab09064322721746ebf8810d4dfae", []},
   "castore": {:hex, :castore, "0.1.5", "591c763a637af2cc468a72f006878584bc6c306f8d111ef8ba1d4c10e0684010", [:mix], [], "hexpm", "6db356b2bc6cc22561e051ff545c20ad064af57647e436650aa24d7d06cd941a"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "805abd97539caf89ec6d4732c91e62ba9da0cda51ac462380bbd28ee697a8c42"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},

--- a/apps/astarte_appengine_api/test/support/database_test_helper.exs
+++ b/apps/astarte_appengine_api/test/support/database_test_helper.exs
@@ -675,7 +675,7 @@ defmodule Astarte.AppEngine.API.DatabaseTestHelper do
   defp insert_datastream_receiving_device_endpoints(client) do
     insert_endpoint_query = """
     INSERT INTO autotestrealm.endpoints(interface_id, endpoint_id, allow_unset, endpoint, expiry, interface_major_version, interface_minor_version, interface_name, interface_type, reliability, retention, value_type) VALUES
-    (13ccc31d-f911-29df-cbe6-be22635293bd, 44c2421d-1abf-f3ec-14e1-986928d764aa, False, '/%{sensor_id}/samplingPeriod', 0, 0, 1, 'org.ServerOwnedIndividual', 2, 1, 1, 3);
+    (13ccc31d-f911-29df-cbe6-be22635293bd, 44c2421d-1abf-f3ec-14e1-986928d764aa, False, '/%{sensor_id}/samplingPeriod', 0, 0, 1, 'org.ServerOwnedIndividual', 2, 3, 1, 3);
     """
 
     DatabaseQuery.call!(client, insert_endpoint_query)
@@ -741,11 +741,11 @@ defmodule Astarte.AppEngine.API.DatabaseTestHelper do
     insert_endpoint_queries = [
       """
       INSERT INTO autotestrealm.endpoints(interface_id, endpoint_id, allow_unset, endpoint, expiry, interface_major_version, interface_minor_version, interface_name, interface_type, reliability, retention, value_type) VALUES
-      (65c96ecb-f2d5-b440-4840-16cd84d2c2be, 76c99541-dd31-6369-bcdd-f2fdacc2d3ff, False, '/%{sensor_id}/enable', 0, 0, 1, 'org.astarte-platform.genericsensors.ServerOwnedAggregateObj', 2, 1, 1, 9);
+      (65c96ecb-f2d5-b440-4840-16cd84d2c2be, 76c99541-dd31-6369-bcdd-f2fdacc2d3ff, False, '/%{sensor_id}/enable', 0, 0, 1, 'org.astarte-platform.genericsensors.ServerOwnedAggregateObj', 2, 3, 1, 9);
       """,
       """
       INSERT INTO autotestrealm.endpoints(interface_id, endpoint_id, allow_unset, endpoint, expiry, interface_major_version, interface_minor_version, interface_name, interface_type, reliability, retention, value_type) VALUES
-      (65c96ecb-f2d5-b440-4840-16cd84d2c2be, 6ebd007e-dd74-8e32-f032-78d433b1b8e7, False, '/%{sensor_id}/samplingPeriod', 0, 0, 1, 'org.astarte-platform.genericsensors.ServerOwnedAggregateObj', 2, 1, 1, 3);
+      (65c96ecb-f2d5-b440-4840-16cd84d2c2be, 6ebd007e-dd74-8e32-f032-78d433b1b8e7, False, '/%{sensor_id}/samplingPeriod', 0, 0, 1, 'org.astarte-platform.genericsensors.ServerOwnedAggregateObj', 2, 3, 1, 3);
       """
     ]
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin.ex
@@ -29,6 +29,7 @@ defmodule Astarte.DataUpdaterPlant.RPC.VMQPlugin do
     GenericErrorReply,
     GenericOkReply,
     Publish,
+    PublishReply,
     Reply
   }
 
@@ -87,6 +88,10 @@ defmodule Astarte.DataUpdaterPlant.RPC.VMQPlugin do
 
   defp extract_reply({:generic_ok_reply, %GenericOkReply{}}) do
     :ok
+  end
+
+  defp extract_reply({:publish_reply, %PublishReply{} = reply}) do
+    {:ok, %{local_matches: reply.local_matches, remote_matches: reply.remote_matches}}
   end
 
   defp extract_reply({:generic_error_reply, error_struct = %GenericErrorReply{}}) do

--- a/apps/astarte_data_updater_plant/mix.lock
+++ b/apps/astarte_data_updater_plant/mix.lock
@@ -4,7 +4,7 @@
   "amqp_client": {:hex, :amqp_client, "3.8.3", "11d4825d56e77bafb246631a5c68b5c245567f6cc6331c4ddaa3f55fa39c9e8a", [:make, :rebar3], [{:rabbit_common, "3.8.3", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "987124a9cf2373d16e0ce8143d8b167548a532826ce80e53ea7b8d959d6a0e5e"},
   "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "0f45c42cf0cceee0f54212320348853e66a251c6", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "394d4682824500a3865bc66d008cea0bbd2ce482", []},
-  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "186bd1c03f1bfedfe0c1f6dc3d4d3cb6c6f495de", []},
+  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "8400d76d938ab09064322721746ebf8810d4dfae", []},
   "castore": {:hex, :castore, "0.1.5", "591c763a637af2cc468a72f006878584bc6c306f8d111ef8ba1d4c10e0684010", [:mix], [], "hexpm", "6db356b2bc6cc22561e051ff545c20ad064af57647e436650aa24d7d06cd941a"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "805abd97539caf89ec6d4732c91e62ba9da0cda51ac462380bbd28ee697a8c42"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},


### PR DESCRIPTION
Use the number of local and remote returned by `astarte_vmq_plugin` (see https://github.com/astarte-platform/astarte_vmq_plugin/pull/25) to determine if a publish has reached the required level of consistency, based on the requested QoS.