### PR TITLE
AppEngine: do not crash on some malformed POST/PUT requests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Consider `allow_bigintegers` and `allow_safe_bigintegers` params
   when querying the root of individual datastream / properties interfaces.
   Fix [#630](https://github.com/astarte-platform/astarte/issues/630).
+- [astarte_appengine_api] Correctly return 405 "Cannot write to device owned resource" when
+  POSTing on device-owned interfaces. Fix [#264](https://github.com/astarte-platform/astarte/issues/264).
 
 ### Changed
 - [doc] Administrator Guide: bump cert-manager dependency to v1.7.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Fix [#630](https://github.com/astarte-platform/astarte/issues/630).
 - [astarte_appengine_api] Correctly return 405 "Cannot write to device owned resource" when
   POSTing on device-owned interfaces. Fix [#264](https://github.com/astarte-platform/astarte/issues/264).
+- [astarte_appengine_api] Correctly return 405 "Cannot write to read-only resource" when
+  POSTing on incomplete paths of server-owned interfaces.
 
 ### Changed
 - [doc] Administrator Guide: bump cert-manager dependency to v1.7.0.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
@@ -125,9 +125,9 @@ defmodule Astarte.AppEngine.APIWeb.FallbackController do
 
   def call(conn, {:error, :read_only_resource}) do
     conn
-    |> put_status(:forbidden)
+    |> put_status(:method_not_allowed)
     |> put_view(Astarte.AppEngine.APIWeb.ErrorView)
-    |> render(:"403_read_only_resource.json")
+    |> render(:"405_read_only_resource")
   end
 
   def call(conn, {:error, :unauthorized}) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
@@ -34,9 +34,9 @@ defmodule Astarte.AppEngine.APIWeb.FallbackController do
 
   def call(conn, {:error, :cannot_write_to_device_owned}) do
     conn
-    |> put_status(:forbidden)
+    |> put_status(:method_not_allowed)
     |> put_view(Astarte.AppEngine.APIWeb.ErrorView)
-    |> render(:"403_cannot_write_to_device_owned.json")
+    |> render(:"405_cannot_write_to_device_owned")
   end
 
   def call(conn, {:error, :device_not_found}) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
@@ -34,7 +34,7 @@ defmodule Astarte.AppEngine.APIWeb.ErrorView do
     %{errors: %{detail: "Cannot write to device owned resource"}}
   end
 
-  def render("403_read_only_resource.json", _assigns) do
+  def render("405_read_only_resource.json", _assigns) do
     %{errors: %{detail: "Cannot write to read-only resource"}}
   end
 

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
@@ -30,7 +30,7 @@ defmodule Astarte.AppEngine.APIWeb.ErrorView do
     %{errors: %{detail: "Value size exceeds size limits"}}
   end
 
-  def render("403_cannot_write_to_device_owned.json", _assigns) do
+  def render("405_cannot_write_to_device_owned.json", _assigns) do
     %{errors: %{detail: "Cannot write to device owned resource"}}
   end
 

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/views/error_view_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/views/error_view_test.exs
@@ -31,8 +31,8 @@ defmodule Astarte.AppEngine.APIWeb.ErrorViewTest do
              %{errors: %{detail: "Cannot write to device owned resource"}}
   end
 
-  test "renders 403_read_only_resource.json" do
-    assert render(Astarte.AppEngine.APIWeb.ErrorView, "403_read_only_resource.json", []) ==
+  test "renders 405_read_only_resource.json" do
+    assert render(Astarte.AppEngine.APIWeb.ErrorView, "405_read_only_resource.json", []) ==
              %{errors: %{detail: "Cannot write to read-only resource"}}
   end
 

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/views/error_view_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/views/error_view_test.exs
@@ -26,8 +26,8 @@ defmodule Astarte.AppEngine.APIWeb.ErrorViewTest do
              %{errors: %{detail: "Bad request"}}
   end
 
-  test "renders 403_cannot_write_to_device_owned.json" do
-    assert render(Astarte.AppEngine.APIWeb.ErrorView, "403_cannot_write_to_device_owned.json", []) ==
+  test "renders 405_cannot_write_to_device_owned.json" do
+    assert render(Astarte.AppEngine.APIWeb.ErrorView, "405_cannot_write_to_device_owned.json", []) ==
              %{errors: %{detail: "Cannot write to device owned resource"}}
   end
 


### PR DESCRIPTION
Instead of failing, return a 405 Method Not Allowed error if:
- A client tries to publish data on a device-owned interface;
- A client tries to publish data on an incomplete path of a server-owned interface.

Close #264 .