### PR TITLE
doc: Add javascript_config_path to doc configuration

### DIFF
--- a/doc/mix.exs
+++ b/doc/mix.exs
@@ -24,6 +24,7 @@ defmodule Doc.MixProject do
       main: "001-intro_user",
       logo: "images/mascot.png",
       source_url: "https://git.ispirata.com/Astarte-NG/%{path}#L%{line}",
+      javascript_config_path: "../common_vars.js", # It's in the docs repo root
       extras: Path.wildcard("pages/*/*.md"),
       assets: "images/",
       groups_for_extras: [


### PR DESCRIPTION
This enables the version-selection dropbox in the documentation's website, making it future-proof from here on.