### PR TITLE
[Doc] Restore limitations section for interfaces

### DIFF
--- a/doc/pages/architecture/030-interface.md
+++ b/doc/pages/architecture/030-interface.md
@@ -222,6 +222,14 @@ of a valid aggregated interface mapping:
     [...]
 ```
 
+Additional limitations (which stem from the MQTT protocol specification) can be outlined. When using
+parametric endpoints, the actual values used in place of parameter placeholders must fulfill the
+following requirements:
+* endpoint parameters must be UTF-8 encoded strings;
+* endpoint parameters must not contain the following characters: `+` and `#`. In particular, those
+  characters are treated as wildcards for MQTT topics and therefore must be avoided;
+* endpoint parameters must not contain the `/` character.
+
 ## Aggregation
 
 In a real world scenario, such as an array of sensors, there are usually two main

--- a/doc/pages/architecture/030-interface.md
+++ b/doc/pages/architecture/030-interface.md
@@ -163,6 +163,8 @@ Make sure that the differences between two distinct interface names are not limi
 the presence of hyphens. This situation leads to a collision in the interface names which brings to
 an error in the interface installation process.
 
+### Limitations
+
 A valid interface must resolve a path univocally to a single endpoint. Take the following example:
 
 ```json


### PR DESCRIPTION
Restore the limitations section within the interfaces page. The section was erroneously removed in the context of 4479a38.
Contextually, additional limitations on the endpoints naming are added.