### PR TITLE
housekeeping_api: remove datacenter name regex check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Fix regression that made it impossible to use Astarte Channels.
 - [astarte_appengine_api] Fix bug that prevented data publishing in object aggregated interfaces.
 
+### Changed
+- [astarte_housekeeping_api] Remove format check on Cassandra datacenter name when a realm is
+  created, the datacenter is just verified against the one present in the database.
+
 ## [1.0.0-alpha.1] - 2020-06-19
 ### Fixed
 - Make sure devices are eventually marked as disconnected even if they disconnect while VerneMQ is

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/realm.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/realm.ex
@@ -21,7 +21,6 @@ defmodule Astarte.Housekeeping.API.Realms.Realm do
   import Ecto.Changeset
 
   @default_replication_factor 1
-  @datacenter_name_regex ~r/^[a-z][a-zA-Z0-9_-]*$/
 
   @required_fields [:realm_name, :jwt_public_key_pem]
   @allowed_fields [
@@ -67,15 +66,10 @@ defmodule Astarte.Housekeeping.API.Realms.Realm do
 
   defp datacenter_map_validator(field, datacenter_map) do
     Enum.reduce(datacenter_map, [], fn {datacenter_name, replication_factor}, errors_acc ->
-      cond do
-        not Regex.match?(@datacenter_name_regex, datacenter_name) ->
-          [{field, "has invalid datacenter name: #{datacenter_name}"} | errors_acc]
-
-        not is_number(replication_factor) or replication_factor <= 0 ->
-          [{field, "has invalid replication factor: #{replication_factor}"} | errors_acc]
-
-        true ->
-          errors_acc
+      if is_number(replication_factor) and replication_factor > 0 do
+        errors_acc
+      else
+        [{field, "has invalid replication factor: #{replication_factor}"} | errors_acc]
       end
     end)
   end

--- a/apps/astarte_housekeeping_api/test/astarte_housekeeping_api/realms/realms_test.exs
+++ b/apps/astarte_housekeeping_api/test/astarte_housekeeping_api/realms/realms_test.exs
@@ -74,12 +74,6 @@ defmodule Astarte.Housekeeping.API.RealmsTest do
       replication_class: "NetworkTopologyStrategy",
       datacenter_replication_factors: %{}
     }
-    @invalid_datacenter_name_attrs %{
-      realm_name: "mytestrealm",
-      jwt_public_key_pem: @pubkey,
-      replication_class: "NetworkTopologyStrategy",
-      datacenter_replication_factors: %{"OR 1=1; --" => 2}
-    }
     @less_than_zero_datacenter_replication_attrs %{
       realm_name: "mytestrealm",
       jwt_public_key_pem: @pubkey,
@@ -137,7 +131,6 @@ defmodule Astarte.Housekeeping.API.RealmsTest do
       assert {:error, %Ecto.Changeset{}} = Realms.create_realm(@malformed_pubkey_attrs)
       assert {:error, %Ecto.Changeset{}} = Realms.create_realm(@invalid_replication_attrs)
       assert {:error, %Ecto.Changeset{}} = Realms.create_realm(@invalid_replication_class_attrs)
-      assert {:error, %Ecto.Changeset{}} = Realms.create_realm(@invalid_datacenter_name_attrs)
 
       assert {:error, %Ecto.Changeset{}} =
                Realms.create_realm(@empty_datacenter_replication_attrs)


### PR DESCRIPTION
The backend already checks that the datacenter is the one contained in the
database, and it's used in a prepared query (so it can't be used as vector for
SQL injections). We can't predict datacenter names, so we might as well drop the
check.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>