### PR TITLE
RM API: consider the ignore_ssl_errors field in Actions

### DIFF
--- a/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
@@ -1157,7 +1157,8 @@ defmodule Astarte.RealmManagement.EngineTest do
     action = """
     {
       "http_url": "http://hello.world.ai",
-      "http_method": "post"
+      "http_method": "post",
+      "ignore_ssl_errors": true
     }
     """
 

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/action.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/action.ex
@@ -34,6 +34,8 @@ defmodule Astarte.RealmManagement.API.Triggers.Action do
     field :template, :string
     field :template_type, :string
     field :http_post_url, :string, virtual: true
+    # Default here because it's Action that gets inserted, not HttpAction
+    field :ignore_ssl_errors, :boolean, default: false
     field :amqp_exchange, :string
     field :amqp_routing_key, :string
     field :amqp_static_headers, {:map, :string}
@@ -49,12 +51,14 @@ defmodule Astarte.RealmManagement.API.Triggers.Action do
         http_method: http_method,
         http_static_headers: http_static_headers,
         template: template,
-        template_type: template_type
+        template_type: template_type,
+        ignore_ssl_errors: ignore_ssl_errors
       } = action
 
       %{
         "http_url" => http_url,
-        "http_method" => http_method
+        "http_method" => http_method,
+        "ignore_ssl_errors" => ignore_ssl_errors
       }
       |> maybe_put("http_static_headers", http_static_headers)
       |> maybe_put("template", template)

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/http_action.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/http_action.ex
@@ -31,6 +31,7 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
     field :template_type, :string
 
     field :http_post_url, :string, virtual: true
+    field :ignore_ssl_errors, :boolean
   end
 
   @all_attrs [
@@ -39,7 +40,8 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
     :http_static_headers,
     :template,
     :template_type,
-    :http_post_url
+    :http_post_url,
+    :ignore_ssl_errors
   ]
 
   @valid_methods ["delete", "get", "head", "options", "patch", "post", "put"]

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/http_action_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/http_action_test.exs
@@ -207,4 +207,24 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpActionTest do
 
     assert length(errors) == 1
   end
+
+  test "ignore_ssl_errors is set" do
+    input = %{
+      "http_url" => "http://example.com/",
+      "http_method" => "get",
+      "ignore_ssl_errors" => true
+    }
+
+    out =
+      %HttpAction{}
+      |> HttpAction.changeset(input)
+      |> Changeset.apply_action(:insert)
+
+    assert {:ok,
+            %HttpAction{
+              http_url: "http://example.com/",
+              http_method: "get",
+              ignore_ssl_errors: true
+            }} = out
+  end
 end

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/trigger_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/trigger_test.exs
@@ -22,6 +22,7 @@ defmodule Astarte.RealmManagement.API.Triggers.TriggerTest do
   alias Astarte.RealmManagement.API.Triggers.Trigger
   alias Astarte.RealmManagement.API.Triggers.AMQPAction
   alias Astarte.RealmManagement.API.Triggers.HttpAction
+  alias Astarte.RealmManagement.API.Triggers.Action
   alias Ecto.Changeset
 
   test "valid triggers with http action are accepted" do
@@ -48,9 +49,50 @@ defmodule Astarte.RealmManagement.API.Triggers.TriggerTest do
     assert {:ok,
             %Trigger{
               name: "test_trigger",
-              action: %HttpAction{
+              action: %Action{
                 http_url: "http://www.example.com",
-                http_method: "delete"
+                http_method: "delete",
+                ignore_ssl_errors: false
+              },
+              simple_triggers: [
+                %SimpleTriggerConfig{
+                  device_id: "*",
+                  on: "device_connected",
+                  type: "device_trigger"
+                }
+              ]
+            }} == out
+  end
+
+  test "valid triggers with http action and ignore_ssl_errors are accepted" do
+    input = %{
+      "name" => "test_trigger",
+      "simple_triggers" => [
+        %{
+          "type" => "device_trigger",
+          "device_id" => "*",
+          "on" => "device_connected"
+        }
+      ],
+      "action" => %{
+        "http_url" => "http://www.example.com",
+        "http_method" => "delete",
+        "ignore_ssl_errors" => true
+      }
+    }
+
+    out =
+      %Trigger{}
+      |> Trigger.changeset(input, realm_name: "test")
+      |> Changeset.apply_action(:insert)
+
+    assert {:ok,
+            %Trigger{
+              name: "test_trigger",
+              action: %Action{
+                http_url: "http://www.example.com",
+                http_method: "delete",
+                ignore_ssl_errors: true
               },
               simple_triggers: [
                 %SimpleTriggerConfig{
@@ -85,7 +127,7 @@ defmodule Astarte.RealmManagement.API.Triggers.TriggerTest do
     assert {:ok,
             %Trigger{
               name: "test_trigger",
-              action: %HttpAction{
+              action: %Action{
                 http_url: "http://www.example.com",
                 http_method: "post"
               },
@@ -126,7 +168,7 @@ defmodule Astarte.RealmManagement.API.Triggers.TriggerTest do
     assert {:ok,
             %Trigger{
               name: "test_trigger",
-              action: %AMQPAction{
+              action: %Action{
                 amqp_exchange: "astarte_events_test_custom_exchange",
                 amqp_routing_key: "routing_key",
                 amqp_message_persistent: true,


### PR DESCRIPTION
Add `ignore_ssl_errors` to HttpAction and Action schemas. Default the field value to false.
Closes #756.