### PR TITLE
Doc: use new URLs in "Astarte in 5 minutes"

### DIFF
--- a/doc/pages/user/015-astarte_dashboard.md
+++ b/doc/pages/user/015-astarte_dashboard.md
@@ -44,7 +44,7 @@ it relies on Kubernetes APIs to operate.
 Depending on how you are using Astarte, here is where you can find the Dashboard:
 
 - Docker-compose: if you are using a local instance of Astarte via `docker-compose`, you will find
-  it by pointing your browser to the default address `http://localhost:4040/`. To login, fill in the
+  it by pointing your browser to the default address `http://dashboard.astarte.localhost`. To login, fill in the
   name of your realm and a valid JWT token: if you possess the realm private key, as it is the case
   if you followed the [Astarte in 5 minutes](010-astarte_in_5_minutes.html) guide, you can generate
   the token with the command `astartectl utils gen-jwt all-realm-apis -k <private_key>`.

--- a/doc/pages/user/080-grafana_datasource.md
+++ b/doc/pages/user/080-grafana_datasource.md
@@ -17,7 +17,7 @@ When deploying locally using `docker-compose` as mentioned in the
 [Astarte in 5 mins
 tutorial](https://docs.astarte-platform.org/astarte/1.1/010-astarte_in_5_minutes.html#install-astarte),
 Astarte Datasource Plugin will be automatically installed. You may then access Grafana
-by visiting http://localhost:3000.
+by visiting http://grafana.astarte.localhost.
 
 When first logging into Grafana, you will be prompted to change default
 credentials user `admin`, password: `admin`.


### PR DESCRIPTION
Use the addresses exposed by Traefik rather than clunky ports.