### PR TITLE
Improve logs

### DIFF
--- a/tools/astarte_e2e/config/prod.exs
+++ b/tools/astarte_e2e/config/prod.exs
@@ -20,5 +20,8 @@ use Mix.Config
 
 config :logger, :console,
   level: :info,
+  compile_time_purge_matching: [
+    [level_lower_than: :info]
+  ],
   format: {PrettyLog.LogfmtFormatter, :format},
   metadata: [:module, :function, :tag]


### PR DESCRIPTION
+ debug messages are ignored in prod env
+ decouple deliver/1 from specific log messages

Signed-off-by: Mattia Mazzucato <matt.mazzucato@gmail.com>