### PR TITLE
data_updater_plant: fix queue block during ask_clean_session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_realm_management] Fix a bug that prevented AMQP triggers to be correctly installed.
 - [astarte_data_updater_plant] Mark device as offline and send device_disconnected event when
   forcing a device disconnection.
+- [astarte_data_updater_plant] Fix bug that blocked queues when trying to disconnect an already
+  disconnected device.
 
 ### Added
 - [astarte_housekeeping] Allow deleting a realm. The feature can be enabled with an environment

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin.ex
@@ -94,6 +94,10 @@ defmodule Astarte.DataUpdaterPlant.RPC.VMQPlugin do
     {:ok, %{local_matches: reply.local_matches, remote_matches: reply.remote_matches}}
   end
 
+  defp extract_reply({:generic_error_reply, %GenericErrorReply{error_name: "not_found"}}) do
+    {:error, :not_found}
+  end
+
   defp extract_reply({:generic_error_reply, error_struct = %GenericErrorReply{}}) do
     error_map = Map.from_struct(error_struct)
 


### PR DESCRIPTION
The return value of ask_clean_session was ignored before, so it did not crash
the process. 5beed84913138bb5ecaa902b1bb64435b191df14 introduced the use of the
returned value, so the process now crashes if an error is returned, which was
happening when we tried to disconnect a device that was already disconnected.
This fixes that problem, making sure to return :ok in that case.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>