### PR TITLE
realm_management: allow mapping updates for object interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - [realm_management] Accept `retention` and `expiry` updates when updating the minor version of an
   interface.
+  
+### Fixed
+- [realm_management] Accept allowed mapping updates in object aggregated interfaces without
+  crashing.
 
 ## [1.0.1] - 2021-12-17
 ### Added

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -33,6 +33,7 @@ defmodule Astarte.RealmManagement.Engine do
   alias Astarte.DataAccess.Interface
   alias Astarte.DataAccess.Mappings
   alias Astarte.RealmManagement.Engine
+  alias Astarte.RealmManagement.Engine.MappingUpdates
   alias Astarte.RealmManagement.Queries
   alias Astarte.RealmManagement.Config
   alias CQEx.Client, as: DatabaseClient
@@ -138,10 +139,8 @@ defmodule Astarte.RealmManagement.Engine do
          {:ok, installed_interface} <- Interface.fetch_interface_descriptor(client, name, major),
          :ok <- error_on_incompatible_descriptor(installed_interface, interface_descriptor),
          :ok <- error_on_downgrade(installed_interface, interface_descriptor),
-         {:ok, new_mappings} <- extract_updated_mappings(client, interface_doc),
+         {:ok, mapping_updates} <- extract_mapping_updates(client, interface_doc),
          {:ok, automaton} <- EndpointsAutomaton.build(interface_doc.mappings) do
-      new_mappings_list = Map.values(new_mappings)
-
       interface_update =
         Map.merge(installed_interface, interface_descriptor, fn _k, old, new ->
           new || old
@@ -152,7 +151,7 @@ defmodule Astarte.RealmManagement.Engine do
         Task.start_link(__MODULE__, :execute_interface_update, [
           client,
           interface_update,
-          new_mappings_list,
+          mapping_updates,
           automaton,
           description,
           doc
@@ -163,7 +162,7 @@ defmodule Astarte.RealmManagement.Engine do
         execute_interface_update(
           client,
           interface_update,
-          new_mappings_list,
+          mapping_updates,
           automaton,
           description,
           doc
@@ -215,7 +214,14 @@ defmodule Astarte.RealmManagement.Engine do
     end
   end
 
-  def execute_interface_update(client, interface_descriptor, new_mappings, automaton, descr, doc) do
+  def execute_interface_update(
+        client,
+        interface_descriptor,
+        %MappingUpdates{} = mapping_updates,
+        automaton,
+        descr,
+        doc
+      ) do
     name = interface_descriptor.name
     major = interface_descriptor.major_version
 
@@ -226,8 +232,18 @@ defmodule Astarte.RealmManagement.Engine do
         tag: "update_interface_started"
       )
 
+    %MappingUpdates{new: new_mappings, updated: updated_mappings} = mapping_updates
+    all_changed_mappings = new_mappings ++ updated_mappings
+
     with :ok <- Queries.update_interface_storage(client, interface_descriptor, new_mappings) do
-      Queries.update_interface(client, interface_descriptor, new_mappings, automaton, descr, doc)
+      Queries.update_interface(
+        client,
+        interface_descriptor,
+        all_changed_mappings,
+        automaton,
+        descr,
+        doc
+      )
     end
   end
 
@@ -273,7 +289,7 @@ defmodule Astarte.RealmManagement.Engine do
     end
   end
 
-  defp extract_updated_mappings(db_client, %{mappings: upd_mappings} = interface_doc) do
+  defp extract_mapping_updates(db_client, %{mappings: upd_mappings} = interface_doc) do
     descriptor = InterfaceDescriptor.from_interface(interface_doc)
 
     with {:ok, mappings_map} <-
@@ -289,7 +305,12 @@ defmodule Astarte.RealmManagement.Engine do
       {existing_mappings, new_mappings} = Map.split(upd_mappings_map, existing_endpoints)
 
       with {:ok, changed_mappings} <- extract_changed_mappings(mappings_map, existing_mappings) do
-        {:ok, Map.merge(new_mappings, changed_mappings)}
+        mapping_updates = %MappingUpdates{
+          new: Map.values(new_mappings),
+          updated: Map.values(changed_mappings)
+        }
+
+        {:ok, mapping_updates}
       end
     end
   end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine/mapping_updates.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine/mapping_updates.ex
@@ -1,0 +1,28 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagement.Engine.MappingUpdates do
+  @moduledoc """
+  A struct tracking the updates happening in a minor version update of an interface.
+
+  The `:new` key contains the list of new mappings.
+  The `:updated` key contains the list of updated mappings.
+  """
+  @enforce_keys [:new, :updated]
+  defstruct @enforce_keys
+end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -431,6 +431,11 @@ defmodule Astarte.RealmManagement.Queries do
     execute_batch(client, insert_mapping_queries ++ [update_interface_query])
   end
 
+  def update_interface_storage(_client, _interface_descriptor, []) do
+    # No new mappings, nothing to do
+    :ok
+  end
+
   def update_interface_storage(
         client,
         %InterfaceDescriptor{storage_type: :one_object_datastream_dbtable, storage: table_name} =


### PR DESCRIPTION
Now object aggregated interfaces can update doc, description, explicit_timestamp, retention and expiry in their mappings in minor version updates.
Fix #642 