### PR TITLE
astarte_pairing_api: don't use legacy format for hw_id

### DIFF
--- a/apps/astarte_pairing_api/priv/static/astarte_pairing_api.yaml
+++ b/apps/astarte_pairing_api/priv/static/astarte_pairing_api.yaml
@@ -96,7 +96,7 @@ paths:
                   $ref: '#/components/schemas/DeviceRegistrationRequest'
               example:
                 data:
-                  hw_id: YHjKs3SMTgqq09eD7fzm6wY25SWGI5RCyD48hqywwznQ
+                  hw_id: YHjKs3SMTgqq09eD7fzm6w
                   initial_introspection:
                     org.astarte-platform.genericsensors.Values:
                       major: 0


### PR DESCRIPTION
Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>