### PR TITLE
appengine: fix extract_aggregate_reliability pattern match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0-beta.1] - Unreleased
 ### Fixed
 - [astarte_appengine_api] Fix regression that made it impossible to use Astarte Channels.
+- [astarte_appengine_api] Fix bug that prevented data publishing in object aggregated interfaces.
 
 ## [1.0.0-alpha.1] - 2020-06-19
 ### Fixed

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -550,7 +550,7 @@ defmodule Astarte.AppEngine.API.Device do
     end)
   end
 
-  defp extract_aggregate_reliability([mapping, _rest] = _mappings) do
+  defp extract_aggregate_reliability([mapping | _rest] = _mappings) do
     # Extract the reliability from the first mapping since it's
     # the same for all mappings in object aggregated interfaces
     mapping.reliability


### PR DESCRIPTION
Match on lists of all lengths, not just 2

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>