### PR TITLE
Revert "DataUpdater: triggers are not yet supported on object aggregated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.0] - Unreleased
+### Added
+- Add support for volatile triggers on interfaces with object aggregation.
+
 ### Changed
 - Document future removal of Astarte Operator's support for Cassandra.
 


### PR DESCRIPTION
This reverts commit 974c065bc937c683c32691ea90ba620984fd39f2.
Volatile triggers are now supported even in object aggregation since all
types are correctly JSON encoded even if they're contained in an object
aggregation (see
https://github.com/astarte-platform/astarte_core/commit/b22148daf84cf2355e9e7ba02e9ce39dae5db336)