### PR TITLE
Fix broken links in documentation

### DIFF
--- a/doc/pages/architecture/070-auth.md
+++ b/doc/pages/architecture/070-auth.md
@@ -110,7 +110,7 @@ Astarte, by default, is extremely easy to configure assuming your chosen SSO is 
 
 The main purpose of Astarte's design, however, is to keep things simple for everyone. Putting up a full-fledged SSO dedicated to Astarte is beyond the scope of this documentation, and we favor the use case where an existing SSO infrastructure is integrated with Astarte, rather than built ad-hoc.
 
-For simple use cases and instant satisfaction, it is strongly advised to use a simpler solution, such as a dedicated OAuth server. Almost all popular languages and frameworks provide great projects which can spin up an OAuth2 server + user management in a matter of hours, from [Elixir/Phoenix](https://github.com/mustafaturan/shield) to [Java/Spring](https://github.com/spring-cloud-samples/authserver) to [Go](https://github.com/RichardKnop/go-oauth2-server).
+For simple use cases and instant satisfaction, it is strongly advised to use a simpler solution, such as a dedicated OAuth server. Almost all popular languages and frameworks provide great projects which can spin up an OAuth2 server + user management in a matter of hours, from [Elixir/Phoenix](https://github.com/mbuhot/shield) to [Java/Spring](https://github.com/spring-cloud-samples/authserver) to [Go](https://github.com/RichardKnop/go-oauth2-server).
 
 [Astarte's Enterprise Distribution](https://astarte.cloud/enterprise) includes other add-ons, such as automation and configuration for popular SSOs.
 

--- a/doc/pages/user/040-connect_device.md
+++ b/doc/pages/user/040-connect_device.md
@@ -28,7 +28,7 @@ is then used for obtaining information about which Transports the Device can use
 and for obtaining Credentials for its assigned Transports.
 
 The ability to request Credentials of a Device can be inhibited with [AppEngine
-API](/api/#/device/updateDeviceStatus) or using
+API](https://docs.astarte-platform.org/1.0/api/#/device/updateDeviceStatus) or using
 [`astartectl`](https://github.com/astarte-platform/astartectl) with this command:
 
 ```bash


### PR DESCRIPTION
This MR replaces broken links in the documentation that resulted in 404 pages with up-to-date links.
