### PR TITLE
Rename http_(custom)_headers to http_static_headers

### DIFF
--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/http_action.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/http_action.ex
@@ -25,7 +25,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
   embedded_schema do
     field :http_url, :string
     field :http_method, :string
-    field :http_headers, {:map, :string}
+    field :http_static_headers, {:map, :string}
 
     field :template, :string
     field :template_type, :string
@@ -36,7 +36,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
   @all_attrs [
     :http_url,
     :http_method,
-    :http_headers,
+    :http_static_headers,
     :template,
     :template_type,
     :http_post_url
@@ -71,7 +71,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
     |> validate_required([:http_post_url])
     |> validate_empty(:http_url)
     |> validate_empty(:http_method)
-    |> validate_empty(:http_headers)
+    |> validate_empty(:http_static_headers)
     |> validate_url(:http_post_url)
     |> validate_length(:template, max: @max_mustache_template_size)
     |> normalize_fields()
@@ -85,8 +85,8 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
     |> validate_empty(:http_post_url)
     |> validate_url(:http_url)
     |> validate_inclusion(:http_method, @valid_methods)
-    |> validate_headers(:http_headers)
-    |> validate_headers_size(:http_headers)
+    |> validate_headers(:http_static_headers)
+    |> validate_headers_size(:http_static_headers)
     |> validate_length(:template, max: @max_mustache_template_size)
   end
 
@@ -162,7 +162,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
       %HttpAction{
         http_url: http_url,
         http_method: http_method,
-        http_headers: http_headers,
+        http_static_headers: http_static_headers,
         template: template,
         template_type: template_type
       } = action
@@ -171,7 +171,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
         "http_url" => http_url,
         "http_method" => http_method
       }
-      |> maybe_put("http_headers", http_headers)
+      |> maybe_put("http_static_headers", http_static_headers)
       |> maybe_put("template", template)
       |> maybe_put("template_type", template_type)
       |> Jason.Encode.map(opts)

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
@@ -180,9 +180,9 @@ defmodule Astarte.TriggerEngine.EventsConsumer do
 
   defp execute_action(payload, headers, action) do
     with {:ok, method, url} <- fetch_method_and_url(action),
-         custom_headers_map = Map.get(action, "http_custom_headers", %{}),
-         custom_headers = Map.to_list(custom_headers_map),
-         {:ok, response} <- HTTPoison.request(method, url, payload, custom_headers ++ headers) do
+         static_headers_map = Map.get(action, "http_static_headers", %{}),
+         static_headers = Map.to_list(static_headers_map),
+         {:ok, response} <- HTTPoison.request(method, url, payload, static_headers ++ headers) do
       %HTTPoison.Response{status_code: status_code} = response
 
       case status_code do

--- a/doc/pages/architecture/060-triggers.md
+++ b/doc/pages/architecture/060-triggers.md
@@ -211,13 +211,13 @@ This is the configuration object representing a minimal default action:
 
 The default action sends an HTTP request to the specified `http_url` using `http_method` method (e.g. `POST`).
 
-Further options might be used, such as "http_headers", enabling auth to remote services:
+Further options might be used, such as "http_static_headers", enabling auth to remote services:
 
 ```json
 {
   "http_url": "<http_url>",
   "http_method": "<method>",
-  "http_headers": {
+  "http_static_headers": {
     "Authorization": "Bearer <token>"
   }
 }


### PR DESCRIPTION
http_static_headers is consistent with AMQP amqp_static_headers and also
it underlines that they are just a subset of all http headers.
"http_custom_headers" has not been chosen since they might be also standard/well-know
headers, such as Authorization.
Furthermore an additional test has been added for http action Jason
encoder.