### PR TITLE
Housekeeping API: add synchronous API for realm operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_housekeeping] Allow to delete a realm only if all its devices are disconnected.
   Realm deletion can still only be enabled with an environment variable (defaults to disabled).
 
+### Added
+- [astarte_housekeeping_api] Allow synchronous requests for realm creation and deletion
+  using the `async_operation` option. Default to async calls.
+
 ## [1.0.1] - 2021-12-17
 ### Added
 - [data_updater_plant] Add handle_data duration metric.

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/realms.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/realms.ex
@@ -62,13 +62,13 @@ defmodule Astarte.Housekeeping.API.Realms do
       {:error, ...}
 
   """
-  def create_realm(attrs \\ %{}) do
+  def create_realm(attrs \\ %{}, opts \\ []) do
     changeset =
       %Realm{}
       |> Realm.changeset(attrs)
 
     with {:ok, %Realm{} = realm} <- Ecto.Changeset.apply_action(changeset, :insert) do
-      case Housekeeping.create_realm(realm) do
+      case Housekeeping.create_realm(realm, opts) do
         :ok -> {:ok, realm}
         {:ok, :started} -> {:ok, realm}
         {:error, reason} -> {:error, reason}
@@ -104,8 +104,8 @@ defmodule Astarte.Housekeeping.API.Realms do
       {:error, ...}
 
   """
-  def delete_realm(realm_name) do
-    case Housekeeping.delete_realm(realm_name) do
+  def delete_realm(realm_name, opts \\ []) do
+    case Housekeeping.delete_realm(realm_name, opts) do
       :ok -> :ok
       {:ok, :started} -> :ok
       {:error, reason} -> {:error, reason}

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
@@ -40,15 +40,18 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
   @rpc_client Config.rpc_client!()
   @destination Astarte.RPC.Protocol.Housekeeping.amqp_queue()
 
-  def create_realm(%Realm{
-        realm_name: realm_name,
-        jwt_public_key_pem: pem,
-        replication_class: "SimpleStrategy",
-        replication_factor: replication_factor
-      }) do
+  def create_realm(
+        %Realm{
+          realm_name: realm_name,
+          jwt_public_key_pem: pem,
+          replication_class: "SimpleStrategy",
+          replication_factor: replication_factor
+        },
+        opts
+      ) do
     %CreateRealm{
       realm: realm_name,
-      async_operation: true,
+      async_operation: Keyword.get(opts, :async_operation, true),
       jwt_public_key_pem: pem,
       replication_class: :SIMPLE_STRATEGY,
       replication_factor: replication_factor
@@ -59,15 +62,18 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
     |> extract_reply()
   end
 
-  def create_realm(%Realm{
-        realm_name: realm_name,
-        jwt_public_key_pem: pem,
-        replication_class: "NetworkTopologyStrategy",
-        datacenter_replication_factors: replication_factors_map
-      }) do
+  def create_realm(
+        %Realm{
+          realm_name: realm_name,
+          jwt_public_key_pem: pem,
+          replication_class: "NetworkTopologyStrategy",
+          datacenter_replication_factors: replication_factors_map
+        },
+        opts
+      ) do
     %CreateRealm{
       realm: realm_name,
-      async_operation: true,
+      async_operation: Keyword.get(opts, :async_operation, true),
       jwt_public_key_pem: pem,
       replication_class: :NETWORK_TOPOLOGY_STRATEGY,
       datacenter_replication_factors: Enum.to_list(replication_factors_map)
@@ -86,8 +92,10 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
     |> extract_reply()
   end
 
-  def delete_realm(realm_name) do
-    %DeleteRealm{realm: realm_name, async_operation: true}
+  def delete_realm(realm_name, opts) do
+    async_operation = Keyword.get(opts, :async_operation, true)
+
+    %DeleteRealm{realm: realm_name, async_operation: async_operation}
     |> encode_call(:delete_realm)
     |> @rpc_client.rpc_call(@destination)
     |> decode_reply()

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/realm_controller.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/realm_controller.ex
@@ -29,8 +29,16 @@ defmodule Astarte.Housekeeping.APIWeb.RealmController do
     render(conn, "index.json", realms: realms)
   end
 
-  def create(conn, %{"data" => realm_params}) do
-    with {:ok, %Realm{} = realm} <- Realms.create_realm(realm_params) do
+  def create(conn, %{"data" => realm_params} = params) do
+    async_operation =
+      if Map.get(params, "async_operation") == "false" do
+        false
+      else
+        true
+      end
+
+    with {:ok, %Realm{} = realm} <-
+           Realms.create_realm(realm_params, async_operation: async_operation) do
       conn
       |> put_status(:created)
       |> put_resp_header("location", realm_path(conn, :show, realm))
@@ -51,8 +59,15 @@ defmodule Astarte.Housekeeping.APIWeb.RealmController do
     end
   end
 
-  def delete(conn, %{"id" => id}) do
-    with :ok <- Realms.delete_realm(id) do
+  def delete(conn, %{"id" => id} = params) do
+    async_operation =
+      if Map.get(params, "async_operation") == "false" do
+        false
+      else
+        true
+      end
+
+    with :ok <- Realms.delete_realm(id, async_operation: async_operation) do
       send_resp(conn, :no_content, "")
     end
   end

--- a/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
+++ b/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
@@ -55,13 +55,23 @@ paths:
       summary: Create a realm
       description: >-
         Creates a new realm, based on the provided realm configuration.
-        Realm creation will be executed asynchronously - it is not guaranteed that
-        the requested realm will be available as soon as the API call returns,
-        but it is guaranteed that it will be eventually created if no errors are
-        returned and Astarte is operating normally.
+        Realm creation will be executed asynchronously by default - it is not
+        guaranteed that the requested realm will be available as soon as the
+        API call returns, but it is guaranteed that it will be eventually created
+        if no errors are returned and Astarte is operating normally.
+        You can perform the call synchronously by setting the async_operation query
+        param to false.
       operationId: createRealm
       security:
         - JWT: []
+      parameters:
+        - name: async_operation
+          in: query
+          description: Whether the operation should be carried out asynchronously.
+          required: false
+          schema:
+            type: boolean
+            default: true
       responses:
         '200':
           description: Success
@@ -126,7 +136,12 @@ paths:
         Deletes a realm from Astarte. This feature must be explicitly enabled
         in the cluster, if it's disabled a 405 status code will be returned.
         If there are connected devices present in the realm, a 422 status
-        code will be returned.
+        code will be returned. Realm deletion will be executed asynchronously
+        by default - it is not guaranteed that the realm will be deleted as
+        soon as the API call returns, but it is guaranteed that it will be
+        eventually removed if no errors are returned and Astarte is
+        operating normally. You can perform the call synchronously by setting
+        the async_operation parameter to false.
       operationId: deleteRealm
       security:
         - JWT: []
@@ -137,6 +152,13 @@ paths:
           required: true
           schema:
             type: string
+        - name: async_operation
+          in: query
+          description: Whether the operation should be carried out asynchronously.
+          required: false
+          schema:
+            type: boolean
+            default: true
       responses:
         '204':
           description: Success


### PR DESCRIPTION
Allow user to create/delete realms with synchronous calls using the `async_operation` query param. Default to the current behaviour, i.e. async calls.