### PR TITLE
appengine_api: remove `topic` from channel metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - Unreleased
+### Changed
+- [appengine_api] Remove `topic` from channel metrics.
+
 ## [0.11.1] - 2020-05-18
 ### Added
 - [data_updater_plant] Add `DATA_UPDATER_PLANT_AMQP_DATA_QUEUE_TOTAL_COUNT` environment variable,

--- a/apps/astarte_appengine_api/config/config.exs
+++ b/apps/astarte_appengine_api/config/config.exs
@@ -60,6 +60,8 @@ config :astarte_appengine_api, :max_results_limit, 10000
 
 config :prometheus, Astarte.AppEngine.APIWeb.Metrics.PhoenixInstrumenter,
   controller_call_labels: [:controller, :action],
+  channel_join_labels: [:channel, :transport],
+  channel_receive_labels: [:channel, :transport, :event],
   duration_buckets: [
     10,
     25,


### PR DESCRIPTION
Remove `topic` from channel metrics preventing the unbounded growth of
metrics' entries.