### PR TITLE
Data Updater Plant: increase timeout for declare_exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - [doc] Administrator Guide: bump cert-manager dependency to v1.7.0.
+- [data_updater_plant] Increase the `declare_exchange` timeout to 60 sec.
 
 ## [1.0.2] - 2022-04-01
 ### Added

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_events_producer.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_events_producer.ex
@@ -39,7 +39,8 @@ defmodule Astarte.DataUpdaterPlant.AMQPEventsProducer do
   end
 
   def declare_exchange(exchange) do
-    GenServer.call(__MODULE__, {:declare_exchange, exchange})
+    # Use a longer timeout to allow RabbitMQ to process requests even if loaded
+    GenServer.call(__MODULE__, {:declare_exchange, exchange}, 60_000)
   end
 
   # Server callbacks


### PR DESCRIPTION
Under heavy loads, the declare exchange call might fail because of the low value of the default timeout. Thus, increase that value to 60 seconds.