### PR TITLE
trigger_engine: add amqp_prefetch_count on 1.0 too

### DIFF
--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_events_consumer.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_events_consumer.ex
@@ -114,6 +114,7 @@ defmodule Astarte.TriggerEngine.AMQPEventsConsumer do
     with amqp_consumer_options = Config.amqp_consumer_options!(),
          {:ok, conn} <- Connection.open(amqp_consumer_options),
          {:ok, chan} <- Channel.open(conn),
+         :ok <- Basic.qos(chan, prefetch_count: Config.amqp_consumer_prefetch_count!()),
          events_exchange_name = Config.events_exchange_name!(),
          events_queue_name = Config.events_queue_name!(),
          events_routing_key = Config.events_routing_key!(),

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/config.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/config.ex
@@ -73,6 +73,12 @@ defmodule Astarte.TriggerEngine.Config do
     type: :binary,
     default: "trigger_engine"
 
+  @envdoc "The AMQP consumer prefetch count."
+  app_env :amqp_consumer_prefetch_count, :astarte_trigger_engine, :amqp_consumer_prefetch_count,
+    os_env: "TRIGGER_ENGINE_AMQP_CONSUMER_PREFETCH_COUNT",
+    type: :integer,
+    default: 300
+
   @envdoc "Enable SSL. If not specified, SSL is disabled."
   app_env :amqp_consumer_ssl_enabled, :astarte_trigger_engine, :amqp_consumer_ssl_enabled,
     os_env: "TRIGGER_ENGINE_AMQP_CONSUMER_SSL_ENABLED",


### PR DESCRIPTION
Allow the setting of amqp_prefetch_count for trigger engine. Avoid
excessive memory usage when consuming events.
Fix #404 