### PR TITLE
astarte_appengine_api: bring check_origin back to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.1] - Unreleased
+### Fixed
+- [astarte_appengine_api] Fix regression that made it impossible to use Astarte Channels.
+
 ## [1.0.0-alpha.1] - 2020-06-19
 ### Fixed
 - Make sure devices are eventually marked as disconnected even if they disconnect while VerneMQ is

--- a/apps/astarte_appengine_api/config/config.exs
+++ b/apps/astarte_appengine_api/config/config.exs
@@ -18,6 +18,7 @@ config :astarte_appengine_api, Astarte.AppEngine.APIWeb.Endpoint,
   secret_key_base: "oLTSqHyMVoBtu3Gu504Dn6HFN1qdFXtkJ0yFViRDbXckOHgTjFs1XaRS0QaKZ8KL",
   render_errors: [view: Astarte.AppEngine.APIWeb.ErrorView, accepts: ~w(json)],
   pubsub: [name: Astarte.AppEngine.API.PubSub, adapter: Phoenix.PubSub.PG2],
+  check_origin: false,
   instrumenters: [Astarte.AppEngine.APIWeb.Metrics.PhoenixInstrumenter]
 
 # Configures Elixir's Logger


### PR DESCRIPTION
It was false before the switch from Conform to Skogsra and leaving it at
its default value breaks the dashboard

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>