### PR TITLE
appengine: allow returning nil in AstarteValue.to_json_friendly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - [astarte_realm_management] Make `amqp_routing_key` mandatory in AMQP actions.
 
+### Fixed
+- [astarte_appengine_api] Don't crash when an interface contains `null` values, just show them as
+  `null` in the resulting JSON.
+
 ## [1.0.0-beta.2] - 2021-03-24
 ### Fixed
 - [astarte_e2e] Fix alerting mechanism preventing "unknown" failures to be raised or linked.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/astarte_value.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/astarte_value.ex
@@ -64,12 +64,10 @@ defmodule Astarte.AppEngine.API.Device.AstarteValue do
     end
   end
 
+  # Allow :null values, converting them to `nil`. They shouldn't be there in the first place,
+  # but if they are it's better to display null than preventing the user to query the interface
   def to_json_friendly(:null, _value_type, _opts) do
-    raise ArgumentError, message: "invalid argument :null"
-  end
-
-  def to_json_friendly(nil, _value_type, _opts) do
-    raise ArgumentError, message: "invalid nil argument"
+    nil
   end
 
   def to_json_friendly(value, _value_type, _opts) do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/astarte_value_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/astarte_value_test.exs
@@ -82,13 +82,9 @@ defmodule Astarte.AppEngine.API.AstarteValueTest do
     assert AstarteValue.to_json_friendly(true, :boolean, []) == true
   end
 
-  test "json friendly fails on unsupported argument" do
-    assert_raise ArgumentError, fn ->
-      assert AstarteValue.to_json_friendly(:null, :string, [])
-    end
+  test "json friendly returns nil on nil-like argument" do
+    assert AstarteValue.to_json_friendly(:null, :string, []) == nil
 
-    assert_raise ArgumentError, fn ->
-      assert AstarteValue.to_json_friendly(nil, :string, [])
-    end
+    assert AstarteValue.to_json_friendly(nil, :string, []) == nil
   end
 end


### PR DESCRIPTION
The interaction between https://github.com/astarte-platform/astarte/issues/550
and https://github.com/astarte-platform/astarte/pull/551 was preventing
aggregate interfaces that got populated with incomplete objects to be queried.
This fixes that, allowing AppEngine to return null in some JSON fields (since
it's not its job to fix that kind of issue anyway).

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>