### PR TITLE
amqp_action: make amqp_routing_key mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_housekeeping_api] Add `/v1/version` endpoint, returning the API application
   version.
 
+### Changed
+- [astarte_realm_management] Make `amqp_routing_key` mandatory in AMQP actions.
+
 ## [1.0.0-beta.2] - 2021-03-24
 ### Fixed
 - [astarte_e2e] Fix alerting mechanism preventing "unknown" failures to be raised or linked.

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/amqp_action.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/amqp_action.ex
@@ -26,7 +26,7 @@ defmodule Astarte.RealmManagement.API.Triggers.AMQPAction do
   @primary_key false
   embedded_schema do
     field :amqp_exchange, :string
-    field :amqp_routing_key, :string, default: ""
+    field :amqp_routing_key, :string
     field :amqp_static_headers, {:map, :string}
     field :amqp_message_expiration_ms, :integer
     field :amqp_message_priority, :integer
@@ -36,9 +36,10 @@ defmodule Astarte.RealmManagement.API.Triggers.AMQPAction do
   @mandatory_attrs [
     :amqp_exchange,
     :amqp_message_expiration_ms,
-    :amqp_message_persistent
+    :amqp_message_persistent,
+    :amqp_routing_key
   ]
-  @all_attrs [:amqp_static_headers, :amqp_message_priority, :amqp_routing_key] ++ @mandatory_attrs
+  @all_attrs [:amqp_static_headers, :amqp_message_priority] ++ @mandatory_attrs
 
   @doc false
   def changeset(%AMQPAction{} = amqp_action, attrs, opts) do

--- a/doc/pages/architecture/060-triggers.md
+++ b/doc/pages/architecture/060-triggers.md
@@ -495,6 +495,7 @@ This is a minimal configuration object representing an
 ```json
 {
   "amqp_exchange": "astarte_events_<realm-name>_<exchange-suffix>",
+  "amqp_routing_key": "my_routing_key",
   "amqp_message_expiration_ms": <expiration in milliseconds>,
   "amqp_message_persistent": <true when disk persistency is used>
 }
@@ -507,7 +508,7 @@ It is possible to configure more advanced AMQP 0-9-1 actions:
   "amqp_exchange": "astarte_events_myrealm_myexchange",
   "amqp_routing_key": "my routing key",
   "amqp_static_headers": {
-    "key": "calue"
+    "key": "value"
   },
   "amqp_message_expiration_ms": 10000,
   "amqp_message_priority": 0,


### PR DESCRIPTION
An empty routing key is problematic since it's not possible to easily bind an
Exchange and a Queue with an empty routing key. Hence, we make it mandatory to
provide a routing key to make the bind explicit.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>