### PR TITLE
appengine_api: always consider push to properties interfaces succesful

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [astarte_appengine_api] Fix regression that made it impossible to use Astarte Channels.
 - [astarte_appengine_api] Fix bug that prevented data publishing in object aggregated interfaces.
+- [astarte_appengine_api] Fix regression that prevented properties to be set before the first
+  connection of a device.
 
 ### Added
 - [astarte_housekeeping] Allow deleting a realm. The feature can be enabled with an environment

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -646,11 +646,20 @@ defmodule Astarte.AppEngine.API.Device do
     # We use get since we can be in a properties case
     reliability = Keyword.get(opts, :reliability)
 
-    if type == :datastream and reliability == :unreliable do
-      # Unreliable datastream is the only case where this is ok
-      :ok
-    else
-      {:error, :cannot_push_to_device}
+    cond do
+      type == :properties ->
+        # No matches will happen only if the device doesn't have a session on
+        # the broker, but the SDK would then send an emptyCache at the first
+        # connection and receive all properties. Hence, we return :ok for
+        # properties even if there are no matches
+        :ok
+
+      type == :datastream and reliability == :unreliable ->
+        # Unreliable datastream is allowed to fail
+        :ok
+
+      true ->
+        {:error, :cannot_push_to_device}
     end
   end
 


### PR DESCRIPTION
A push can fail only if the device doesn't have a session on the broker. But if
it this happen, then the device will ask for all properties at the next
reconnection. This allows to push properties to devices before their first
connection, making sure they're saved to the database.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>