### PR TITLE
Volatile triggers: do not install if target device does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - [astarte_appengine_api] Check for device existence before accepting a watch request on
   Astarte rooms.
+- [astarte_data_updater_plant] Check for device existence before installation or deletion
+  of volatile triggers.
 
 ## [1.0.3] - 2022-07-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - Unreleased
+### Changed
+- [astarte_appengine_api] Check for device existence before accepting a watch request on
+  Astarte rooms.
+
 ## [1.0.3] - 2022-07-04
 ### Fixed
 - [astarte_appengine_api] Consider `allow_bigintegers` and `allow_safe_bigintegers` params

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/queries.ex
@@ -1,0 +1,53 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.AppEngine.API.Rooms.Queries do
+  alias CQEx.Query, as: DatabaseQuery
+  alias CQEx.Result, as: DatabaseResult
+  require CQEx
+  require Logger
+
+  def check_device_exists(client, device_id) do
+    device_statement = """
+    SELECT device_id
+    FROM devices
+    WHERE device_id=:device_id
+    """
+
+    device_query =
+      DatabaseQuery.new()
+      |> DatabaseQuery.statement(device_statement)
+      |> DatabaseQuery.put(:device_id, device_id)
+
+    with {:ok, result} <- DatabaseQuery.call(client, device_query),
+         device_row when is_list(device_row) <- DatabaseResult.head(result) do
+      {:ok, true}
+    else
+      :empty_dataset ->
+        {:ok, false}
+
+      %{acc: _, msg: error_message} ->
+        _ = Logger.warn("Database error: #{error_message}.", tag: "db_error")
+        {:error, :database_error}
+
+      {:error, reason} ->
+        _ = Logger.warn("Database error, reason: #{inspect(reason)}.", tag: "db_error")
+        {:error, :database_error}
+    end
+  end
+end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -767,6 +767,35 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     end
   end
 
+  def check_device_exists(client, device_id) do
+    device_statement = """
+    SELECT device_id
+    FROM devices
+    WHERE device_id=:device_id
+    """
+
+    device_query =
+      DatabaseQuery.new()
+      |> DatabaseQuery.statement(device_statement)
+      |> DatabaseQuery.put(:device_id, device_id)
+
+    with {:ok, result} <- DatabaseQuery.call(client, device_query),
+         device_row when is_list(device_row) <- DatabaseResult.head(result) do
+      {:ok, true}
+    else
+      :empty_dataset ->
+        {:ok, false}
+
+      %{acc: _, msg: error_message} ->
+        _ = Logger.warn("Database error: #{error_message}.", tag: "db_error")
+        {:error, :database_error}
+
+      {:error, reason} ->
+        _ = Logger.warn("Database error, reason: #{inspect(reason)}.", tag: "db_error")
+        {:error, :database_error}
+    end
+  end
+
   defp to_db_friendly_type(array) when is_list(array) do
     # If we have an array, we convert its elements to a db friendly type
     Enum.map(array, &to_db_friendly_type/1)


### PR DESCRIPTION
Volatile triggers are currently installed even if they refer to a device that does not exist; this causes 
1. DataUpdaterPlant to fail to initialise the data updater process for such device
2. the AppEngine RPC to DataUpdaterPlant to timeout.

Check that the relevant device exists before allowing volatile triggers.