### PR TITLE
AppEngine: Consider microseconds when dealing with timestamps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Correctly serialize events containing datetime and array values.
 - [astarte_appengine_api] Do not fail when querying `datastream` interfaces data with `since`, 
 `to`, `sinceAfter` params if result is empty. Fix [#552](https://github.com/astarte-platform/astarte/issues/552). 
+- [astarte_appengine_api] Consider microseconds when using timestamps.
+  Fix [#620](https://github.com/astarte-platform/astarte/issues/620).
 - [astarte_trigger_engine] Correctly serialize events containing datetime and array values.
 - [astarte_data_updater_plant] Don't crash when receiving `binaryblobarray` and `datetimearray`
   values.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
@@ -28,10 +28,10 @@ defmodule Astarte.AppEngine.API.Device.DeviceStatus do
     field :aliases, {:map, :string}
     field :introspection, :map
     field :connected, :boolean
-    field :last_connection, :utc_datetime
-    field :last_disconnection, :utc_datetime
-    field :first_registration, :utc_datetime
-    field :first_credentials_request, :utc_datetime
+    field :last_connection, :utc_datetime_usec
+    field :last_disconnection, :utc_datetime_usec
+    field :first_registration, :utc_datetime_usec
+    field :first_credentials_request, :utc_datetime_usec
     field :last_credentials_request_ip
     field :last_seen_ip
     field :attributes, {:map, :string}

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/interface_values_options.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/interface_values_options.ex
@@ -22,9 +22,9 @@ defmodule Astarte.AppEngine.API.Device.InterfaceValuesOptions do
 
   @primary_key false
   embedded_schema do
-    field :since, :utc_datetime
-    field :since_after, :utc_datetime
-    field :to, :utc_datetime
+    field :since, :utc_datetime_usec
+    field :since_after, :utc_datetime_usec
+    field :to, :utc_datetime_usec
     field :limit, :integer
     field :downsample_to, :integer
     field :downsample_key, :string


### PR DESCRIPTION
Use `utc_datetime_usec` instead of `utc_datetime` in  changesets. 
Indeed, `utc_datetime` no longer keeps microseconds information since Ecto 3.0.0 (see https://github.com/elixir-ecto/ecto/blob/master/CHANGELOG.md).
Fix [#620](https://github.com/astarte-platform/astarte/issues/620).