### PR TITLE
E2E: group emails in the same thread and let user set the email subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [data_updater_plant] Increase the `publish` timeout to 60 sec for the AMQPEventsProducer.
 - [astarte_realm_management_api] Do not crash when receiving trigger errors.
   Fix [683](https://github.com/astarte-platform/astarte/issues/683).
+- [astarte_e2e] Allow setting custom subjects for alerting emails.
+- [astarte_e2e] Group in a single thread emails referencing the same failure_id.
 
 ## [1.0.2] - 2022-04-01
 ### Added

--- a/tools/astarte_e2e/lib/astarte_e2e/application.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/application.ex
@@ -31,7 +31,7 @@ defmodule AstarteE2E.Application do
       children = [
         {Registry, keys: :unique, name: Registry.AstarteE2E},
         AstarteE2EWeb.Telemetry,
-        ServiceNotifier,
+        {ServiceNotifier, Config.notifier_opts()},
         {Device, Config.device_opts()},
         {Client, Config.client_opts()},
         {Scheduler, Config.scheduler_opts()}

--- a/tools/astarte_e2e/lib/astarte_e2e/config.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/config.ex
@@ -41,9 +41,13 @@ defmodule AstarteE2E.Config do
           | {:realm, String.t()}
           | {:device_id, Device.encoded_device_id()}
 
+  @type notifier_option ::
+          {:mail_subject, String.t()}
+
   @type client_options :: [client_option()]
   @type device_options :: Astarte.Device.device_options()
   @type scheduler_options :: [scheduler_option()]
+  @type notifier_options :: [notifier_option()]
 
   @envdoc "Astarte Pairing URL (e.g. https://api.astarte.example.com/pairing)."
   app_env :pairing_url, :astarte_e2e, :pairing_url,
@@ -135,6 +139,12 @@ defmodule AstarteE2E.Config do
     type: NormalizedMailAddress,
     default: ""
 
+  @envdoc "The subject of the notification email."
+  app_env :mail_subject, :astarte_e2e, :mail_subject,
+    os_env: "E2E_MAIL_SUBJECT",
+    type: :binary,
+    required: true
+
   @envdoc """
   The mail service's API key. This env var must be set and valid to use the mail
   service.
@@ -225,6 +235,11 @@ defmodule AstarteE2E.Config do
       realm: realm!(),
       device_id: device_id!()
     ]
+  end
+
+  @spec notifier_opts() :: notifier_options()
+  def notifier_opts do
+    [mail_subject: mail_subject!()]
   end
 
   def service_notifier_config do

--- a/tools/astarte_e2e/lib/astarte_e2e/service_notifier/email.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/service_notifier/email.ex
@@ -21,7 +21,7 @@ defmodule AstarteE2E.ServiceNotifier.Email do
 
   alias AstarteE2E.Config
 
-  def service_down_email(reason, failure_id) do
+  def service_down_email(reason, failure_id, mail_subject) do
     text = """
     AstarteE2E detected a service malfunction at #{current_timestamp()}.
 
@@ -31,20 +31,28 @@ defmodule AstarteE2E.ServiceNotifier.Email do
     Please take actions to prevent further issues.
     """
 
+    msg_id = "<#{failure_id}@astarte-monitoring.cloud>"
+
     base_email()
-    |> subject("Astarte Warning! Service is down")
+    |> subject(mail_subject)
+    |> put_header("Message-ID", msg_id)
     |> text_body(text)
   end
 
-  def service_up_email(failure_id) do
+  def service_up_email(failure_id, mail_subject) do
     text = """
     AstarteE2E service is back to its normal state at #{current_timestamp()}.
 
     Linked FailureId: #{failure_id}
     """
 
+    msg_id = "<#{failure_id}@astarte-monitoring.cloud>"
+
     base_email()
-    |> subject("Astarte: service back to its normal state.")
+    |> subject(mail_subject)
+    |> put_header("Message-ID", msg_id)
+    |> put_header("In-Reply-To", msg_id)
+    |> put_header("References", msg_id)
     |> text_body(text)
   end
 


### PR DESCRIPTION
- add headers to the alerting emails so that they are grouped in the same thread when referencing the same `failure_id`,
- make the mail subject configurable thanks to the `E2E_MAIL_SUBJECT` env variable.
