### PR TITLE
RealmManagement / API: handle gracefully all trigger errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [doc] Administrator Guide: bump cert-manager dependency to v1.7.0.
 - [data_updater_plant] Increase the `declare_exchange` timeout to 60 sec.
 - [data_updater_plant] Increase the `publish` timeout to 60 sec for the AMQPEventsProducer.
+- [astarte_realm_management_api] Do not crash when receiving trigger errors.
+  Fix [683](https://github.com/astarte-platform/astarte/issues/683).
 
 ## [1.0.2] - 2022-04-01
 ### Added

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -736,6 +736,11 @@ defmodule Astarte.RealmManagement.Engine do
           }
         }
       else
+        Logger.warn("Failed to get trigger.",
+          trigger_name: trigger_name,
+          tag: "get_trigger_fail"
+        )
+
         {:error, :cannot_retrieve_simple_trigger}
       end
     end
@@ -765,6 +770,11 @@ defmodule Astarte.RealmManagement.Engine do
       if delete_all_succeeded do
         Queries.delete_trigger(client, trigger_name)
       else
+        Logger.warn("Failed to delete trigger.",
+          trigger_name: trigger_name,
+          tag: "delete_trigger_fail"
+        )
+
         {:error, :cannot_delete_simple_trigger}
       end
     end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/trigger_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/trigger_controller.ex
@@ -44,6 +44,21 @@ defmodule Astarte.RealmManagement.APIWeb.TriggerController do
         |> put_status(:conflict)
         |> render("already_installed_trigger.json")
 
+      {:error, :invalid_datastream_trigger} ->
+        conn
+        |> put_status(:bad_request)
+        |> render("invalid_datastream_trigger.json")
+
+      {:error, :unsupported_trigger_type} ->
+        conn
+        |> put_status(:bad_request)
+        |> render("unsupported_trigger_type.json")
+
+      {:error, :invalid_object_aggregation_trigger} ->
+        conn
+        |> put_status(:bad_request)
+        |> render("invalid_object_aggregation_trigger.json")
+
       # To FallbackController
       {:error, other} ->
         {:error, other}
@@ -53,6 +68,11 @@ defmodule Astarte.RealmManagement.APIWeb.TriggerController do
   def show(conn, %{"realm_name" => realm_name, "id" => id}) do
     with {:ok, trigger} <- Triggers.get_trigger(realm_name, id) do
       render(conn, "show.json", trigger: trigger)
+    else
+      {:error, :cannot_retrieve_simple_trigger} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> render("cannot_retrieve_simple_trigger.json")
     end
   end
 
@@ -72,6 +92,11 @@ defmodule Astarte.RealmManagement.APIWeb.TriggerController do
     with {:ok, %Trigger{} = trigger} <- Triggers.get_trigger(realm_name, id),
          {:ok, %Trigger{}} <- Triggers.delete_trigger(realm_name, trigger) do
       send_resp(conn, :no_content, "")
+    else
+      {:error, :cannot_delete_simple_trigger} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> render("cannot_delete_simple_trigger.json")
     end
   end
 end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/trigger_view.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/trigger_view.ex
@@ -35,6 +35,26 @@ defmodule Astarte.RealmManagement.APIWeb.TriggerView do
     %{errors: %{detail: "Trigger already exists"}}
   end
 
+  def render("invalid_datastream_trigger.json", _assigns) do
+    %{errors: %{detail: "Invalid datastream trigger"}}
+  end
+
+  def render("unsupported_trigger_type.json", _assigns) do
+    %{errors: %{detail: "Unsupported trigger type"}}
+  end
+
+  def render("invalid_object_aggregation_trigger.json", _assigns) do
+    %{errors: %{detail: "Invalid object aggregation trigger"}}
+  end
+
+  def render("cannot_retrieve_simple_trigger.json", _assigns) do
+    %{errors: %{detail: "Could not get trigger"}}
+  end
+
+  def render("cannot_delete_simple_trigger.json", _assigns) do
+    %{errors: %{detail: "Could not delete trigger"}}
+  end
+
   def render("trigger.json", %{trigger: trigger}) do
     %{
       name: trigger.name,

--- a/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
+++ b/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
@@ -295,6 +295,8 @@ paths:
       responses:
         '201':
           $ref: '#/components/responses/InstallTrigger'
+        '400':
+          description: Bad request
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -324,6 +326,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          description: Internal Server Error.
     delete:
       tags:
         - trigger
@@ -344,6 +348,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '500':
+          description: Internal Server Error.
 components:
   responses:
     ConfigValidationError:
@@ -545,6 +551,12 @@ components:
           example:
             errors:
               detail: Interface minor version was not increased
+    InternalServerError:
+      description: Internal Server Error.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GenericError'
   securitySchemes:
     JWT:
       type: apiKey


### PR DESCRIPTION
- RealmManagement API does not crash on trigger errors and produces informative responses
- RealmManagement logs trigger retrieval / deletion errors
Fix #683.