### PR TITLE
090-database: invert manual migration steps for attributes column

### DIFF
--- a/doc/pages/architecture/090-database.md
+++ b/doc/pages/architecture/090-database.md
@@ -315,16 +315,17 @@ ADD (
 
 *Warning*: migrating data from the `metadata` column to the `attributes` one is possible but is out
 of scope of this guide since this change happened between development releases. The procedure below
-just removes and recreates the column *without migrating data*.
-
-```sql
-ALTER TABLE devices
-DROP metadata;
-```
+just creates the new column and then deletes the old one *without migrating data*. You're free to
+implement a migration procedure between the two steps.
 
 ```sql
 ALTER TABLE devices
 ADD (
     attributes map<varchar, varchar>
 );
+```
+
+```sql
+ALTER TABLE devices
+DROP metadata;
 ```


### PR DESCRIPTION
This way the old column is still there while the new one can be already used,
and a migration procedure can be easily implemented if needed

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>