### PR TITLE
020-upgrade_011_10: make clear we need `gawk`

### DIFF
--- a/doc/pages/upgrade/020-upgrade_011_10.md
+++ b/doc/pages/upgrade/020-upgrade_011_10.md
@@ -114,6 +114,15 @@ to your needs. For instance, if you want to refer to a particular Operator's tag
 is to append `--set image.tag=<the-required-tag>` to the previous command. To check all the
 configurable values run `helm show values astarte/astarte-operator`.
 
+Before moving on, make sure that `gawk` is installed on your host machine. If you are on OSX,
+running the following command will be sufficient:
+```bash
+$ brew install gawk
+```
+while on any Debian based OS run:
+```bash
+# apt install gawk
+```
 Now it's time to prepare the cluster to allow the new operator installation by means of the
 templates generated in the previous step.
 


### PR DESCRIPTION
`awk` is breaking the upgrade procedure for OSX users. Use `gawk` to ensure the proper behavior.
Fix  #593 