### PR TITLE
appengine: fix null values support in interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Document future removal of Astarte Operator's support for Cassandra.
 
+### Fixed
+- [astarte_appengine_api] Fix the support for `null` values in interfaces, the fix contained in
+`1.0.0-rc.0` was incomplete.
+
 ## [1.0.0-rc.0] - 2021-05-10
 ### Added
 - [astarte_appengine_api] Add `/v1/<realm>/version` endpoint, returning the API application version.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/astarte_value.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/astarte_value.ex
@@ -16,6 +16,18 @@
 # limitations under the License.
 
 defmodule Astarte.AppEngine.API.Device.AstarteValue do
+  # Match on nil values, skipping any conversion. This is needed to handle missing endpoints in
+  # object aggregations, which are allowed due to semantic versioning (i.e. data sent from a
+  # previous minor version doesn't contain data on new endpoints)
+  def to_json_friendly(nil, _value_type, _opts) do
+    nil
+  end
+
+  # Allow :null values, converting them to `nil`. See comment above.
+  def to_json_friendly(:null, _value_type, _opts) do
+    nil
+  end
+
   def to_json_friendly(value, :longinteger, opts) do
     cond do
       opts[:allow_bigintegers] ->
@@ -62,12 +74,6 @@ defmodule Astarte.AppEngine.API.Device.AstarteValue do
     for item <- value do
       to_json_friendly(item, :datetime, opts)
     end
-  end
-
-  # Allow :null values, converting them to `nil`. They shouldn't be there in the first place,
-  # but if they are it's better to display null than preventing the user to query the interface
-  def to_json_friendly(:null, _value_type, _opts) do
-    nil
   end
 
   def to_json_friendly(value, _value_type, _opts) do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/astarte_value_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/astarte_value_test.exs
@@ -82,9 +82,8 @@ defmodule Astarte.AppEngine.API.AstarteValueTest do
     assert AstarteValue.to_json_friendly(true, :boolean, []) == true
   end
 
-  test "json friendly returns nil on nil-like argument" do
-    assert AstarteValue.to_json_friendly(:null, :string, []) == nil
-
-    assert AstarteValue.to_json_friendly(nil, :string, []) == nil
+  test "json friendly returns nil on nil-like argument, skipping conversions" do
+    assert AstarteValue.to_json_friendly(:null, :longinteger, []) == nil
+    assert AstarteValue.to_json_friendly(nil, :binaryblob, []) == nil
   end
 end


### PR DESCRIPTION
This is needed to handle object aggregations with missing endpoints, which are
supported due to interface versioning. This avoid crashes when nil values are
received on mappings with datatypes which imply a conversion.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>