### PR TITLE
Rename ...genericsensors.Values/_/value to ...genericsensors.Values/_…

### DIFF
--- a/standard-interfaces/org.astarte-platform.genericsensors.Values.json
+++ b/standard-interfaces/org.astarte-platform.genericsensors.Values.json
@@ -8,7 +8,7 @@
     "doc": "Values allows generic sensors to stream samples. It is usually used in combination with AvailableSensors, which makes API client aware of what sensors and what unit of measure they are reporting. sensor_id represents an unique identifier for an individual sensor, and should match sensor_id in AvailableSensors when used in combination.",
     "mappings": [
         {
-            "endpoint": "/%{sensor_id}/value",
+            "endpoint": "/%{sensor_id}/values",
             "type": "double",
             "explicit_timestamp": true,
             "description": "Sampled real value.",


### PR DESCRIPTION
…/values

GET on AppEngine on /value will return a collection of items, therefore
it should be renamed to /values.
On the SDK side it would look as:
```
sendData("org.astarte-platform.genericsensors.Values", "/values", value);
```
Using astartectl on it would be something like:
```
astartectl rlm appengine devices get-samples device_id ...Values /id/values
```