### PR TITLE
Data Updater Plant: increase timeout for AMQPEventsProducer publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - [doc] Administrator Guide: bump cert-manager dependency to v1.7.0.
 - [data_updater_plant] Increase the `declare_exchange` timeout to 60 sec.
+- [data_updater_plant] Increase the `publish` timeout to 60 sec for the AMQPEventsProducer.
 
 ## [1.0.2] - 2022-04-01
 ### Added

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_events_producer.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_events_producer.ex
@@ -35,7 +35,8 @@ defmodule Astarte.DataUpdaterPlant.AMQPEventsProducer do
   end
 
   def publish(exchange, routing_key, payload, opts) do
-    GenServer.call(__MODULE__, {:publish, exchange, routing_key, payload, opts})
+    # Use a longer timeout to allow RabbitMQ to process requests even if loaded
+    GenServer.call(__MODULE__, {:publish, exchange, routing_key, payload, opts}, 60_000)
   end
 
   def declare_exchange(exchange) do


### PR DESCRIPTION
Under heavy loads, the publish call might fail because of the low value of the default timeout. Thus, increase that value to 60 seconds.