### PR TITLE
Add ServerCommands and DeviceEvents standard interfaces

### DIFF
--- a/standard-interfaces/org.astarte-platform.genericcommands.ServerCommands.json
+++ b/standard-interfaces/org.astarte-platform.genericcommands.ServerCommands.json
@@ -1,0 +1,19 @@
+{
+    "interface_name": "org.astarte-platform.genericcommands.ServerCommands",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "server",
+    "description": "Generic server commands interface.",
+    "doc": "This interface allows sending strings representing a command to a device. This allows to build simple applications that interact with the device to, e.g., turn on or off a switch.",
+    "mappings": [
+        {
+            "endpoint": "/command",
+            "type": "string",
+            "explicit_timestamp": true,
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 86400,
+            "doc": "A string representing a command. The command is deleted from Astarte after 24 hours."
+        }
+    ]
+}

--- a/standard-interfaces/org.astarte-platform.genericevents.DeviceEvents.json
+++ b/standard-interfaces/org.astarte-platform.genericevents.DeviceEvents.json
@@ -1,0 +1,17 @@
+{
+    "interface_name": "org.astarte-platform.genericevents.DeviceEvents",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "device",
+    "description": "Generic device events interface.",
+    "doc": "This interface allows a device to send a string representing an event. This allows to build simple applications that notify Astarte when, e.g., a button is pressed on the device.",
+    "mappings": [
+        {
+            "endpoint": "/event",
+            "type": "string",
+            "explicit_timestamp": true,
+            "doc": "A string representing a device event."
+        }
+    ]
+}


### PR DESCRIPTION
Allow sending generic events and commands

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>