### PR TITLE
Housekeeping: do not delete realm having connected devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   crashing.
 - [astarte_appengine_api] Handle server owned datetimearray values correctly.
 
+### Changed
+- [astarte_housekeeping] Allow to delete a realm only if all its devices are disconnected.
+  Realm deletion can still only be enabled with an environment variable (defaults to disabled).
+
 ## [1.0.1] - 2021-12-17
 ### Added
 - [data_updater_plant] Add handle_data duration metric.

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
@@ -194,6 +194,12 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
     {:error, :realm_deletion_disabled}
   end
 
+  defp extract_reply(
+         {:generic_error_reply, %GenericErrorReply{error_name: "connected_devices_present"}}
+       ) do
+    {:error, :connected_devices_present}
+  end
+
   defp extract_reply({:generic_error_reply, error_struct = %GenericErrorReply{}}) do
     error_map = Map.from_struct(error_struct)
 

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/fallback_controller.ex
@@ -48,6 +48,13 @@ defmodule Astarte.Housekeeping.APIWeb.FallbackController do
     |> render(:realm_deletion_disabled)
   end
 
+  def call(conn, {:error, :connected_devices_present}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(ErrorView)
+    |> render(:connected_devices_present)
+  end
+
   def call(conn, {:error, :not_found}) do
     conn
     |> put_status(:not_found)

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/error_view.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/error_view.ex
@@ -43,6 +43,10 @@ defmodule Astarte.Housekeeping.APIWeb.ErrorView do
     %{errors: %{detail: "Realm deletion disabled"}}
   end
 
+  def render("connected_devices_present.json", _assigns) do
+    %{errors: %{detail: "Realm still contains connected devices"}}
+  end
+
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do

--- a/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
+++ b/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
@@ -125,6 +125,8 @@ paths:
       description: >
         Deletes a realm from Astarte. This feature must be explicitly enabled
         in the cluster, if it's disabled a 405 status code will be returned.
+        If there are connected devices present in the realm, a 422 status
+        code will be returned.
       operationId: deleteRealm
       security:
         - JWT: []
@@ -140,6 +142,8 @@ paths:
           description: Success
         '405':
           description: Realm deletion disabled
+        '422':
+          description: Connected devices present
 components:
   securitySchemes:
     JWT:


### PR DESCRIPTION
Add a check on the presence of active devices when realm deletion is performed, in order to avoid unexpected device behaviour. The async API still returns a success.
See #661.