### PR TITLE
Document the procedure to migrate to the AstarteDefaultIngress

### DIFF
--- a/doc/pages/administrator/020-prerequisites.md
+++ b/doc/pages/administrator/020-prerequisites.md
@@ -30,7 +30,13 @@ $ helm install ingress-nginx ingress-nginx/ingress-nginx -n ingress-nginx \
     --create-namespace
 ```
 
-You don't need to create NGINX ingresses yourself - just the Operator itself is enough.
+Please, be aware that trying to deploy multiple ingress controllers in your cluster may result in all
+of them trying simultaneously to handle the Astarte ingress resource. Consider using ingress classes
+for avoiding confusing situations as outlined
+[here](https://kubernetes.github.io/ingress-nginx/user-guide/multiple-ingress/).
+
+In the end, you won't need to create NGINX ingresses yourself: the Astarte Operator itself will take
+care of this task.
 
 ## Voyager (deprecated)
 

--- a/doc/pages/administrator/064-setup_astartedefaultingress.md
+++ b/doc/pages/administrator/064-setup_astartedefaultingress.md
@@ -10,7 +10,7 @@ related Astarte [issue](https://github.com/astarte-platform/astarte/issues/613) 
 details).
 
 If you want to migrate away from AstarteVoyagerIngress to the new AstarteDefaultIngress, please
-refer to the procedure outlined [here](030-upgrade_100_101.html).
+refer to the procedure outlined [here](066-migrate_to_astartedefaultingress.html).
 
 ## Prerequisites
 

--- a/doc/pages/administrator/066-migrate_to_astartedefaultingress.md
+++ b/doc/pages/administrator/066-migrate_to_astartedefaultingress.md
@@ -1,0 +1,146 @@
+# Migrating to the Astarte Default Ingress
+
+If your Astarte deployment is still being served by the deprecated AstarteVoyagerIngress, it is
+highly advised to move to the new managed ingress, namely, the AstarteDefaultIngress.
+
+The current page focuses on describing the procedure for migrating your ingress with ease, simply
+employing `astartectl`.
+
+Please, make sure you have read the entirety of this page and to understand all the concepts and the
+implications before performing the actual migration.
+
+## Prerequisites and preliminary checks
+
+Before starting with the actual migration procedure, some preliminary activities are required:
+
+- ensure that the version of the Astarte operator in your cluster is at least `>= v1.0.1` and
+  stable. If this requirement is not fulfilled, please refer to the [Upgrade
+  Procedures](000-upgrade_index.html) section;
+
+- the [`ingress-nginx`](https://kubernetes.github.io/ingress-nginx/) ingress controller must be
+  deployed in your cluster (see [this section](020-prerequisites.html#nginx) for the details).
+  Be sure of taking note of the `ingress-class` of the controller which is meant to handle your
+  Astarte ingress. This information will come handy during the migration itself;
+
+- make sure the TLS secrets used to secure the communications to and from Astarte are deployed. For
+  the details, please refer to the [Handling Astarte certificates](050-handling_certificates.html)
+  page;
+
+- ensure that [`astartectl`](https://github.com/astarte-platform/astartectl) is installed on your
+  machine and its version is at least `>= v1.0.0`.
+
+## Performing the migration
+
+Performing the actual ingress migration is as simple as executing an `astartectl` command:
+
+```bash
+$ astartectl cluster instances migrate replace-voyager
+```
+
+The `replace-voyager` command provides meaningful defaults so that, if your Astarte deployment
+relies on standard naming practices, you can simply omit all the flags.
+
+The following list of options is available:
+- `--namespace`: the namespace in which the Astarte instance resides (default: "astarte");
+- `--operator-name`: the name of the Astarte Operator instance (default:
+  "astarte-operator-controller-manager");
+- `--operator-namespace`: the namespace in which the Astarte Operator resides (default:
+  "kube-system");
+- `--ingress-name`: the name of the AstarteVoyagerIngress to be migrated. When not set, the first
+  ingress found in the cluster will be selected.
+
+  To find the AstarteVoyagerIngress resources present in your cluster simply run:
+  ```bash
+  $ kubectl get avi -n <astarte-namespace>
+  ```
+- `--out`: the name of the file in which the AstarteVoyagerIngress custom resource will be saved
+  (optional).
+
+To successfully complete the procedure, you will be prompted to interactively insert details such
+as:
+- the name of the Astarte TLS secrets,
+- the name of the to-be-installed AstarteDefaultIngress resource,
+- the ingress class of the NGINX ingress controller.
+
+Before starting the migration routine, you will be asked to review the generated
+AstarteDefaultIngress custom resource. The migration will start only upon confirmation.
+
+Please, note that you can contextually dump your AstarteVoyagerIngress custom resource for backup
+purposes simply using the `--out <filename>` option.
+
+### What happens under the hood?
+
+When invoking the `replace-voyager` command, `astartectl` interacts with your Astarte cluster and
+retrieves the AstarteVoyagerIngress resource which serves your Astarte instance. If no
+AstarteVoyagerIngresses are present, the procedure is immediately terminated as there is nothing to
+migrate.
+
+After all the required information is provided through the interactive prompt, the
+AstarteDefaultIngress resource is reviewed and the final confirmation is provided, the following
+tasks are performed:
+- the Astarte resource is patched so that TLS termination is handled at the VerneMQ level: in
+particular, the fields `sslListener` and `sslListenerCertSecretName` are populated;
+- the AstarteDefaultIngress resource is installed within your cluster. Once installed, the Astarte
+Operator takes over and ensures that:
+  - a service of kind LoadBalancer is created to serve the Astarte broker,
+  - an ingress resource is created to serve the Astarte APIs (and the Dashboard, if requested).
+
+If one of the previous tasks are not successful, the migration logic is reverted as not to leave
+your cluster in a broken state.
+
+At the end of the procedure, after the AstarteDefaultIngress is successfully created, the old
+AstarteVoyagerIngress resource will be deleted. Anyway, if any errors occur during the deletion of
+the AstarteVoyagerIngress, the migration procedure is not reverted (as the AstarteDefaultIngress
+resource is successfully deployed) and, as such, you are required to explicitly delete the
+AstarteVoyagerIngress resource by hand.
+
+Be aware that Voyager specific annotations cannot be mapped to the AstarteDefaultIngress. If any of
+those annotations are present, the `replace-voyager` command will print a warning message. It will
+be your responsibility confirming whether you want to proceed or abort the procedure.
+
+## Advanced use cases
+
+The current section focuses on some advanced configuration scenarios that might help you in handling
+specific non-standard use cases.
+
+### Preserve the API and Broker IPs
+
+The need of preserving both the API and Broker IPs may arise in specific use cases when, for
+example, there are any number of impediments in updating your DNS zones.
+
+Please, be aware that the following instructions rely on the assumption that you can reserve (or you
+already reserved) external IPs. This task is highly dependent on your cloud service provider and, as
+such, you are required to ensure that it can be performed in your specific case.
+
+If your Astarte instance is exposed to the outer world through the AstarteVoyagerIngress, two
+external IPs are assigned to your services: one for the Broker and another for the Astarte APIs (and
+the dashboard, if deployed).
+
+Before migrating your ingress to the AstarteDefaultIngress, perform the following operations:
+- ensure that both the API and the Broker IPs are reserved,
+- patch your AstarteVoyagerIngress resource such that the `loadBalancerIP` field is set for the
+  broker (if this field is already set, you can skip this step):
+  ```yaml
+  broker:
+    loadBalancerIP: <the-broker-reserved-IP>
+    ...
+  ```
+- install (or update, if already installed) the `ingress-nginx` deployment by explicitly setting the
+  IP for the ingress controller as to make it coincident with the IP assigned to the Astarte APIs.
+  Be aware that, at first, the ingress controller external IP will remain in pending state until the
+  AstarteVoyagerIngress will be deleted and, once that IP will be available, it will be correctly
+  assigned to the ingress controller.
+  ```bash
+  $ helm upgrade --install <ingress-nginx-name> ingress-nginx/ingress-nginx \
+    -n ingress-nginx \
+    --set controller.service.externalTrafficPolicy=Local \
+    --set controller.service.loadBalancerIP=<the-API-reserved-IP>
+  ```
+
+Once the previous instructions are executed, you are ready to perform the migration to the
+AstarteDefaultIngress as described in the [Performing the Migration](#performing-the-migration)
+section.
+
+As a final remark, if you are interested in preserving only one of the external IPs, please refer
+only to the instructions that apply to your needs (e.g.: the broker) while neglecting the remaining
+parts.

--- a/doc/pages/administrator/095-advanced-operations.md
+++ b/doc/pages/administrator/095-advanced-operations.md
@@ -399,7 +399,8 @@ database even when Astarte is deleted from your cluster.
 
 To restore your Astarte instance all you have to do is saving the following resources:
 + Astarte CR;
-+ AstarteVoyagerIngress CR;
++ AstarteVoyagerIngress CR (if deployed);
++ AstarteDefaultIngress CR (if deployed);
 + CA certificate and key;
 
 and, assuming that the name of your Astarte is `astarte` and that it is deployed within the
@@ -407,6 +408,7 @@ and, assuming that the name of your Astarte is `astarte` and that it is deployed
 ```bash
 kubectl get astarte -n astarte -o yaml > astarte-backup.yaml
 kubectl get avi -n astarte -o yaml > avi-backup.yaml
