### PR TITLE
data_updater_plant: use database_retention_ttl in device aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   housekeeping keypair.
 - [trigger_engine] Correctly handle triggers on binaryblob interfaces, serializing value with base64
   like appengine does.
+- [data_updater_plant] Consider `database_retention_ttl` when inserting data on device owned
+  aggregate interfaces.
 
 ## [0.11.3] - 2020-09-24
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -1877,9 +1877,15 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
         end
 
       :object ->
-        with {:guessed, guessed_endpoints} <-
+        with {:guessed, [first_endpoint_id | _tail] = guessed_endpoints} <-
                EndpointsAutomaton.resolve_path(path, interface_descriptor.automaton),
-             :ok <- check_object_aggregation_prefix(path, guessed_endpoints, mappings) do
+             :ok <- check_object_aggregation_prefix(path, guessed_endpoints, mappings),
+             {:ok, first_mapping} <- Map.fetch(mappings, first_endpoint_id) do
+          # We return the first guessed mapping changing just its endpoint id, using the canonical
+          # endpoint id used in object aggregated interfaces. This way all mapping properties
+          # (database_retention_ttl, reliability etc) are correctly set since they're the same in
+          # all mappings (this is enforced by Realm Management when the interface is installed)
+
           endpoint_id =
             CQLUtils.endpoint_id(
               interface_descriptor.name,
@@ -1887,7 +1893,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
               ""
             )
 
-          {:ok, %Mapping{endpoint_id: endpoint_id}}
+          {:ok, %{first_mapping | endpoint_id: endpoint_id}}
         else
           {:ok, _endpoint_id} ->
             # This is invalid here, publish doesn't happen on endpoints in object aggregated interfaces


### PR DESCRIPTION
database_retention_ttl was ignored on device-owned interfaces with object
aggregation, fix that.

Fix #501

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>