### PR TITLE
Use Ispirata OTP23 + Elixir 1.10.3 docker image

### DIFF
--- a/apps/astarte_appengine_api/Dockerfile
+++ b/apps/astarte_appengine_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/apps/astarte_data_updater_plant/Dockerfile
+++ b/apps/astarte_data_updater_plant/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/apps/astarte_housekeeping/Dockerfile
+++ b/apps/astarte_housekeeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/apps/astarte_housekeeping_api/Dockerfile
+++ b/apps/astarte_housekeeping_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/apps/astarte_pairing/Dockerfile
+++ b/apps/astarte_pairing/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/apps/astarte_pairing_api/Dockerfile
+++ b/apps/astarte_pairing_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/apps/astarte_realm_management/Dockerfile
+++ b/apps/astarte_realm_management/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/apps/astarte_realm_management_api/Dockerfile
+++ b/apps/astarte_realm_management_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/apps/astarte_trigger_engine/Dockerfile
+++ b/apps/astarte_trigger_engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.10.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/tools/astarte_export/Dockerfile
+++ b/tools/astarte_export/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.8.1 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 WORKDIR /app
 

--- a/tools/astarte_import/Dockerfile
+++ b/tools/astarte_import/Dockerfile
@@ -1,4 +1,4 @@
-FROM elixir:1.8.2 as builder
+FROM ispirata/elixir:1.10-otp-23 as builder
 
 RUN apt-get -qq update
 RUN apt-get -qq install git build-essential curl


### PR DESCRIPTION
There is no "official" OTP23 + Elixir 1.10.3 image, so use a custom one.