### PR TITLE
realm_management: allow retention and expiry changes in minor update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - Unreleased
+### Added
+- [realm_management] Accept `retention` and `expiry` updates when updating the minor version of an
+  interface.
+
 ## [1.0.1] - 2021-12-17
 ### Added
 - [data_updater_plant] Add handle_data duration metric.

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -323,11 +323,20 @@ defmodule Astarte.RealmManagement.Engine do
   defp is_mapping_updated?(mapping, upd_mapping) do
     mapping.explicit_timestamp != upd_mapping.explicit_timestamp or
       mapping.doc != upd_mapping.doc or
-      mapping.description != upd_mapping.description
+      mapping.description != upd_mapping.description or
+      mapping.retention != upd_mapping.retention or
+      mapping.expiry != upd_mapping.expiry
   end
 
   defp drop_mapping_negligible_fields(%Mapping{} = mapping) do
-    %{mapping | doc: nil, description: nil, explicit_timestamp: false}
+    %{
+      mapping
+      | doc: nil,
+        description: nil,
+        explicit_timestamp: false,
+        retention: nil,
+        expiry: nil
+    }
   end
 
   def delete_interface(realm_name, name, major, opts \\ []) do


### PR DESCRIPTION
Those properties are purely device side so they should not be considered
breaking when updating an interface to a different minor version

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>