### PR TITLE
Remove leftover `--devel` from the docs

### DIFF
--- a/doc/pages/administrator/095-advanced-operations.md
+++ b/doc/pages/administrator/095-advanced-operations.md
@@ -243,7 +243,7 @@ CRD and its resources.
 Even if it might look like the status of the cluster is compromised, a simple command reestablishes
 the order:
 ```bash
-helm upgrade --install astarte-operator astarte/astarte-operator --devel -n kube-system
+helm upgrade --install astarte-operator astarte/astarte-operator -n kube-system
 ```
 This command simply upgrades the Operator and, as a result, installs the missing CRDs. Now it's time
 to restore the Astarte resources.

--- a/doc/pages/upgrade/020-upgrade_011_10.md
+++ b/doc/pages/upgrade/020-upgrade_011_10.md
@@ -102,7 +102,6 @@ export ASTARTE_OP_RELEASE_NAMESPACE=kube-system
 Generate the Helm templates with the following:
 ```bash
 helm template $ASTARTE_OP_RELEASE_NAME astarte/astarte-operator \
-    --devel \
     --namespace $ASTARTE_OP_RELEASE_NAMESPACE \
     --output-dir $ASTARTE_OP_TEMPLATE_DIR
 ```
@@ -166,7 +165,7 @@ To install the Operator, simply run:
 
 ```bash
 helm install $ASTARTE_OP_RELEASE_NAME astarte/astarte-operator -n $ASTARTE_OP_RELEASE_NAMESPACE \
-    --devel --skip-crds
+    --skip-crds
 ```
 
 Note that the `--skip-crds` flag is required as, following the migration path, we already

--- a/doc/pages/upgrade/030-upgrade_10.md
+++ b/doc/pages/upgrade/030-upgrade_10.md
@@ -6,7 +6,7 @@ Astarte Operator's upgrade procedure is handled by Helm. To upgrade the Helm cha
 dedicated `helm upgrade` command:
 
 ```bash
-helm upgrade astarte-operator astarte/astarte-operator --devel
+helm upgrade astarte-operator astarte/astarte-operator
 ```
 
 The optional `--version` switch allows to specify the version to upgrade to - when not specified,
@@ -21,7 +21,7 @@ referenced by the chart is changed. You can check the Operator's tag binded to t
 running:
 
 ```bash
-helm show values astarte/astarte-operator --devel
+helm show values astarte/astarte-operator
 ```
 
 As usual, you can use the usual `--version` flag to point to a specific chart version.


### PR DESCRIPTION
The stable Operator's Helm chart was released. Using `--devel` is not
needed anymore. Thus, remove it from the instructions contained in the
doc.