### PR TITLE
Handle device disconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Fix regression that prevented properties to be set before the first
   connection of a device.
 - [astarte_realm_management] Fix a bug that prevented AMQP triggers to be correctly installed.
+- [astarte_data_updater_plant] Mark device as offline and send device_disconnected event when
+  forcing a device disconnection.
 
 ### Added
 - [astarte_housekeeping] Allow deleting a realm. The feature can be enabled with an environment


### PR DESCRIPTION
Mark device as offline and send device_disconnected event when forcing a device disconnection
Fix #398 