### PR TITLE
Update docs to warn about dangling CFSSL pv after upgrading to 1.0

### DIFF
--- a/doc/pages/upgrade/020-upgrade_011_10.md
+++ b/doc/pages/upgrade/020-upgrade_011_10.md
@@ -201,3 +201,15 @@ kubectl edit astarte -n astarte
 Find the `version` field in the Astarte Spec section and change it according to your needs. Once the
 yaml file will be saved, the Operator will take over ensuring the reconciliation of your Astarte
 instance to the requested version.
+
+### Caveats
+Astarte v0.11 employs a persistent volume to store CA certificate and private key, while upgrading
+to v1.0 involves a change in how device certificates are stored as, behind the scenes, these data
+are held as a Kubernetes TLS secret.
+
+Following the Kubernetes conventions, the formerly used persistent volume and its corresponding
+claim are left within the cluster even if not used anymore.
+
+If you followed the procedure described [here](#migrate-ca-certificate-and-key) you are free to
+remove the CFSSL persistent volume and claim without the need for your devices to request new
+credentials.


### PR DESCRIPTION
Users should be aware of the dangling CSFFL pv after upgrading to 1.0. Make it clear adding a small section to the docs.