### PR TITLE
doc/swagger-ui-index.html: use v0.11 AppEngine API swagger

### DIFF
--- a/doc/swagger-ui-index.html
+++ b/doc/swagger-ui-index.html
@@ -42,7 +42,7 @@
         urls: [
           {
             name: "AppEngine API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/release-0.10/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/release-0.11/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml"
           },
           {
             name: "Realm Management API", 


### PR DESCRIPTION
doc/swagger-ui-index.html was pointing to release-0.10 yaml file on v0.11
branch.