### PR TITLE
Docs: fix Astarte in 5 minutes typo for Trigger example

### DIFF
--- a/doc/pages/tutorials/010-astarte_in_5_minutes.md
+++ b/doc/pages/tutorials/010-astarte_in_5_minutes.md
@@ -125,7 +125,7 @@ We will also test Astarte's push capabilities with a trigger. This will send a P
 
 Due to how triggers work, it is fundamental to install the trigger before a device connects. Doing otherwise will cause the trigger to kick in at a later time, and as such no events will be streamed for a while.
 
-Replace `http://example.com` with your target URL in the command below, you can use a Postbin service like [Mailgun Postbin](http://bin.mailgun.net) to generate a URL and see the POST requests. The resulting trigger would be:
+Replace `$TRIGGER_TARGET_URL` with your target URL in the example below, you can use a Postbin service like [Mailgun Postbin](http://bin.mailgun.net) to generate a URL and see the POST requests. The resulting trigger would be:
 
 ```json
 {


### PR DESCRIPTION
Fix typo in Astarte in 5 minutes guide where there was a reference to a non existent URL.