### PR TITLE
Fix 500 error in Appengine when interface queries have no matching data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - [astarte_appengine_api] Correctly serialize events containing datetime and array values.
+- [astarte_appengine_api] Do not fail when querying `datastream` interfaces data with `since`, 
+`to`, `sinceAfter` params if result is empty. Fix [#552](https://github.com/astarte-platform/astarte/issues/552). 
 - [astarte_trigger_engine] Correctly serialize events containing datetime and array values.
 - [astarte_data_updater_plant] Don't crash when receiving `binaryblobarray` and `datetimearray`
   values.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/config/non_negative_integer.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/config/non_negative_integer.ex
@@ -37,6 +37,10 @@ defmodule Astarte.AppEngine.API.Config.NonNegativeInteger do
     end
   end
 
+  def cast(value) when is_integer(value) do
+    if value >= 0, do: {:ok, value}, else: {:ok, 0}
+  end
+
   def cast(_) do
     :error
   end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -1338,7 +1338,7 @@ defmodule Astarte.AppEngine.API.Device do
   end
 
   defp get_interface_values_from_path([], _metadata, _path, _only_path) do
-    {:ok, %{}}
+    {:ok, %InterfaceValues{data: %{}}}
   end
 
   defp get_interface_values_from_path(values, metadata, path, only_path) when is_list(values) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -1068,14 +1068,7 @@ defmodule Astarte.AppEngine.API.Device do
         if String.starts_with?(row[:path], path) do
           [{:path, row_path}] = row
 
-          simplified_path = simplify_path(path, row_path)
-
-          [
-            {:value_timestamp, tstamp},
-            {:reception_timestamp, reception},
-            _,
-            {_, v}
-          ] =
+          last_value =
             Queries.last_datastream_value!(
               client,
               device_id,
@@ -1086,28 +1079,41 @@ defmodule Astarte.AppEngine.API.Device do
               opts
             )
 
-          nice_value =
-            AstarteValue.to_json_friendly(
-              v,
-              ValueType.from_int(endpoint_row[:value_type]),
-              allow_bigintegers: true
-            )
+          case last_value do
+            :empty_dataset ->
+              %{}
 
-          Map.put(values_map, simplified_path, %{
-            "value" => nice_value,
-            "timestamp" =>
-              AstarteValue.to_json_friendly(
-                tstamp,
-                :datetime,
-                keep_milliseconds: opts.keep_milliseconds
-              ),
-            "reception_timestamp" =>
-              AstarteValue.to_json_friendly(
-                reception,
-                :datetime,
-                keep_milliseconds: opts.keep_milliseconds
-              )
-          })
+            [
+              {:value_timestamp, tstamp},
+              {:reception_timestamp, reception},
+              _,
+              {_, v}
+            ] ->
+              simplified_path = simplify_path(path, row_path)
+
+              nice_value =
+                AstarteValue.to_json_friendly(
+                  v,
+                  ValueType.from_int(endpoint_row[:value_type]),
+                  allow_bigintegers: true
+                )
+
+              Map.put(values_map, simplified_path, %{
+                "value" => nice_value,
+                "timestamp" =>
+                  AstarteValue.to_json_friendly(
+                    tstamp,
+                    :datetime,
+                    keep_milliseconds: opts.keep_milliseconds
+                  ),
+                "reception_timestamp" =>
+                  AstarteValue.to_json_friendly(
+                    reception,
+                    :datetime,
+                    keep_milliseconds: opts.keep_milliseconds
+                  )
+              })
+          end
         else
           values_map
         end


### PR DESCRIPTION
When querying on an interface for device data with `since`, `to` and `sinceAfter` params, Appengine API does not fail if the result is empty. See [#552](https://github.com/astarte-platform/astarte/issues/552).