### PR TITLE
Add `docker-compose pull` before `docker-compose up` in guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Can't be easier. Pick your favorite machine with at least 4GB of free RAM, make 
 ```sh
 $ git clone https://github.com/astarte-platform/astarte.git -b v1.0.3 && cd astarte
 $ docker run -v $(pwd)/compose:/compose astarte/docker-compose-initializer:1.0.3
+$ docker-compose pull
 $ docker-compose up -d
 ```
 

--- a/doc/pages/tutorials/010-astarte_in_5_minutes.md
+++ b/doc/pages/tutorials/010-astarte_in_5_minutes.md
@@ -62,6 +62,7 @@ To get our Astarte instance running as fast as possible, we will install Astarte
 ```sh
 $ git clone https://github.com/astarte-platform/astarte.git -b v1.0.3 && cd astarte
 $ docker run -v $(pwd)/compose:/compose astarte/docker-compose-initializer:1.0.3
+$ docker-compose pull
 $ docker-compose up -d
 ```
 


### PR DESCRIPTION
Issuing `docker-compose up` will build images locally by default. That's
not what users usually want to do, so add `docker-compose pull` in
guides to make sure that prebuilt images are used.

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
