### PR TITLE
openapi: Fix HTTP response code on realm creation

### DIFF
--- a/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
+++ b/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
@@ -34,7 +34,7 @@ paths:
       security:
         - JWT: []
       responses:
-        '200':
+        '201':
           description: Success
           content:
             application/json:


### PR DESCRIPTION
As you can see `created` [status](https://hexdocs.pm/plug/Plug.Conn.Status.html#code/1-known-status-codes) is returned on successful realm creation (https://github.com/astarte-platform/astarte/blob/release-1.0/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/realm_controller.ex#L43)