### PR TITLE
Support introspection triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [astarte_data_updater_plant] Add support for device introspection triggers.
+- [astarte_realm_management] Add support for device introspection triggers.
+- [astarte_realm_management_api] Add support for device introspection triggers.
 
 ## [1.0.3] - 2022-07-04
 ### Fixed

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/event_type_utils.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/event_type_utils.ex
@@ -40,22 +40,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.EventTypeUtils do
     end
   end
 
-  def pretty_change_type(change_type) do
-    case change_type do
-      :INCOMING_INTROSPECTION ->
-        :on_incoming_introspection
-
-      :INTERFACE_ADDED ->
-        :on_interface_added
-
-      :INTERFACE_REMOVED ->
-        :on_interface_removed
-
-      :INTERFACE_MINOR_UPDATED ->
-        :on_interface_minor_updated
-    end
-  end
-
   def pretty_device_event_type(device_event_type) do
     case device_event_type do
       :DEVICE_CONNECTED ->
@@ -69,6 +53,18 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.EventTypeUtils do
 
       :DEVICE_ERROR ->
         :on_device_error
+
+      :INCOMING_INTROSPECTION ->
+        :on_incoming_introspection
+
+      :INTERFACE_ADDED ->
+        :on_interface_added
+
+      :INTERFACE_REMOVED ->
+        :on_interface_removed
+
+      :INTERFACE_MINOR_UPDATED ->
+        :on_interface_minor_updated
     end
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -26,6 +26,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.Core.Triggers.DataTrigger
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.DataTrigger, as: ProtobufDataTrigger
+  alias Astarte.Core.Triggers.SimpleTriggersProtobuf.DeviceTrigger, as: ProtobufDeviceTrigger
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.Utils, as: SimpleTriggersProtobufUtils
   alias Astarte.DataAccess.Data
   alias Astarte.DataAccess.Database
@@ -66,7 +67,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       device_triggers: %{},
       data_triggers: %{},
       volatile_triggers: [],
-      introspection_triggers: %{},
       interface_exchanged_bytes: %{},
       interface_exchanged_msgs: %{},
       last_seen_message: 0,
@@ -1078,14 +1078,14 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
     any_interface_id = SimpleTriggersProtobufUtils.any_interface_object_id()
 
-    %{introspection_triggers: introspection_triggers} =
+    %{device_triggers: device_triggers} =
       populate_triggers_for_object!(new_state, db_client, any_interface_id, :any_interface)
 
     realm = new_state.realm
     device_id_string = Device.encode_device_id(new_state.device_id)
 
     on_introspection_targets =
