### PR TITLE
Allow changing `database_retention_policy` and `database_retention_ttl` on a minor interface upgrade.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - [data_updater_plant] Add handle_data duration metric.
 
+### Changed
+- [astarte_realm_management] Allow changing `database_retention_policy` and `database_retention_ttl` 
+  on a minor interface upgrade. See [504](https://github.com/astarte-platform/astarte/issues/504).  
+
 ### Fixed
 - [astarte_appengine_api] Correctly serialize events containing datetime and array values.
 - [astarte_appengine_api] Do not fail when querying `datastream` interfaces data with `since`, 

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -323,11 +323,20 @@ defmodule Astarte.RealmManagement.Engine do
   defp is_mapping_updated?(mapping, upd_mapping) do
     mapping.explicit_timestamp != upd_mapping.explicit_timestamp or
       mapping.doc != upd_mapping.doc or
-      mapping.description != upd_mapping.description
+      mapping.description != upd_mapping.description or
+      mapping.database_retention_policy != upd_mapping.database_retention_policy or
+      mapping.database_retention_ttl != upd_mapping.database_retention_ttl
   end
 
   defp drop_mapping_negligible_fields(%Mapping{} = mapping) do
-    %{mapping | doc: nil, description: nil, explicit_timestamp: false}
+    %{
+      mapping
+      | doc: nil,
+        description: nil,
+        explicit_timestamp: false,
+        database_retention_policy: nil,
+        database_retention_ttl: :no_ttl
+    }
   end
 
   def delete_interface(realm_name, name, major, opts \\ []) do

--- a/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
@@ -381,7 +381,9 @@ defmodule Astarte.RealmManagement.EngineTest do
             "type": "double",
             "explicit_timestamp": false,
             "description": "Updated description.",
-            "doc": "Updated docs."
+            "doc": "Updated docs.",
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 60
         }
     ]
   }


### PR DESCRIPTION
See [504](https://github.com/astarte-platform/astarte/issues/504).