### PR TITLE
Update setup-elixir Github action

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -60,7 +60,7 @@ jobs:
         key: ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/setup-elixir@v1.5.0
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}
@@ -129,7 +129,7 @@ jobs:
         key: ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/setup-elixir@v1.5.0
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}

--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -29,7 +29,7 @@ jobs:
       with:
         repository: astarte-platform/docs
         path: docs
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/setup-elixir@v1.5.0
       with:
         otp-version: 21.3
         elixir-version: 1.8.2


### PR DESCRIPTION
This is needed since Github deprecated some commands that were used by the old
version, see
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>