### PR TITLE
compose: Always pull CFSSL 1.4.1-astarte.0 for 0.11

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,7 +151,7 @@ services:
     volumes:
       - postgresql-data:/var/lib/postgresql/data
   cfssl:
-    image: astarte/cfssl
+    image: astarte/cfssl:1.4.1-astarte.0
     depends_on:
       - "postgresql"
     volumes:


### PR DESCRIPTION
Make sure that all images are always tagged / versioned.