### PR TITLE
docs-workflow: remove docs prefix when restoring SDK docs

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -45,7 +45,7 @@ jobs:
         rm -rf docs/$DOCS_DIRNAME
         mkdir docs/$DOCS_DIRNAME
         # Restore Device SDK docs. Don't fail if they're not there.
-        cd docs && git restore docs/$DOCS_DIRNAME/device-sdks || true && cd ..
+        cd docs && git restore $DOCS_DIRNAME/device-sdks || true && cd ..
         cp -r astarte/doc/doc/* docs/$DOCS_DIRNAME/
     - name: Checkout Swagger UI
       uses: actions/checkout@v2


### PR DESCRIPTION
We're already cd-ing in the directory

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>