### PR TITLE
DUP: better logs on receving unexpected object key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_e2e] Group in a single thread emails referencing the same failure_id.
 - [astarte_appengine_api] Make property unset succeed independently of whether there exist a device
   session on the broker or not. Fix [#640](https://github.com/astarte-platform/astarte/issues/640).
+- [astarte_data_updater_plant] Log the base64-encoded object when receiving an object
+  with unexpected key.
 
 ## [1.0.2] - 2022-04-01
 ### Added

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -802,7 +802,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
         update_stats(new_state, interface, nil, path, payload)
 
       {:error, :unexpected_object_key} ->
-        Logger.warn("Object has unexpected key: #{inspect(payload)} sent to #{interface}#{path}.",
+        base64_payload = Base.encode64(payload)
+
+        Logger.warn(
+          "Received object with unexpected key, object base64 is: #{base64_payload} sent to #{
+            interface
+          }#{path}.",
           tag: "unexpected_object_key"
         )
 
@@ -814,8 +819,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           %{},
           %{realm: new_state.realm}
         )
-
-        base64_payload = Base.encode64(payload)
 
         error_metadata = %{
           "interface" => inspect(interface),


### PR DESCRIPTION
Log the base64-encoded payload instead of the Elixir binary representation.
