### PR TITLE
AppEngine: Fix reception of server-owned datetimearray values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [realm_management] Accept allowed mapping updates in object aggregated interfaces without
   crashing.
+- [astarte_appengine_api] Handle server owned datetimearray values correctly.
 
 ## [1.0.1] - 2021-12-17
 ### Added

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -570,6 +570,11 @@ defmodule Astarte.AppEngine.API.Device.Queries do
   end
 
   # TODO Copy&pasted from data updater plant, make it a library
+  defp to_db_friendly_type(array) when is_list(array) do
+    # If we have an array, we convert its elements to a db friendly type
+    Enum.map(array, &to_db_friendly_type/1)
+  end
+
   defp to_db_friendly_type(%DateTime{} = datetime) do
     DateTime.to_unix(datetime, :millisecond)
   end


### PR DESCRIPTION
Do not crash when datetimearray values are pushed to Astarte on a server-owned interface.
Apply the fix in #610 to AppEngine, too.