### PR TITLE
Replace all usages of whitelist/blacklist

### DIFF
--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/http_action.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/http_action.ex
@@ -44,7 +44,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
 
   @valid_methods ["delete", "get", "head", "options", "patch", "post", "put"]
 
-  @headers_blacklist MapSet.new([
+  @headers_blocklist MapSet.new([
                        "connection",
                        "content-length",
                        "date",
@@ -139,7 +139,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
       |> String.trim()
       |> String.downcase()
 
-    MapSet.member?(@headers_blacklist, normalized) == false
+    MapSet.member?(@headers_blocklist, normalized) == false
   end
 
   defp validate_headers_size(changeset, field, opts \\ []) do

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/http_action_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/http_action_test.exs
@@ -149,7 +149,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpActionTest do
     assert length(errors) == 1
   end
 
-  test "http_headers with blacklisted header must be rejected" do
+  test "http_headers with blocklisted header must be rejected" do
     input = %{
       "http_url" => "http://example.com/",
       "http_method" => "put",

--- a/doc/pages/architecture/070-auth.md
+++ b/doc/pages/architecture/070-auth.md
@@ -20,7 +20,7 @@ This makes integrating Astarte with 3rd party authentication/authorization frame
 
 ## Authorization
 
-Currently, Astarte supports a URL-based authorization for the API. Given that Astarte's data access APIs match the devices' topology like a tree, declaring the authorization in terms of path whitelisting gives enough flexibility to give each user the correct permissions without limitations.
+Currently, Astarte supports a URL-based authorization for the API. Given that Astarte's data access APIs match the devices' topology like a tree, declaring the authorization in terms of path allow-listing gives enough flexibility to give each user the correct permissions without limitations.
 
 As said, Astarte does not have the concept of user, and neither has a durable storage which tracks permissions. As such, it expects the authorization information to be inside the token, which is the only entity Astarte can trust - given it has been verified and authenticated through its signature.
 


### PR DESCRIPTION
I apologize about introducing blacklisting in my last PR, so I rename it
to blocklist.
Replace whitelist in our documentation too.