### PR TITLE
Include changes from release-1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Return empty data instead of error when querying `properties` interfaces 
   which are not fully populated. Fix [531](astarte-platform#531).
 
+## [1.0.4] - 2022-10-25
+### Changed
+- [astarte_appengine_api] Check for device existence before accepting a watch request on
+  Astarte rooms.
+- [astarte_data_updater_plant] Check for device existence before installation or deletion
+  of volatile triggers.
+
 ## [1.0.3] - 2022-07-04
 ### Fixed
 - [astarte_appengine_api] Consider `allow_bigintegers` and `allow_safe_bigintegers` params

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Can't be easier. Pick your favorite machine with at least 4GB of free RAM, make 
 ```sh
 $ git clone https://github.com/astarte-platform/astarte.git && cd astarte
 $ docker run -v $(pwd)/compose:/compose astarte/docker-compose-initializer:snapshot
+$ docker-compose pull
 $ docker-compose up -d
 ```
 

--- a/apps/astarte_trigger_engine/mix.lock
+++ b/apps/astarte_trigger_engine/mix.lock
@@ -4,7 +4,7 @@
   "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "9b991a24f0c1a5a6bca52a71ca1b9da9fcc1ef9a", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "66803d3c60329e3be79be8dba4e883ba9df7e327", []},
   "bbmustache": {:hex, :bbmustache, "1.11.0", "a6dbfc5cee3e1d7d17aad5f5b8880b4508d974611da8d73e1f6c28bde65d4c47", [:rebar3], [], "hexpm", "7c9cdcf58dc043377ab792a8c7109d8902695fcae3b35c1078a8b38ddcf86e5f"},
-  "castore": {:hex, :castore, "0.1.16", "2675f717adc700475345c5512c381ef9273eb5df26bdd3f8c13e2636cf4cc175", [:mix], [], "hexpm", "28ed2c43d83b5c25d35c51bc0abf229ac51359c170cba76171a462ced2e4b651"},
+  "castore": {:hex, :castore, "0.1.18", "deb5b9ab02400561b6f5708f3e7660fc35ca2d51bfc6a940d2f513f89c2975fc", [:mix], [], "hexpm", "61bbaf6452b782ef80b33cdb45701afbcf0a918a45ebe7e73f1130d661e66a06"},
   "certifi": {:hex, :certifi, "2.6.1", "dbab8e5e155a0763eea978c913ca280a6b544bfa115633fa20249c3d396d9493", [:rebar3], [], "hexpm", "524c97b4991b3849dd5c17a631223896272c6b0af446778ba4675a1dff53bb7e"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},
   "cowboy": {:hex, :cowboy, "2.8.0", "f3dc62e35797ecd9ac1b50db74611193c29815401e53bac9a5c0577bd7bc667d", [:rebar3], [{:cowlib, "~> 2.9.1", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.7.1", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm", "4643e4fba74ac96d4d152c75803de6fad0b3fa5df354c71afdd6cbeeb15fac8a"},

--- a/doc/pages/tutorials/010-astarte_in_5_minutes.md
+++ b/doc/pages/tutorials/010-astarte_in_5_minutes.md
@@ -64,6 +64,7 @@ To get our Astarte instance running as fast as possible, we will install Astarte
 ```sh
 $ git clone https://github.com/astarte-platform/astarte.git && cd astarte
 $ docker run -v $(pwd)/compose:/compose astarte/docker-compose-initializer:1.0.0
+$ docker-compose pull
 $ docker-compose up -d
 ```
 


### PR DESCRIPTION
[#737](https://github.com/astarte-platform/astarte/pull/737/) did not include some changes from release-1.0, i.e. 1.0.4 CHANGELOG.md entry, documentation bits, minor dep update in TriggerEngine.
Add them.

(version control works in mysterious ways)