### PR TITLE
Disable flow preview in local dashboard

### DIFF
--- a/compose/astarte-dashboard/config.json
+++ b/compose/astarte-dashboard/config.json
@@ -1,6 +1,7 @@
 {
     "astarte_api_url": "localhost",
     "default_auth": "token",
+    "enable_flow_preview": false,
     "auth": [
         {
             "type": "token"


### PR DESCRIPTION
Don't show Flow related stuff on the Dashboard
when using docker-compose, as Flow is not deployed

Signed-off-by: Mattia Pavinati <mattia.pavinati@ispirata.com>