### PR TITLE
docker-compose: make CFSSL stateless, removing postgresql dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Rework metrics to reduce the clutter while monitoring astarte services.
 - [realm_management] Allow updating doc, description and explicit_timestamp within mappings when
   bumping an interface minor.
+- Remove postgresql dependency in `docker-compose`, make CFSSL stateless.
 
 ## [1.0.0-alpha.1] - 2020-06-19
 ### Fixed

--- a/compose/cfssl-config/db_config.json
+++ b/compose/cfssl-config/db_config.json
@@ -1,4 +1,0 @@
-{
-    "driver":"postgres",
-    "data_source":"postgres://astarte:astarte@postgresql/astarte?sslmode=disable"
-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,22 +143,12 @@ services:
       - rabbitmq-data:/var/lib/rabbitmq
 
   # CFSSL
-  postgresql:
-    image: postgres:9.6
-    environment:
-      POSTGRES_USER: "astarte"
-      POSTGRES_PASSWORD: "astarte"
-    volumes:
-      - postgresql-data:/var/lib/postgresql/data
   cfssl:
     image: astarte/cfssl
-    depends_on:
-      - "postgresql"
     volumes:
       - ./compose/cfssl-config:/config
       - cfssl-data:/data
-    # Ensure we wait for pg
-    command: wait-for postgresql:5432 -t 90 -- cfssl serve -address=0.0.0.0 -ca=/data/ca.pem -ca-key=/data/ca-key.pem -port=8080 -config=/etc/cfssl/ca_root_config.json -db-config=/etc/cfssl/db_config.json
+    command: cfssl serve -address=0.0.0.0 -ca=/data/ca.pem -ca-key=/data/ca-key.pem -port=8080 -config=/etc/cfssl/ca_root_config.json
     # Restart if we fail
     restart: on-failure
 
@@ -202,7 +192,6 @@ services:
     restart: on-failure
 volumes:
   rabbitmq-data:
-  postgresql-data:
   scylla-data:
   vernemq-data:
   cfssl-data:


### PR DESCRIPTION
We already removed the dependency from K8s deployments, it makes sense to also
do this in this kind of setup.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>