### PR TITLE
Fix docs example of Trigger Delivery Policy using undefined strategy

### DIFF
--- a/doc/pages/user/062-using_trigger_delivery_policies.md
+++ b/doc/pages/user/062-using_trigger_delivery_policies.md
@@ -118,11 +118,11 @@ The following policy has a different behaviour depending on whether the HTTP del
     "error_handlers" : [
             {
                 "on" : "server_error",
-                "strategy" : "none"
+                "strategy" : "retry"
             },
             {
                 "on" : "client_error",
-                "strategy" : "retry"
+                "strategy" : "discard"
             }
         ],
     "retry_times" : 5,


### PR DESCRIPTION
An example of Trigger Delivery Policy is referring to a *none* strategy that does not exist.
The PR fixes the example so that existing strategies are used.

