### PR TITLE
docker-compose: avoid accidentally creating housekeeping_public.pem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.4] - Unreleased
+### Fixed
+- Avoid creating an `housekeeping_public.pem` directory if `docker-compose up` doesn't find the
+  housekeeping keypair.
+
 ## [0.11.3] - 2020-09-24
 
 ## [0.11.2] - 2020-08-14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.3'
 services:
   astarte-housekeeping:
     image: astarte/astarte_housekeeping:0.11.3
@@ -20,7 +20,9 @@ services:
     ports:
       - "4001:4001"
     volumes:
-      - ./compose/astarte-keys/housekeeping_public.pem:/keys/housekeeping_public.pem
+      - type: bind
+        source: ./compose/astarte-keys/housekeeping_public.pem
+        target: /keys/housekeeping_public.pem
     restart: on-failure
     depends_on:
       - "rabbitmq"


### PR DESCRIPTION
The short syntax for docker-compose volumes creates the source on the
host if it does not exist. This meant that user that accidentally tried
to launch docker-compose up before executing docker-compose-initializer
found themselves with a housekeeping_public.pem directory, that was seen
as an existing file by the initializer and left the setup in an invalid
state.
Using the long syntax avoids the silent creation of the directory and
just makes the docker-compose up command fail (so the user can read the
instructions again and find docker-compose-initializer).
The long volume syntax requires at least compose syntax v2.3, so we also
have to bump that.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>