-      Map.get(introspection_triggers, {:on_incoming_introspection, :any_interface}, [])
+      Map.get(device_triggers, {:on_incoming_introspection, :any_interface}, [])
 
     TriggersHandler.incoming_introspection(
       on_introspection_targets,
@@ -1129,8 +1129,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
             minor = Map.get(db_introspection_minor_map, interface_name)
 
+            # TODO: move away from :any_interface, I guess
             interface_added_targets =
-              Map.get(introspection_triggers, {:on_interface_added, :any_interface}, [])
+              Map.get(device_triggers, {:on_interface_added, :any_interface}, [])
 
             TriggersHandler.interface_added(
               interface_added_targets,
@@ -1159,8 +1160,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
                 :ok
               end
 
+            # TODO: move away from :any_interface, I guess
             interface_removed_targets =
-              Map.get(introspection_triggers, {:on_interface_deleted, :any_interface}, [])
+              Map.get(device_triggers, {:on_interface_deleted, :any_interface}, [])
 
             TriggersHandler.interface_removed(
               interface_removed_targets,
@@ -1495,9 +1497,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
               {{:error, reason}, state}
           end
 
-        {:introspection_trigger, _} ->
-          {:ok, new_state}
-
         {:device_trigger, _} ->
           {:ok, load_trigger(new_state, trigger, target)}
       end
@@ -1609,30 +1608,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     updated_device_triggers = Map.put(device_triggers, event_type, updated_targets_list)
 
     {:ok, %{state | device_triggers: updated_device_triggers}}
-  end
-
-  defp delete_volatile_trigger(
-         state,
-         {_obj_id, _obj_type},
-         {{:introspection_trigger, proto_buf_introspection_trigger}, trigger_target}
-       ) do
-    introspection_triggers = state.introspection_triggers
-
-    event_type = EventTypeUtils.pretty_change_type(proto_buf_introspection_trigger.change_type)
-
-    introspection_trigger_key =
-      {event_type, proto_buf_introspection_trigger.match_interface || :any_interface}
-
-    updated_targets_list =
-      Map.get(introspection_triggers, introspection_trigger_key, [])
-      |> Enum.reject(fn target ->
-        target == trigger_target
-      end)
-
-    updated_introspection_triggers =
-      Map.put(introspection_triggers, introspection_trigger_key, updated_targets_list)
-
-    {:ok, %{state | introspection_triggers: updated_introspection_triggers}}
   end
 
   defp reload_groups_on_expiry(state, timestamp, db_client) do
@@ -2161,48 +2136,51 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   # TODO: implement on_incoming_introspection, on_interface_minor_updated
-  defp load_trigger(
-         state,
-         {:introspection_trigger, proto_buf_introspection_trigger},
-         trigger_target
-       ) do
-    introspection_triggers = state.introspection_triggers
-
-    event_type = EventTypeUtils.pretty_change_type(proto_buf_introspection_trigger.change_type)
-
-    introspection_trigger_key =
-      {event_type, proto_buf_introspection_trigger.match_interface || :any_interface}
-
-    existing_trigger_targets = Map.get(introspection_triggers, introspection_trigger_key, [])
-
-    new_targets = [trigger_target | existing_trigger_targets]
-
-    next_introspection_triggers =
-      Map.put(introspection_triggers, introspection_trigger_key, new_targets)
-
-    # Register the new target
-    :ok = TriggersHandler.register_target(trigger_target)
-
-    Map.put(state, :introspection_triggers, next_introspection_triggers)
-  end
-
   # TODO: implement on_empty_cache_received
   defp load_trigger(state, {:device_trigger, proto_buf_device_trigger}, trigger_target) do
     device_triggers = state.device_triggers
 
+    # device event type is one of
+    # :on_device_connected, :on_device_disconnected, :on_device_empty_cache_received, :on_device_error,
+    # :on_incoming_introspection, :on_interface_added, :on_interface_removed, :on_interface_minor_updated
     event_type =
       EventTypeUtils.pretty_device_event_type(proto_buf_device_trigger.device_event_type)
 
-    existing_trigger_targets = Map.get(device_triggers, event_type, [])
+    # introspection triggers have a pair as key, device ones do not
+    # TODO make a beautiful function
+    trigger_key =
+      case event_type do
+        :on_incoming_introspection ->
+          {event_type, introspection_trigger_interface(proto_buf_device_trigger)}
+
+        :on_interface_added ->
+          {event_type, introspection_trigger_interface(proto_buf_device_trigger)}
+
+        :on_interface_removed ->
+          {event_type, introspection_trigger_interface(proto_buf_device_trigger)}
+
+        :on_interface_minor_updated ->
+          {event_type, introspection_trigger_interface(proto_buf_device_trigger)}
+
+        _ ->
+          event_type
+      end
+
+    existing_trigger_targets = Map.get(device_triggers, trigger_key, [])
 
     new_targets = [trigger_target | existing_trigger_targets]
 
     # Register the new target
     :ok = TriggersHandler.register_target(trigger_target)
 
-    next_device_triggers = Map.put(device_triggers, event_type, new_targets)
+    next_device_triggers = Map.put(device_triggers, trigger_key, new_targets)
     Map.put(state, :device_triggers, next_device_triggers)
   end
+
+  # TODO
+  # defp introspection_tigger_interface(%ProtobufDeviceTrigger{match_interface: interface}),
+  #   do: interface
+  defp introspection_trigger_interface(%ProtobufDeviceTrigger{}), do: :any_interface
 
   defp resolve_path(path, interface_descriptor, mappings) do
     case interface_descriptor.aggregation do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -1084,8 +1084,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     realm = new_state.realm
     device_id_string = Device.encode_device_id(new_state.device_id)
 
-    on_introspection_targets =
-      Map.get(device_triggers, {:on_incoming_introspection, :any_interface}, [])
+    on_introspection_targets = Map.get(device_triggers, :on_incoming_introspection, [])
 
     TriggersHandler.incoming_introspection(
       on_introspection_targets,
@@ -1130,7 +1129,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
             minor = Map.get(db_introspection_minor_map, interface_name)
 
             interface_added_targets =
-              Map.get(device_triggers, {:on_interface_added, interface_name}, [])
+              Map.get(
+                device_triggers,
+                {:on_interface_added, CQLUtils.interface_id(interface_name, interface_major)},
+                []
+              ) ++
+                Map.get(device_triggers, {:on_interface_added, :any_interface}, [])
 
             TriggersHandler.interface_added(
               interface_added_targets,
@@ -1160,7 +1164,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
               end
 
             interface_removed_targets =
-              Map.get(device_triggers, {:on_interface_removed, interface_name}, [])
+              Map.get(
+                device_triggers,
+                {:on_interface_removed, CQLUtils.interface_id(interface_name, interface_major)},
+                []
+              ) ++
+                Map.get(device_triggers, {:on_interface_removed, :any_interface}, [])
 
             TriggersHandler.interface_removed(
               interface_removed_targets,
@@ -1207,32 +1216,16 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     :ok = Queries.add_old_interfaces(db_client, new_state.device_id, old_introspection)
     :ok = Queries.remove_old_interfaces(db_client, new_state.device_id, readded_introspection)
 
-    interface_minor_updated_map =
-      Enum.map(old_minors, fn {iface, old_minor} ->
-        old_major = Map.fetch!(state.introspection, iface)
-        {iface, old_major, old_minor}
-      end)
-      |> Enum.filter(fn {iface, old_major, _old_minor} ->
-        Enum.member?(db_introspection_map, {iface, old_major})
-      end)
-      |> Enum.reduce(%{}, fn {iface, old_major, old_minor}, acc ->
-        new_minor = Map.get(db_introspection_minor_map, iface)
+    # Deliver interface_minor_updated triggers if needed
+    for {interface_name, old_minor} <- old_minors,
+        interface_major = Map.fetch!(state.introspection, interface_name),
+        Map.get(db_introspection_map, interface_name) == interface_major,
+        new_minor = Map.get(db_introspection_minor_map, interface_name),
+        new_minor != old_minor do
+      interface_id = CQLUtils.interface_id(interface_name, interface_major)
 
-        if new_minor > old_minor do
-          Map.put(acc, {iface, old_major}, {old_minor, new_minor})
-        else
-          acc
-        end
-      end)
-
-    Enum.each(interface_minor_updated_map, fn {{interface_name, interface_major},
-                                               {old_minor, new_minor}} ->
-      interface_minor_update_targets =
-        Map.get(device_triggers, {:on_interface_minor_updated, interface_name}, []) ++
-          Map.get(device_triggers, {:on_interface_minor_updated, :any_interface}, [])
-
-      TriggersHandler.interface_minor_updated(
-        interface_minor_update_targets,
+      Map.get(device_triggers, {:on_interface_minor_updated, interface_id}, [])
+      |> TriggersHandler.interface_minor_updated(
         realm,
         device_id_string,
         interface_name,
@@ -1241,7 +1234,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
         new_minor,
         timestamp_ms
       )
-    end)
+    end
 
     # Removed/updated interfaces must be purged away, otherwise data will be written using old
     # interface_id.
@@ -2178,7 +2171,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       EventTypeUtils.pretty_device_event_type(proto_buf_device_trigger.device_event_type)
 
     # introspection triggers have a pair as key, standard device ones do not
-    trigger_key = compute_device_trigger_key(event_type, proto_buf_device_trigger)
+    trigger_key = device_trigger_to_key(event_type, proto_buf_device_trigger)
 
     existing_trigger_targets = Map.get(device_triggers, trigger_key, [])
 
@@ -2188,14 +2181,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     :ok = TriggersHandler.register_target(trigger_target)
 
     next_device_triggers = Map.put(device_triggers, trigger_key, new_targets)
+
     Map.put(state, :device_triggers, next_device_triggers)
   end
 
-  defp compute_device_trigger_key(event_type, proto_buf_device_trigger) do
+  defp device_trigger_to_key(event_type, proto_buf_device_trigger) do
     case event_type do
-      :on_incoming_introspection ->
-        {event_type, introspection_trigger_interface(proto_buf_device_trigger)}
-
       :on_interface_added ->
         {event_type, introspection_trigger_interface(proto_buf_device_trigger)}
 
@@ -2205,17 +2196,18 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       :on_interface_minor_updated ->
         {event_type, introspection_trigger_interface(proto_buf_device_trigger)}
 
+      # other device triggers do not care about interfaces
       _ ->
         event_type
     end
   end
 
-  defp introspection_trigger_interface(%ProtobufDeviceTrigger{match_interface: interface})
-       when interface != nil do
-    interface
+  defp introspection_trigger_interface(%ProtobufDeviceTrigger{
+         interface_name: interface_name,
+         interface_major: interface_major
+       }) do
+    SimpleTriggersProtobufUtils.get_interface_id_or_any(interface_name, interface_major)
   end
-
-  defp introspection_trigger_interface(%ProtobufDeviceTrigger{}), do: :any_interface
 
   defp resolve_path(path, interface_descriptor, mappings) do
     case interface_descriptor.aggregation do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
@@ -130,6 +130,7 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
   end
 
   def incoming_introspection(target, realm, device_id, introspection, timestamp) do
+    # TODO check that introspection is a string here
     %IncomingIntrospectionEvent{introspection: introspection}
     |> make_simple_event(
       :incoming_introspection_event,

--- a/apps/astarte_data_updater_plant/mix.lock
+++ b/apps/astarte_data_updater_plant/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "2.1.1", "ad8dec713ba885afffffcb81feb619fe7cfcbcabe9377ab65ab7a110bd4f43a0", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "b6d926770e4508e30e3e9e476c57b6c8aeda44f7715663bdc38935620ce5be6f"},
   "amqp_client": {:hex, :amqp_client, "3.8.14", "7569517aefb47e0d1c41bca2f4768dc8a2d88487daf7819fecca0d78943f293c", [:make, :rebar3], [{:rabbit_common, "3.8.14", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "e5ba3ac18abbe34a1d990a6bcac25633dc7061ab8f8d101c7dcff97f49f4c523"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "8f3f53c392bc886885af830e6dcabcb9a57b1130", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "150d0ce3045a890eb5df421e3288d2a1574bd1fb", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "bf5f5958420a5c1cd99258b4b6a9c18e6335d4ce", []},
   "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "29d26a272da9c4f67c62b5200a5a7e133655dd31", []},
   "castore": {:hex, :castore, "0.1.16", "2675f717adc700475345c5512c381ef9273eb5df26bdd3f8c13e2636cf4cc175", [:mix], [], "hexpm", "28ed2c43d83b5c25d35c51bc0abf229ac51359c170cba76171a462ced2e4b651"},

--- a/apps/astarte_realm_management/mix.lock
+++ b/apps/astarte_realm_management/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "2.1.1", "ad8dec713ba885afffffcb81feb619fe7cfcbcabe9377ab65ab7a110bd4f43a0", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "b6d926770e4508e30e3e9e476c57b6c8aeda44f7715663bdc38935620ce5be6f"},
   "amqp_client": {:hex, :amqp_client, "3.8.14", "7569517aefb47e0d1c41bca2f4768dc8a2d88487daf7819fecca0d78943f293c", [:make, :rebar3], [{:rabbit_common, "3.8.14", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "e5ba3ac18abbe34a1d990a6bcac25633dc7061ab8f8d101c7dcff97f49f4c523"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "8f3f53c392bc886885af830e6dcabcb9a57b1130", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "150d0ce3045a890eb5df421e3288d2a1574bd1fb", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "bf5f5958420a5c1cd99258b4b6a9c18e6335d4ce", []},
   "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "29d26a272da9c4f67c62b5200a5a7e133655dd31", []},
   "castore": {:hex, :castore, "0.1.16", "2675f717adc700475345c5512c381ef9273eb5df26bdd3f8c13e2636cf4cc175", [:mix], [], "hexpm", "28ed2c43d83b5c25d35c51bc0abf229ac51359c170cba76171a462ced2e4b651"},

--- a/apps/astarte_realm_management_api/mix.lock
+++ b/apps/astarte_realm_management_api/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "2.1.1", "ad8dec713ba885afffffcb81feb619fe7cfcbcabe9377ab65ab7a110bd4f43a0", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "b6d926770e4508e30e3e9e476c57b6c8aeda44f7715663bdc38935620ce5be6f"},
   "amqp_client": {:hex, :amqp_client, "3.8.14", "7569517aefb47e0d1c41bca2f4768dc8a2d88487daf7819fecca0d78943f293c", [:make, :rebar3], [{:rabbit_common, "3.8.14", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "e5ba3ac18abbe34a1d990a6bcac25633dc7061ab8f8d101c7dcff97f49f4c523"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "8f3f53c392bc886885af830e6dcabcb9a57b1130", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "150d0ce3045a890eb5df421e3288d2a1574bd1fb", []},
   "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "29d26a272da9c4f67c62b5200a5a7e133655dd31", []},
   "castore": {:hex, :castore, "0.1.16", "2675f717adc700475345c5512c381ef9273eb5df26bdd3f8c13e2636cf4cc175", [:mix], [], "hexpm", "28ed2c43d83b5c25d35c51bc0abf229ac51359c170cba76171a462ced2e4b651"},
   "certifi": {:hex, :certifi, "2.6.1", "dbab8e5e155a0763eea978c913ca280a6b544bfa115633fa20249c3d396d9493", [:rebar3], [], "hexpm", "524c97b4991b3849dd5c17a631223896272c6b0af446778ba4675a1dff53bb7e"},


### PR DESCRIPTION
Allow to create device triggers which refer to device introspection, such as:
- incoming introspection, when device introspection is received, e.g.
```json
{
  "name": "incoming_introspection_trigger",
  "action": {
    "http_url": "https://4yagof76fkbopbuc.mfpb.in",
    "http_method": "post"
  },
  "simple_triggers": [
    {
      "type": "device_trigger",
      "on": "incoming_introspection",
      "device_id": "HEbrzh3hSx2k_NfgyK24yw"
    }
  ]
}
```
- interface added, when a new interface is added to introspection;
- interface minor updated, when an interface gets a minor bump, e.g.
```json
{
    "name": "interface_minor_updated_trigger",
    "action": {
        "http_url": "https://mkupllkgyacgjnal.mfpb.in",
        "http_method": "post"
    },
    "simple_triggers": [
        {
            "type": "device_trigger",
            "on": "interface_minor_updated",
            "interface_name": "org.astarte-platform.genericsensors.Values",
            "interface_major": 1,
            "device_id": "*"
        }
    ]
}
```
- interface removed, when an interface is deleted from introspection.

While incoming introspection triggers cannot be restricted to a single interface, both interface added ones and interface removed one can be on a specific interface (name + major) or on any interface. Interface minor updated triggers must always be restricted to a specific interface.