### PR TITLE
Add device error triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [realm_management_api] Allow installing device-specific and group-specific triggers. To do so,
   pass the `device_id` or `group_name` key inside the `simple_trigger`.
 - [data_updater_plant] Add support for device-specific and group-specific triggers.
+- Add support for device error triggers.
 
 ### Removed
 - [appengine_api] Remove deprecated not versioned socket route.

--- a/apps/astarte_appengine_api/mix.lock
+++ b/apps/astarte_appengine_api/mix.lock
@@ -2,7 +2,7 @@
   "accept": {:hex, :accept, "0.3.5", "b33b127abca7cc948bbe6caa4c263369abf1347cfa9d8e699c6d214660f10cd1", [:rebar3], [], "hexpm", "11b18c220bcc2eab63b5470c038ef10eb6783bcb1fcdb11aa4137defa5ac1bb8"},
   "amqp": {:hex, :amqp, "1.4.2", "4181290cda65d35b757460e87b3023486b080fdf6560d3e38e288e23bd2a0b3d", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "080ab24601ef503d930fce28f913ac996e5f29fe6c91ce21a4f6d1f5aa6017b6"},
   "amqp_client": {:hex, :amqp_client, "3.8.5", "279a73dcbdc5f797d7874d600a51fad6a82a716eec40ab1f25e3497939fc7f2d", [:make, :rebar3], [{:rabbit_common, "3.8.5", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "19bc8b22ddd00e5afa4bd7922090425e86f7ab26eb26a7230426e7637692d5cf"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "ad8cd0b19567a7e0dede14d0f4b1ad1dcfad4b79", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "ead2c8a9e4d37b5e1238bf365ee5eb2fba3f1543", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "a327fa9790217cccb2a1dd3222f2b19dd17f5e32", []},
   "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "b4780430eb4a3cfc433044259c8a6730ca13149b", []},
   "castore": {:hex, :castore, "0.1.6", "2da0dccb3eacb67841d11790598ff03cd5caee861e01fad61dce1376b5da28e6", [:mix], [], "hexpm", "f874c510b720d31dd6334e9ae5c859a06a3c9e67dfe1a195c512e57588556d3f"},

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
@@ -71,6 +71,28 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
     |> dispatch_event(target)
   end
 
+  def device_error(targets, realm, device_id, error_name, error_metadata, timestamp)
+      when is_list(targets) do
+    execute_all_ok(targets, fn target ->
+      device_error(target, realm, device_id, error_name, error_metadata, timestamp) == :ok
+    end)
+  end
+
+  def device_error(target, realm, device_id, error_name, error_metadata, timestamp) do
+    metadata_kw = Enum.into(error_metadata, [])
+
+    %DeviceErrorEvent{error_name: error_name, metadata: metadata_kw}
+    |> make_simple_event(
+      :device_error_event,
+      target.simple_trigger_id,
+      target.parent_trigger_id,
+      realm,
+      device_id,
+      timestamp
+    )
+    |> dispatch_event(target)
+  end
+
   def incoming_data(targets, realm, device_id, interface, path, bson_value, timestamp)
       when is_list(targets) do
     execute_all_ok(targets, fn target ->

--- a/apps/astarte_data_updater_plant/mix.lock
+++ b/apps/astarte_data_updater_plant/mix.lock
@@ -2,7 +2,7 @@
   "accept": {:hex, :accept, "0.3.5", "b33b127abca7cc948bbe6caa4c263369abf1347cfa9d8e699c6d214660f10cd1", [:rebar3], [], "hexpm", "11b18c220bcc2eab63b5470c038ef10eb6783bcb1fcdb11aa4137defa5ac1bb8"},
   "amqp": {:hex, :amqp, "1.4.2", "4181290cda65d35b757460e87b3023486b080fdf6560d3e38e288e23bd2a0b3d", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "080ab24601ef503d930fce28f913ac996e5f29fe6c91ce21a4f6d1f5aa6017b6"},
   "amqp_client": {:hex, :amqp_client, "3.8.5", "279a73dcbdc5f797d7874d600a51fad6a82a716eec40ab1f25e3497939fc7f2d", [:make, :rebar3], [{:rabbit_common, "3.8.5", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "19bc8b22ddd00e5afa4bd7922090425e86f7ab26eb26a7230426e7637692d5cf"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "ad8cd0b19567a7e0dede14d0f4b1ad1dcfad4b79", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "ead2c8a9e4d37b5e1238bf365ee5eb2fba3f1543", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "a327fa9790217cccb2a1dd3222f2b19dd17f5e32", []},
   "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "b4780430eb4a3cfc433044259c8a6730ca13149b", []},
   "castore": {:hex, :castore, "0.1.6", "2da0dccb3eacb67841d11790598ff03cd5caee861e01fad61dce1376b5da28e6", [:mix], [], "hexpm", "f874c510b720d31dd6334e9ae5c859a06a3c9e67dfe1a195c512e57588556d3f"},

--- a/apps/astarte_trigger_engine/mix.lock
+++ b/apps/astarte_trigger_engine/mix.lock
@@ -2,7 +2,7 @@
   "accept": {:hex, :accept, "0.3.5", "b33b127abca7cc948bbe6caa4c263369abf1347cfa9d8e699c6d214660f10cd1", [:rebar3], [], "hexpm", "11b18c220bcc2eab63b5470c038ef10eb6783bcb1fcdb11aa4137defa5ac1bb8"},
   "amqp": {:hex, :amqp, "1.4.2", "4181290cda65d35b757460e87b3023486b080fdf6560d3e38e288e23bd2a0b3d", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "080ab24601ef503d930fce28f913ac996e5f29fe6c91ce21a4f6d1f5aa6017b6"},
   "amqp_client": {:hex, :amqp_client, "3.8.5", "279a73dcbdc5f797d7874d600a51fad6a82a716eec40ab1f25e3497939fc7f2d", [:make, :rebar3], [{:rabbit_common, "3.8.5", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "19bc8b22ddd00e5afa4bd7922090425e86f7ab26eb26a7230426e7637692d5cf"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "ad8cd0b19567a7e0dede14d0f4b1ad1dcfad4b79", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "ead2c8a9e4d37b5e1238bf365ee5eb2fba3f1543", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "a327fa9790217cccb2a1dd3222f2b19dd17f5e32", []},
   "bbmustache": {:hex, :bbmustache, "1.10.0", "ddc927463f0e95d66cdac889153af08015d609124d6d79006c248ad2de7f6ecd", [:rebar3], [], "hexpm", "43effa3fd4bb9523157af5a9e2276c493495b8459fc8737144aa186cb13ce2ee"},
   "castore": {:hex, :castore, "0.1.6", "2da0dccb3eacb67841d11790598ff03cd5caee861e01fad61dce1376b5da28e6", [:mix], [], "hexpm", "f874c510b720d31dd6334e9ae5c859a06a3c9e67dfe1a195c512e57588556d3f"},

--- a/doc/pages/architecture/060-triggers.md
+++ b/doc/pages/architecture/060-triggers.md
@@ -106,6 +106,7 @@ This is the generic representation of a Data Trigger:
 
 - `device_connected`: triggered when a device connects to its transport.
 - `device_disconnected`: triggered when a device disconnects from its transport.
+- `device_error`: triggered when data from a device causes an error.
 
 `device_id` can be used to pass a specific Device ID to restrict the trigger to a single device. `*`
 is also accepted as `device_id` to maintain backwards compatibility and it is considered equivalent
@@ -224,7 +225,10 @@ Further options might be used, such as "http_headers", enabling auth to remote s
 
 Please, beware that some http headers might be not allowed or reserved for http connection signaling.
 
-The payload of the request is JSON document with this format:
+### SimpleEvent payloads
+
+The payload delivered in a default HTTP action or in [Astarte Channels](052-using_channels.html) is
+a JSON document with this format:
 
 ```json
 {
@@ -265,6 +269,25 @@ Additionally, the realm that originated the trigger is available in the request 
   "type": "device_disconnected"
 }
 ```
+
+###### DeviceErrorEvent
+
+```json
+{
+  "type": "device_error",
+  "error_name": "<error_name>",
+  "metadata": {
+    "<key>": "<value>"
+  }
+}
+```
+
+`error_name` is a string identifying the error. More details can be found in the [device errors
+documentation](045-device_errors.html)
+
+`metadata` is a map with string key and string values that may contain additional information about
+the error. Some metadata (_e.g._ binary payloads) might be encoded in base64 if they cannot be
+represented as string. In that case, the key is prepended with the `base64_` prefix.
 
 ###### IncomingDataEvent
 

--- a/doc/pages/user/045-device_errors.md
+++ b/doc/pages/user/045-device_errors.md
@@ -1,0 +1,81 @@
+# Device errors
+
+This page details the errors that can affect a device while it's sending data. The user can monitor
+device errors by installing a [device trigger](060-triggers.html#device-triggers) on `device_error`
+or checking the Devices tab in the Astarte Dashboard. The same errors are also provided as log
+messages on Data Updater Plant.
+
+## `write_on_server_owned_interface`
+
+The device is trying to write on a server owned interface. The device can only push data on device
+owned interfaces.
+
+## `invalid_interface`
+
+The interface name received in the message is invalid.
+
+## `invalid_path`
+
+The path received in the message is invalid. This might happen when a path does not have a valid
+path format or it's not a valid UTF-8 string.
+
+## `mapping_not_found`
+
+The path received in the message can't be found in the interface mappings. This could be the result
+of the device having a more recent version of the inteface than the one installed in the realm or an
+interface with the same name and version but different contents.
+
+## `interface_loading_failed`
+
+The target interface was not found in the database. Usually this means the interface is not
+installed in the realm, but the error can also derive from the database being temporarily
+unavailable.
+
+## `ambiguous_path`
+
+The path received in the message can't be mapped univocally on a mapping. This is often the result
+of an incomplete path.
+
+## `undecodable_bson_payload`
+
+The payload of the message can't be decoded as BSON.
+
+## `unexpected_value_type`
+
+The value of the message does not have the expected type (_e.g._ the mapping expects a string value
+but an integer value was received instead).
+
+## `value_size_exceeded`
+
+The value of the message exceeds the maximum size of its type. The size limitations of the types are
+documented [here](030-interface.html#supported-data-types).
+
+## `unexpected_object_key`
+
+An object aggregated value with an unexpected key was received.
+
+## `invalid_introspection`
+
+The introspection sent from the device can't be parsed correctly. The introspection format is
+documented [here](080-mqtt-v1-protocol.html#introspection).
+
+## `unexpected_control_message`
+
+The device sent a message on an unhandled control path. The supported control paths are detailed in
+the [protocol documentation](080-mqtt-v1-protocol.html#introspection).
+
+## `device_session_not_found`
+
+Data Updater Plant failed to push data towards the device. This could result from the device being
+currently offline and not having a persistent session on the MQTT broker or from the device not
+having all the [MQTT subscriptions required by the Astarte
+protocol](https://docs.astarte-platform.org/latest/080-mqtt-v1-protocol.html#mqtt-topics-overview)
+
+## `resend_interface_properties_failed`
+
+Data Updater Plant failed to resend the properties of an interface. This could result from the
+device declaring a uninstalled properties interface in its introspection right before an emptyCache.
+
+## `empty_cache_error`
+
+The empty cache operation for a device failed. This could result from a temporary database failure.

--- a/doc/pages/user/052-using_channels.md
+++ b/doc/pages/user/052-using_channels.md
@@ -23,10 +23,9 @@ A Room is identified by a topic with the following semantics: `rooms:<realm>:<na
 
 A room can be joined by any number of concurrent users. Rooms serve as containers for Transient
 Triggers, which can be installed by any authorized user. Transient Triggers are actual
-[Triggers](060-triggers.md), with the difference that they exist within a Channels Room rather than
-within a Realm - this mostly affects their timespan - and that the `action` can't be configured -
-every time a Condition is triggered a message is delivered to users in the Room, [in a well-known
-format](https://github.com/astarte-platform/astarte_core/blob/master/lib/astarte_core/triggers/simple_events/encoder.ex).
+[Triggers](060-triggers.html), with the difference that they exist within a Channels Room rather
+than within a Realm - this mostly affects their timespan - and that the `action` can't be
+configured - every time a Condition is triggered an event is delivered to users in the Room.
 
 ### Events
 
@@ -45,12 +44,8 @@ with a similar payload:
 
 `device_id` is always present (as long as the trigger matches a device) and identifies the device
 emitting the event. `event`, instead, depends on the kind of installed trigger. It always carries a
-`type` string, which identifies the content of the object. Currently, the documentation of every
-event's payload can be found in [Astarte's protobuf
-files](https://github.com/astarte-platform/astarte_core/tree/master/lib/astarte_core/triggers/simple_events).
-However, there are some discrepancies in mapping (e.g.). It is advised also to have a look at the
-[encoder](https://github.com/astarte-platform/astarte_core/blob/master/lib/astarte_core/triggers/simple_events/encoder.ex).
-In the foreseeable future, more user friendly documentation will be provided.
+`type` string, which identifies the content of the object. The complete list of possible
+event payloads can be found [here](060-triggers.html#simple-event-payloads).
 
 ### Lifecycle
 


### PR DESCRIPTION
DeviceErrorEvent is now emitted when a device_trigger on device_error is
installed, either with RealmManagement or through a volatile AppEngine trigger.

Fix #135

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>