### PR TITLE
Realm Management API: add synchronous API for interface operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - [realm_management] Accept `retention` and `expiry` updates when updating the minor version of an
   interface.
-  
+- [astarte_realm_management_api] Allow synchronous requests for interface creation, update
+  and deletion using the `async_operation` option. Default to async calls.
+- [astarte_housekeeping_api] Allow synchronous requests for realm creation and deletion
+  using the `async_operation` option. Default to async calls.
+
 ### Fixed
 - [realm_management] Accept allowed mapping updates in object aggregated interfaces without
   crashing.
@@ -17,10 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - [astarte_housekeeping] Allow to delete a realm only if all its devices are disconnected.
   Realm deletion can still only be enabled with an environment variable (defaults to disabled).
-
-### Added
-- [astarte_housekeeping_api] Allow synchronous requests for realm creation and deletion
-  using the `async_operation` option. Default to async calls.
 
 ## [1.0.1] - 2021-12-17
 ### Added

--- a/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
@@ -140,6 +140,14 @@ defmodule Astarte.RealmManagement.RPC.Handler do
     {:ok, Reply.encode(%Reply{error: false, reply: {:generic_ok_reply, %GenericOkReply{}}})}
   end
 
+  def encode_reply(_call_atom, :ok) do
+    msg = %GenericOkReply{
+      async_operation: false
+    }
+
+    {:ok, Reply.encode(%Reply{error: false, reply: {:generic_ok_reply, msg}})}
+  end
+
   def encode_reply(_call_atom, {:ok, :started}) do
     msg = %GenericOkReply{
       async_operation: true

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
@@ -87,11 +87,11 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
     |> extract_reply()
   end
 
-  def install_interface(realm_name, interface_json) do
+  def install_interface(realm_name, interface_json, opts) do
     %InstallInterface{
       realm_name: realm_name,
       interface_json: interface_json,
-      async_operation: true
+      async_operation: Keyword.get(opts, :async_operation, true)
     }
     |> encode_call(:install_interface)
     |> @rpc_client.rpc_call(@destination)
@@ -99,11 +99,11 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
     |> extract_reply()
   end
 
-  def update_interface(realm_name, interface_json) do
+  def update_interface(realm_name, interface_json, opts) do
     %UpdateInterface{
       realm_name: realm_name,
       interface_json: interface_json,
-      async_operation: true
+      async_operation: Keyword.get(opts, :async_operation, true)
     }
     |> encode_call(:update_interface)
     |> @rpc_client.rpc_call(@destination)
@@ -111,12 +111,12 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
     |> extract_reply()
   end
 
-  def delete_interface(realm_name, interface_name, interface_major_version) do
+  def delete_interface(realm_name, interface_name, interface_major_version, opts) do
     %DeleteInterface{
       realm_name: realm_name,
       interface_name: interface_name,
       interface_major_version: interface_major_version,
-      async_operation: true
+      async_operation: Keyword.get(opts, :async_operation, true)
     }
     |> encode_call(:delete_interface)
     |> @rpc_client.rpc_call(@destination)

--- a/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
+++ b/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
@@ -115,6 +115,7 @@ paths:
           required: false
           schema:
             type: boolean
+            default: true
       responses:
         '201':
           $ref: '#/components/responses/InstallInterface'
@@ -193,6 +194,7 @@ paths:
           required: false
           schema:
             type: boolean
+            default: true
       responses:
         '204':
           description: Success
@@ -248,6 +250,7 @@ paths:
           required: false
           schema:
             type: boolean
+            default: true
       responses:
         '204':
           description: Success

--- a/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
+++ b/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
@@ -102,10 +102,19 @@ paths:
       description: >-
         Install a new interface, or a newer major version for a given interface.
         Validation is performed, and an error is returned if interface cannot be
-        installed. The installation is performed asynchronously.
+        installed. The installation is performed asynchronously by default. You
+        can perform the call synchronously by setting the async_operation query
+        param to false.
       operationId: installInterface
       security:
         - JWT: []
+      parameters:
+        - name: async_operation
+          in: query
+          description: Whether the operation should be carried out asynchronously.
+          required: false
+          schema:
+            type: boolean
       responses:
         '201':
           $ref: '#/components/responses/InstallInterface'
@@ -168,14 +177,22 @@ paths:
       description: >-
         Replace an existing interface with a certain major version with a new
         one (that must have same major version and a higher minor version).
-        Server side validation is performed and the interface upgrade is
-        performed aynchronously. For more information about what is allowed when
-        updating an interface, see [the
+        Server side validation is performed. Interface upgrade is performed
+        asynchronously by default. You can perform the call synchronously by
+        setting the async_operation query param to false. For more information
+        about what is allowed when updating an interface, see [the
         doc](https://docs.astarte-platform.org/1.0/030-interface.html#versioning).
         This operation cannot be reverted.
       operationId: updateInterface
       security:
         - JWT: []
+      parameters:
+        - name: async_operation
+          in: query
+          description: Whether the operation should be carried out asynchronously.
+          required: false
+          schema:
+            type: boolean
       responses:
         '204':
           description: Success
@@ -218,10 +235,19 @@ paths:
       description: >-
         Delete an interface draft (a draft is an interface with major version
         0). An interface with a major version different than 0 should be
-        manually deleted.
+        manually deleted. Interface deletion is performed asynchronously by
+        default. You can perform the call synchronously by setting the
+        async_operation query param to false.
       operationId: deleteInterface
       security:
         - JWT: []
+      parameters:
+        - name: async_operation
+          in: query
+          description: Whether the operation should be carried out asynchronously.
+          required: false
+          schema:
+            type: boolean
       responses:
         '204':
           description: Success


### PR DESCRIPTION
Allow user to create, delete or update interfaces in a synchronous fashion using the `async_operation` query param. Default to the current behaviour, i.e. async calls.