### PR TITLE
Add note on /socket endpoint deprecation for Astarte Channels

### DIFF
--- a/doc/pages/upgrade/020-upgrade_011_10.md
+++ b/doc/pages/upgrade/020-upgrade_011_10.md
@@ -203,6 +203,9 @@ yaml file will be saved, the Operator will take over ensuring the reconciliation
 instance to the requested version.
 
 ### Caveats
+
+#### CFSSL leftover persistent volume
+
 Astarte v0.11 employs a persistent volume to store CA certificate and private key, while upgrading
 to v1.0 involves a change in how device certificates are stored as, behind the scenes, these data
 are held as a Kubernetes TLS secret.
@@ -213,3 +216,9 @@ claim are left within the cluster even if not used anymore.
 If you followed the procedure described [here](#migrate-ca-certificate-and-key) you are free to
 remove the CFSSL persistent volume and claim without the need for your devices to request new
 credentials.
+
+#### AppEngine `/socket` route removal
+
+The `/socket` endpoint exposed by AppEngine to interact with Astarte Channels, which was already
+deprecated in Astarte v0.11, has been removed. You must use the new route `/v1/socket`
+instead.


### PR DESCRIPTION
Add caveat for 0.11 -> 1.0 migration docs to advise users to use the new Astarte Channels endpoint since the already deprecated `/socket` route on AppEngine has been definitely removed in v1.0 in favor of `/v1/socket`
