### PR TITLE
AppEngine: Intermediate paths return valid data also when a `properties` interface is not fully populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_realm_management] Add support for device introspection triggers.
 - [astarte_realm_management_api] Add support for device introspection triggers.
 
+### Fixed
+- [astarte_appengine_api] Return empty data instead of error when querying `properties` interfaces 
+  which are not fully populated. Fix [531](astarte-platform#531).
+
+
 ## [1.0.3] - 2022-07-04
 ### Fixed
 - [astarte_appengine_api] Consider `allow_bigintegers` and `allow_safe_bigintegers` params

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -879,48 +879,36 @@ defmodule Astarte.AppEngine.API.Device do
          path,
          opts
        ) do
-    {status, result} =
-      List.foldl(endpoint_ids, {:ok, %{}}, fn endpoint_id, {status, values} ->
-        if status == :ok do
-          endpoint_row = Queries.execute_value_type_query(client, endpoint_query, endpoint_id)
+    result =
+      List.foldl(endpoint_ids, %{}, fn endpoint_id, values ->
+        endpoint_row = Queries.execute_value_type_query(client, endpoint_query, endpoint_id)
 
-          value =
-            retrieve_endpoint_values(
-              client,
-              device_id,
-              :individual,
-              :properties,
-              interface_row,
-              endpoint_id,
-              endpoint_row,
-              path,
-              opts
-            )
+        value =
+          retrieve_endpoint_values(
+            client,
+            device_id,
+            :individual,
+            :properties,
+            interface_row,
+            endpoint_id,
+            endpoint_row,
+            path,
+            opts
+          )
 
-          if value != %{} do
-            {:ok, Map.merge(values, value)}
-          else
-            {:error, :path_not_found}
-          end
-        else
-          {status, values}
-        end
+        Map.merge(values, value)
       end)
 
-    if status == :ok do
-      individual_value = Map.get(result, "")
+    individual_value = Map.get(result, "")
 
-      data =
-        if individual_value != nil do
-          individual_value
-        else
-          MapTree.inflate_tree(result)
-        end
+    data =
+      if individual_value != nil do
+        individual_value
+      else
+        MapTree.inflate_tree(result)
+      end
 
-      {:ok, %InterfaceValues{data: data}}
-    else
-      {:error, result}
-    end
+    {:ok, %InterfaceValues{data: data}}
   end
 
   defp do_get_interface_values!(

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
@@ -243,21 +243,25 @@ defmodule Astarte.AppEngine.API.DeviceTest do
              %{}
            ) == {:error, :endpoint_not_found}
 
-    assert Device.get_interface_values!(
-             "autotestrealm",
-             "f0VMRgIBAQAAAAAAAAAAAA",
-             "com.test.LCDMonitor",
-             "weekSchedule/9/start",
-             %{}
-           ) == {:error, :path_not_found}
+    assert unpack_interface_values(
+             Device.get_interface_values!(
+               "autotestrealm",
+               "f0VMRgIBAQAAAAAAAAAAAA",
+               "com.test.LCDMonitor",
+               "weekSchedule/9/start",
+               %{}
+             )
+           ) == %{}
 
-    assert Device.get_interface_values!(
-             "autotestrealm",
-             "f0VMRgIBAQAAAAAAAAAAAA",
-             "com.test.LCDMonitor",
-             "weekSchedule/9",
-             %{}
-           ) == {:error, :path_not_found}
+    assert unpack_interface_values(
+             Device.get_interface_values!(
+               "autotestrealm",
+               "f0VMRgIBAQAAAAAAAAAAAA",
+               "com.test.LCDMonitor",
+               "weekSchedule/9",
+               %{}
+             )
+           ) == %{}
   end
 
   test "get_interface_values! returns interfaces values on individual datastream interface" do


### PR DESCRIPTION
Fix [531](https://github.com/astarte-platform/astarte/issues/531).