### PR TITLE
device: don't discard opts when retrieving object aggregations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0-beta.2] - Unreleased
 ### Fixed
 - [astarte_e2e] Fix alerting mechanism preventing "unknown" failures to be raised or linked.
+- [astarte_appengine_api] Allow retrieving data from interfaces with parametric endpoint and object
+  aggregation (see [#480](https://github.com/astarte-platform/astarte/issues/480)).
 
 ### Changed
 - [astarte_e2e] Client disconnections are responsible for triggering a mail alert.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -1190,7 +1190,7 @@ defmodule Astarte.AppEngine.API.Device do
                 endpoint_id,
                 endpoint_row,
                 a_path,
-                %InterfaceValuesOptions{limit: 1}
+                %{opts | limit: 1}
               )
 
             case values do


### PR DESCRIPTION
The call to retrieve_endpoint_values was discarding opts when multiple paths
were present in an object aggregation (e.g. when it contained multiple instances
of a parametric path). This caused the call to always have false in the
explicit_timestamp option, which in turn caused a crash when an interface with
explicit_timestamp true was queried due to different timestamp columns.

Fix #480