### PR TITLE
Handle `binaryblob` and `datetime` in server aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - Unreleased
+### Fixed
+- [astarte_appengine_api] Correctly handle `binaryblob` and `datetime` in server-owned object
+  aggregated interfaces.
+
 ## [1.0.4] - 2022-10-25
 ### Changed
 - [astarte_appengine_api] Check for device existence before accepting a watch request on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [astarte_appengine_api] Correctly handle `binaryblob` and `datetime` in server-owned object
   aggregated interfaces.
+- [astarte_appengine_api] Handle non-array values POSTed to an array endpoint gracefully instead of
+  crashing with an Internal Server Error
 
 ## [1.0.4] - 2022-10-25
 ### Changed

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -751,7 +751,7 @@ defmodule Astarte.AppEngine.API.Device do
     {:ok, anyvalue}
   end
 
-  defp map_while_ok(values, fun) do
+  defp map_while_ok(values, fun) when is_list(values) do
     result =
       Enum.reduce_while(values, {:ok, []}, fn value, {:ok, acc} ->
         case fun.(value) do
@@ -766,6 +766,10 @@ defmodule Astarte.AppEngine.API.Device do
     with {:ok, mapped_values} <- result do
       {:ok, Enum.reverse(mapped_values)}
     end
+  end
+
+  defp map_while_ok(not_list_values, _fun) do
+    {:error, :values_is_not_a_list}
   end
 
   defp wrap_to_bson_struct(:binaryblob, value) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 Ispirata Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -412,8 +412,9 @@ defmodule Astarte.AppEngine.API.Device do
            resolve_object_aggregation_path(path, interface_descriptor, mappings),
          endpoint_id <- endpoint.endpoint_id,
          expected_types <- extract_expected_types(mappings),
-         :ok <- validate_value_type(expected_types, raw_value),
-         wrapped_value = wrap_to_bson_struct(nil, raw_value),
+         {:ok, value} <- cast_value(expected_types, raw_value),
+         :ok <- validate_value_type(expected_types, value),
+         wrapped_value = wrap_to_bson_struct(nil, value),
          reliability = extract_aggregate_reliability(mappings),
          interface_type = interface_descriptor.type,
          publish_opts = build_publish_opts(interface_type, reliability),
@@ -447,7 +448,7 @@ defmodule Astarte.AppEngine.API.Device do
         nil,
         nil,
         path,
-        raw_value,
+        value,
         timestamp_micro,
         opts
       )
@@ -674,6 +675,21 @@ defmodule Astarte.AppEngine.API.Device do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  defp cast_value(expected_types, object) when is_map(expected_types) and is_map(object) do
+    Enum.reduce_while(object, {:ok, %{}}, fn {key, value}, {:ok, acc} ->
+      with {:ok, expected_type} <- Map.fetch(expected_types, key),
+           {:ok, normalized_value} <- cast_value(expected_type, value) do
+        {:cont, {:ok, Map.put(acc, key, normalized_value)}}
+      else
+        {:error, reason, expected} ->
+          {:halt, {:error, reason, expected}}
+
+        :error ->
+          {:halt, {:error, :unexpected_object_key}}
+      end
+    end)
   end
 
   defp cast_value(:datetime, value) when is_binary(value) do


### PR DESCRIPTION
`binaryblob` and `datetime` (and their array equivalents) were not handled correctly in server owned aggregated interfaces (see linked issues below), this PR fixes the bug.
Additionally, it fixes a crash (discovered while testing) that happened when sending non-array values on array endpoints.
    
Fix #753
Fix #754

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
