### PR TITLE
OpenAPI: Fix HTTP response code for delete on device interface endpoint

### DIFF
--- a/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml
+++ b/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml
@@ -707,7 +707,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        '204':
           description: Success
         '401':
           description: Realm doesn't exist or operation not allowed.


### PR DESCRIPTION
As you can see no_content [status](https://hexdocs.pm/plug/Plug.Conn.Status.html#code/1-known-status-codes) is returned on successful [delete](https://github.com/astarte-platform/astarte/blob/release-1.0/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_controller.ex#L92)