### PR TITLE
RM: Queries: fix all interfaces with same name deletion bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.5] - Unreleased
+- [realm_management] Avoid deleting all interfaces sharing the same name by mistake, only the v0
+  interface can be deleted.
+
 ## [0.11.4] - 2021-01-26
 ### Fixed
 - Avoid creating an `housekeeping_public.pem` directory if `docker-compose up` doesn't find the

--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -470,12 +470,14 @@ defmodule Astarte.RealmManagement.Queries do
       |> DatabaseQuery.put(:interface_id, interface_id)
       |> DatabaseQuery.consistency(:each_quorum)
 
-    delete_interface_statement = "DELETE FROM interfaces WHERE name=:name"
+    delete_interface_statement =
+      "DELETE FROM interfaces WHERE name=:name AND major_version=:major"
 
     delete_interface =
       DatabaseQuery.new()
       |> DatabaseQuery.statement(delete_interface_statement)
       |> DatabaseQuery.put(:name, interface_name)
+      |> DatabaseQuery.put(:major, interface_major_version)
       |> DatabaseQuery.consistency(:each_quorum)
 
     # TODO: use a batch here


### PR DESCRIPTION
The query was limiting the delete operation on all interfaces with given
name. The DELETE query must be limited using (name, major) couple,
otherwise other interfaces are deleted by mistake.

This bug was not causing data loss, however it causes service
distruption and it requires a manual fix.