### PR TITLE
housekeeping: increase the delay between connection attempts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [astarte_appengine_api] Fix regression that made it impossible to use Astarte Channels.
 
+### Changed
+- [housekeeping] Increase the delay between connection attempts to 1000 ms, for an overall number
+  of 60 attempts.
+
 ## [1.0.0-alpha.1] - 2020-06-19
 ### Fixed
 - Make sure devices are eventually marked as disconnected even if they disconnect while VerneMQ is

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/release_tasks.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/release_tasks.ex
@@ -87,14 +87,14 @@ defmodule Astarte.Housekeeping.ReleaseTasks do
     :ok = stop_services()
   end
 
-  defp wait_connection_and_check_astarte_keyspace(retries \\ 10) do
+  defp wait_connection_and_check_astarte_keyspace(retries \\ 60) do
     case Queries.is_astarte_keyspace_existing() do
       {:ok, exists?} ->
         {:ok, exists?}
 
       {:error, :database_connection_error} ->
         if retries > 0 do
-          :timer.sleep(100)
+          :timer.sleep(1000)
           wait_connection_and_check_astarte_keyspace(retries - 1)
         else
           {:error, :database_connection_error}


### PR DESCRIPTION
Increase the delay between connection attempts towards Cassandra to 1000
ms, for an overall number of 60 attempts.

Fix #427 