### PR TITLE
Data Updater Plant: use a reasonable backoff time when publishing to RabbitMQ.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [realm_management] Avoid deleting all interfaces sharing the same name by mistake, only the v0
   interface can be deleted.
+- [data_updater_plant] Use a reasonable backoff time (at most around 5 minutes) when publishing 
+  to RabbitMQ.
 
 ## [0.11.4] - 2021-01-26
 ### Fixed

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
@@ -25,7 +25,7 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
   by the Trigger targets
   """
 
-  @max_backoff_exponent 10
+  @max_backoff_exponent 8
 
   use Astarte.Core.Triggers.SimpleEvents
 
@@ -410,7 +410,8 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
       "Failed publish on events exchange with #{routing_key}. Reason: #{inspect(reason)}"
     )
 
-    :rand.uniform(1 <<< (retry * 1000))
+    retry
+    |> compute_backoff_time()
     |> :timer.sleep()
 
     next_retry =
@@ -468,5 +469,10 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
     )
 
     result
+  end
+
+  defp compute_backoff_time(current_attempt) do
+    minimum_duration = (1 <<< current_attempt) * 1000
+    minimum_duration + round(minimum_duration * 0.25 * :rand.uniform())
   end
 end


### PR DESCRIPTION
Maximum (exponential) backoff time is now around 5 minutes.