### PR TITLE
RM API doc: update handler field name in Trigger Delivery Policy

### DIFF
--- a/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
+++ b/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
@@ -559,7 +559,7 @@ components:
               data:
                 name: my_policy
                 maximum_capacity: 100
-                handlers:
+                error_handlers:
                   - 'on': any_error
                     strategy: discard
     GetTriggerList:
@@ -1116,7 +1116,7 @@ components:
         maximum_capacity:
           type: integer
           description: Maximum size of the event queue of the trigger delivery policy.
-        handlers:
+        error_handlers:
           description: >-
             Handlers for HTTP errors. Specify what action to take upon errors.
           type: array
@@ -1133,11 +1133,11 @@ components:
       required:
         - name
         - maximum_capacity
-        - handlers
+        - error_handlers
       example:
         name: my_policy
         maximum_capacity: 100
-        handlers:
+        error_handlers:
           - 'on': any_error
             strategy: discard
     TriggerDeliveryPolicyErrorHandler:


### PR DESCRIPTION
Renamed handler field name to an "error_handlers" in the Realm Management API yaml file.

Closes #762 