### PR TITLE
AppEngine: return longinteger values as string for some interface combinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - Unreleased
+### Fixed
+- [astarte_appengine_api] Consider `allow_bigintegers` and `allow_safe_bigintegers` params
+  when querying the root of individual datastream / properties interfaces.
+  Fix [#630](https://github.com/astarte-platform/astarte/issues/630).
+
 ## [1.0.2] - 2022-04-01
 ### Added
 - [realm_management] Accept `retention` and `expiry` updates when updating the minor version of an

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -1095,7 +1095,7 @@ defmodule Astarte.AppEngine.API.Device do
                 AstarteValue.to_json_friendly(
                   v,
                   ValueType.from_int(endpoint_row[:value_type]),
-                  allow_bigintegers: true
+                  fetch_biginteger_opts_or_default(opts)
                 )
 
               Map.put(values_map, simplified_path, %{
@@ -1305,7 +1305,7 @@ defmodule Astarte.AppEngine.API.Device do
          endpoint_id,
          endpoint_row,
          path,
-         _opts
+         opts
        ) do
     values =
       Queries.all_properties_for_endpoint!(
@@ -1325,7 +1325,7 @@ defmodule Astarte.AppEngine.API.Device do
             AstarteValue.to_json_friendly(
               row_value,
               ValueType.from_int(endpoint_row[:value_type]),
-              allow_bigintegers: true
+              fetch_biginteger_opts_or_default(opts)
             )
 
           Map.put(values_map, simplified_path, nice_value)
@@ -1719,6 +1719,23 @@ defmodule Astarte.AppEngine.API.Device do
       not_ok ->
         _ = Logger.warn("Database error: #{inspect(not_ok)}.", tag: "db_error")
         {:error, :database_error}
+    end
+  end
+
+  defp fetch_biginteger_opts_or_default(opts) do
+    allow_bigintegers = Map.get(opts, :allow_bigintegers)
+    allow_safe_bigintegers = Map.get(opts, :allow_safe_bigintegers)
+
+    cond do
+      allow_bigintegers ->
+        [allow_bigintegers: allow_bigintegers]
+
+      allow_safe_bigintegers ->
+        [allow_safe_bigintegers: allow_safe_bigintegers]
+
+      # Default allow_bigintegers to true in order to not break the existing API
+      true ->
+        [allow_bigintegers: true]
     end
   end
 end


### PR DESCRIPTION
Take into account the `allow_bigintegers` and `allow_safe_bigintegers` options when querying the root of individual datastream or properties interfaces. Keep the behaviour as default in order not to break the API.
Close #630 .