+kubectl get adi -n astarte -o yaml > adi-backup.yaml
 kubectl get secret astarte-devices-ca -n astarte -o yaml > astarte-devices-ca-backup.yaml
 ```
 
@@ -422,10 +424,16 @@ kubectl apply -f astarte-devices-ca-backup.yaml
 kubectl apply -f astarte-backup.yaml
 ```
 
-And when your Astarte resource is ready:
+And when your Astarte resource is ready, to restore your AstarteVoyagerIngress:
 
 ```bash
 kubectl apply -f avi-backup.yaml
+```
+
+while to restore your AstarteDefaultIngress resource:
+
+```bash
+kubectl apply -f adi-backup.yaml
 ```
 
 At the end of this step, your cluster is restored. Please, notice that the external IP of the

--- a/doc/pages/upgrade/030-upgrade_100_10x.md
+++ b/doc/pages/upgrade/030-upgrade_100_10x.md
@@ -159,79 +159,9 @@ The current section describes the procedure for replacing the deprecated `Astart
 with the new `AstarteDefaultIngress`. If the Voyager ingress is not deployed within your cluster,
 feel free to skip this section.
 
-The first step requires the installation of the [NGINX Ingress
-Controller](https://kubernetes.github.io/ingress-nginx/):
+The advised migration path involves the employment of `astartectl`: this is the most straightforward
+way of performing the migration task and, as soon as all the requirements are satisfied, it requires
+the execution of one single command.
 
-```bash
-$ helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-$ helm repo update
-$ helm install ingress-nginx ingress-nginx/ingress-nginx -n ingress-nginx \
-    --set controller.service.externalTrafficPolicy=Local \
-    --create-namespace
-```
-
-Then, the `AstarteDefaultIngress` must be deployed. If your Kubernetes installation supports
-LoadBalancer ingresses (most managed ones do), you should be able to get away with the most standard
-CR:
-
-```yaml
-apiVersion: ingress.astarte-platform.org/v1alpha1
-kind: AstarteDefaultIngress
-metadata:
-  name: adi
-  namespace: astarte
-spec:
-  ### Astarte Default Ingress CRD
-  astarte: astarte
-  tlsSecret: <your-astarte-tls-secret>
-  api:
-    exposeHousekeeping: true
-  dashboard:
-    deploy: true
-    ssl: true
-    host: <your-astarte-dashboard-host>
-  broker:
-    deploy: true
-    serviceType: LoadBalancer
-```
-
-Further details on this topic can be found at [this page](064-setup_astartedefaultingress.html). If
-your certificate is issued by cert-manager after the solution of an HTTP challenge, please refer to
-[this
-section](064-setup_astartedefaultingress.html#how-to-support-automatic-certificate-renewal-for-http-challenges)
-to support the automatic renewal of your certificate.
-
-When the `AstarteDefaultIngress` resource is created, the Operator is responsible for the creation
-of:
-- an NGINX ingress which is devoted to routing requests to both the Astarte API and the Astarte
-  Dashboard;
-- a service of type LoadBalancer that exposes the Astarte broker to the outer world.
-
-As soon as both the ingress and the broker service have an assigned external IP, update your Cloud
-DNS zone record sets with the new external IPs. Assuming that your Astarte and AstarteDefaultIngress
-are named `astarte` and `adi` respectively and that they resides in the `astarte` namespace, you can
-find the external IPs with:
-
-```bash
-$ # retrieve information about the ingress
-$ kubectl get ingress -n astarte
-NAME              CLASS   HOSTS          ADDRESS   PORTS     AGE
-adi-api-ingress   nginx   <your-hosts>   X.Y.W.Z   80, 443   6s
-```
-
-and
-
-```bash
-$ # retrieve information about the broker service
-$ kubectl get service -n astarte adi-broker-service
-NAME                 TYPE           CLUSTER-IP     EXTERNAL-IP   PORT(S)         AGE
-adi-broker-service   LoadBalancer   x.x.x.x        A.B.C.D       443:32149/TCP   17s
-```
-
-At this, point your requests are routed to your Astarte instance through the new
-AstarteDefaultIngress.
-
-The dangling AstarteVoyagerIngress is not needed anymore. To delete the resource simply run:
-```bash
-$ kubectl delete avi -n astarte
-```
+The [Migrating to the AstarteDefaultIngress](066-migrate_to_astartedefaultingress.html) page
+extensively cover this topic.


### PR DESCRIPTION
- Document how to migrate from the deprecated AstarteVoyagerIngress to the new AstarteDefaultIngress;
- Rework the upgrade guide v1.0.0 --> v1.0.x to avoid duplicate information;
- Add the AstarteDefaultIngress resource to the backup and restore procedures.