### PR TITLE
doc/swagger-ui-index.html: use snapshot API instead of 0.11 one.

### DIFF
--- a/doc/swagger-ui-index.html
+++ b/doc/swagger-ui-index.html
@@ -42,19 +42,19 @@
         urls: [
           {
             name: "AppEngine API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/release-0.11/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/master/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml"
           },
           {
             name: "Realm Management API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/release-0.11/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/master/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml"
           },
           {
             name: "Pairing API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/release-0.11/apps/astarte_pairing_api/priv/static/astarte_pairing_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/master/apps/astarte_pairing_api/priv/static/astarte_pairing_api.yaml"
           },
           {
             name: "Housekeeping API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/release-0.11/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/master/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml"
         }],
         dom_id: '#swagger-ui',
         deepLinking: true,


### PR DESCRIPTION
Use URL to master yamls instead of release-0.11 ones.