### PR TITLE
docs: Add needed steps to install cert-manager

### DIFF
--- a/doc/pages/administrator/010-system_requirements.md
+++ b/doc/pages/administrator/010-system_requirements.md
@@ -6,12 +6,17 @@ the scope of this document.
 
 ## Kubernetes Requirements
 
-Astarte requires at least Kubernetes 1.12 - however, it currently targets Kubernetes 1.16+. It is advised
-to consult Astarte Operator's compatibility matrix in the README to ensure a specific Kubernetes setup is
-supported.
+Astarte requires at least Kubernetes 1.16, and strives to be compatible with all newer Kubernetes versions.
+It is advised to consult Astarte Operator's compatibility matrix in the README to ensure a specific Kubernetes
+setup is supported.
 
 The Astarte Operator does not require any unstable feature gate in Kubernetes 1.16, and is actively tested
 against KinD and major Managed Kubernetes installations on various Cloud Providers.
+
+## Dependencies
+
+Astarte Operator requires [`cert-manager`](https://cert-manager.io/) to enable Webhooks. This documentation will
+detail all needed steps for installing `cert-manager` in the cluster in case it's not installed yet.
 
 ## Resource Requirements
 

--- a/doc/pages/administrator/020-prerequisites.md
+++ b/doc/pages/administrator/020-prerequisites.md
@@ -24,6 +24,32 @@ you should refer to [Voyager's documentation](https://appscode.com/products/voya
 
 You don't need to create Voyager ingresses yourself - just the Operator itself is enough.
 
+## cert-manager
+
+Astarte requires [`cert-manager`](https://cert-manager.io/) to be installed in the cluster in its default
+configuration (installed in namespace `cert-manager` as `cert-manager`). If you are using `cert-manager` in your
+cluster already you don't need to take any action - otherwise, you will need to install it.
+
+Astarte is actively tested with `cert-manager` 1.1, but should work with any 1.0+ releases of `cert-manager`.
+
+[`cert-manager` documentation](https://cert-manager.io/docs/installation/) details all needed steps to have
+a working instance on your cluster - however, in case you won't be using `cert-manager` for other components beyond
+Astarte or, in general, if you don't have very specific requirements, it is advised to install it through its Helm
+chart. To do so, run the following commands:
+
+```bash
+$ helm repo add jetstack https://charts.jetstack.io
+$ helm repo update
+$ kubectl create namespace cert-manager
+$ helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --version v1.1.0 \
+  --set installCRDs=true
+```
+
+This will install `cert-manager` 1.1.0 and its CRDs in the cluster.
+
 ## External Cassandra
 
 In production deployments, it is strongly advised to have a separate Cassandra cluster interacting with the Kubernetes


### PR DESCRIPTION
cert-manager is a new needed dependency for Astarte Operator 1.0+ that has to be manually installed for a number of good reasons. Detail in the docs how to proceed and how to set up the Cluster.