### PR TITLE
Add ignore_ssl_errors option to trigger action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [0.11.2] - Unreleased
+### Added
+- [trigger_engine] Add `ignore_ssl_errors` key in trigger actions, allowing to ignore SSL actions
+  when delivering an HTTP trigger action.
+
 ### Changed
 - [appengine_api] Remove `topic` from channel metrics.
 

--- a/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
+++ b/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
@@ -881,6 +881,10 @@ components:
         http_post_url:
           description: The target URL for the POST
           type: string
+        ignore_ssl_errors:
+          description: If true, ignore SSL errors when performing the HTTP request.
+          default: false
+          type: boolean
         template_type:
           description: >-
             The type of template used for the POST request, if any. If not

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
@@ -177,9 +177,18 @@ defmodule Astarte.TriggerEngine.EventsConsumer do
     end
   end
 
-  defp execute_action(payload, headers, action) do
+  defp build_request_opts(%{"ignore_ssl_errors" => true} = _action) do
+    [ssl: [verify: :verify_none]]
+  end
+
+  defp build_request_opts(_action) do
+    []
+  end
+
+  def execute_action(payload, headers, action) do
     with {:ok, url} <- Map.fetch(action, "http_post_url"),
-         {:ok, response} <- HTTPoison.post(url, payload, headers) do
+         opts = build_request_opts(action),
+         {:ok, response} <- HTTPoison.post(url, payload, headers, opts) do
       %HTTPoison.Response{status_code: status_code} = response
 
       case status_code do

--- a/doc/pages/architecture/060-triggers.md
+++ b/doc/pages/architecture/060-triggers.md
@@ -182,11 +182,16 @@ This is the configuration object representing the default action:
 
 ```json
 {
-  "http_post_url": "<http_post_url>"
+  "http_post_url": "<http_post_url>",
+  "ignore_ssl_errors": <true|false>
 }
 ```
 
 The default action sends an HTTP `POST` request to the specified `http_post_url`.
+
+The `ignore_ssl_errors` key is optional and defaults to `false`. If set to `true`, any SSL error
+encountered while doing the HTTP request will be ignored. This can be useful if the trigger must
+ignore self-signed or expired certificates.
 
 The payload of the request is JSON document with this format:
 
@@ -351,6 +356,7 @@ This is the configuration object representing a Mustache action:
   "http_post_url": "<http_post_url>",
   "template_type": "mustache",
   "template": "<template>"
+  "ignore_ssl_errors": <true|false>
 }
 ```
 
@@ -364,6 +370,10 @@ The basic keys that can be use to populate the template are:
 - `{{ realm }}`: the realm the trigger belongs to.
 - `{{ device_id }}`: the device that originated the trigger.
 - `{{ event_type }}`: the type of the received event.
+
+The `ignore_ssl_errors` key is optional and defaults to `false`. If set to `true`, any SSL error
+encountered while doing the HTTP request will be ignored. This can be useful if the trigger must
+ignore self-signed or expired certificates.
 
 Moreover, depending on the event type, all keys that are contained in the events [described in the
 previous section](#event-objects) are available, always by wrapping them in `{{ }}`.


### PR DESCRIPTION
Allow the user to make the requests go through even if an invalid certificate is
involved.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>