### PR TITLE
docs-workflow: preserve SDK docs when copying new docs

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -39,11 +39,13 @@ jobs:
     - name: Build Docs
       working-directory: ./astarte/doc
       run: mix docs
-    - name: Copy Docs
+    - name: Copy Docs, preserving Device SDK docs
       run: |
         export DOCS_DIRNAME="$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-//g')"
         rm -rf docs/$DOCS_DIRNAME
         mkdir docs/$DOCS_DIRNAME
+        # Restore Device SDK docs. Don't fail if they're not there.
+        cd docs && git restore docs/$DOCS_DIRNAME/device-sdks || true && cd ..
         cp -r astarte/doc/doc/* docs/$DOCS_DIRNAME/
     - name: Checkout Swagger UI
       uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>