### PR TITLE
Doc: bump cert-manager version to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   when querying the root of individual datastream / properties interfaces.
   Fix [#630](https://github.com/astarte-platform/astarte/issues/630).
 
+### Changed
+- [doc] Administrator Guide: bump cert-manager dependency to v1.7.0.
+
 ## [1.0.2] - 2022-04-01
 ### Added
 - [realm_management] Accept `retention` and `expiry` updates when updating the minor version of an

--- a/doc/pages/administrator/020-prerequisites.md
+++ b/doc/pages/administrator/020-prerequisites.md
@@ -49,8 +49,9 @@ default configuration (installed in namespace `cert-manager` as `cert-manager`).
 `cert-manager` in your cluster already you don't need to take any action - otherwise, you will need
 to install it.
 
-Astarte is actively tested with `cert-manager` 1.1, but should work with any 1.0+ releases of
-`cert-manager`.
+Astarte is actively tested with `cert-manager` 1.7, but should work with any 1.0+ releases of
+`cert-manager`. If your `cert-manager` release is outdated, please consider upgrading to a newer
+version according to [this guide](https://cert-manager.io/docs/installation/upgrading/).
 
 [`cert-manager` documentation](https://cert-manager.io/docs/installation/) details all needed steps
 to have a working instance on your cluster - however, in case you won't be using `cert-manager` for
@@ -64,11 +65,11 @@ $ kubectl create namespace cert-manager
 $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.1.0 \
+  --version v1.7.0 \
   --set installCRDs=true
 ```
 
-This will install `cert-manager` 1.1.0 and its CRDs in the cluster.
+This will install `cert-manager` 1.7.0 and its CRDs in the cluster.
 
 ## External Cassandra / Scylla
 

--- a/doc/pages/administrator/050-handling_certificates.md
+++ b/doc/pages/administrator/050-handling_certificates.md
@@ -40,7 +40,7 @@ $ kubectl create namespace cert-manager
 $ helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.1.0 \
+  --version v1.7.0 \
   --set installCRDs=true
 ```
 - install NGINX ingress controller:

--- a/doc/pages/upgrade/020-upgrade_011_10.md
+++ b/doc/pages/upgrade/020-upgrade_011_10.md
@@ -68,7 +68,7 @@ kubectl create namespace cert-manager
 helm install \
   cert-manager jetstack/cert-manager \
   --namespace cert-manager \
-  --version v1.1.0 \
+  --version v1.7.0 \
   --set installCRDs=true
 ```
 


### PR DESCRIPTION
cert-manager 1.1.0 is quite old and is not supported anymore on k8s 1.22+. Thus, bump the dependency for Astarte.