### PR TITLE
data_updater_plant: default data queue count to 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   created, the datacenter is just verified against the one present in the database.
 - [housekeeping] Increase the delay between connection attempts to 1000 ms, for an overall number
   of 60 attempts.
+- [data_updater_plant] Default the total queue count to 128, de facto exploiting multiqueue support.
+- [data_updater_plant] Default the queue range end to 127.
 
 ## [1.0.0-alpha.1] - 2020-06-19
 ### Fixed

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -181,13 +181,13 @@ defmodule Astarte.DataUpdaterPlant.Config do
   app_env :data_queue_range_end, :astarte_data_updater_plant, :amqp_data_queue_range_end,
     os_env: "DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_RANGE_END",
     type: :integer,
-    default: 0
+    default: 127
 
   @envdoc "The total number of data queues in all the Astarte cluster."
   app_env :data_queue_total_count, :astarte_data_updater_plant, :amqp_data_queue_total_count,
     os_env: "DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_TOTAL_COUNT",
     type: :integer,
-    default: 1
+    default: 128
 
   @envdoc "The prefetch count of the AMQP consumer connection. A prefetch count of 0 means unlimited (not recommended)."
   app_env :consumer_prefetch_count,


### PR DESCRIPTION
Exploit astarte's mulitique support by default.