### PR TITLE
DUP: Use the `internal` event type for Astarte internal messages (e.g. device heartbeat).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.1.0-rc.0] - Unreleased
 ### Changed
 - Update Elixir to 1.14.5 and Erlang/OTP to 25.3.2.
+- [astarte_data_updater_plant] Use the `internal` event type for Astarte
+  internal messages. (e.g. device heartbeat).
 ### Fixed
 - [astarte_realm_management_api] Provide detailed feedback when a trigger action
   is malformed. Fix [#748](https://github.com/astarte-platform/astarte/issues/748).

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_data_consumer.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_data_consumer.ex
@@ -35,6 +35,7 @@ defmodule Astarte.DataUpdaterPlant.AMQPDataConsumer do
   @control_path_header "x_astarte_control_path"
   @interface_header "x_astarte_interface"
   @path_header "x_astarte_path"
+  @internal_path_header "x_astarte_internal_path"
 
   # API
 
@@ -255,6 +256,7 @@ defmodule Astarte.DataUpdaterPlant.AMQPDataConsumer do
     end
   end
 
+  # TODO remove this when all heartbeats will be moved to internal
   defp handle_consume("heartbeat", payload, headers, timestamp, meta) do
     with %{
            @realm_header => realm,
@@ -263,6 +265,27 @@ defmodule Astarte.DataUpdaterPlant.AMQPDataConsumer do
          {:ok, tracking_id} <- get_tracking_id(meta) do
       # Following call might spawn processes and implicitly monitor them
       DataUpdater.handle_heartbeat(realm, device_id, tracking_id, timestamp)
+    else
+      _ -> handle_invalid_msg(payload, headers, timestamp, meta)
+    end
+  end
+
+  defp handle_consume("internal", payload, headers, timestamp, meta) do
+    with %{
+           @realm_header => realm,
+           @device_id_header => device_id,
+           @internal_path_header => internal_path
+         } <- headers,
+         {:ok, tracking_id} <- get_tracking_id(meta) do
+      # Following call might spawn processes and implicitly monitor them
+      DataUpdater.handle_internal(
+        realm,
+        device_id,
+        internal_path,
+        payload,
+        tracking_id,
+        timestamp
+      )
     else
       _ -> handle_invalid_msg(payload, headers, timestamp, meta)
     end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater.ex
@@ -49,6 +49,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater do
     |> GenServer.cast({:handle_disconnection, message_id, timestamp})
   end
 
+  # TODO remove this when all heartbeats will be moved to internal
   def handle_heartbeat(realm, encoded_device_id, tracking_id, timestamp) do
     message_tracker = get_message_tracker(realm, encoded_device_id)
     {message_id, delivery_tag} = tracking_id
@@ -56,6 +57,22 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater do
 
     get_data_updater_process(realm, encoded_device_id, message_tracker)
     |> GenServer.cast({:handle_heartbeat, message_id, timestamp})
+  end
+
+  def handle_internal(
+        realm,
+        encoded_device_id,
+        path,
+        payload,
+        tracking_id,
+        timestamp
+      ) do
+    message_tracker = get_message_tracker(realm, encoded_device_id)
+    {message_id, delivery_tag} = tracking_id
+    MessageTracker.track_delivery(message_tracker, message_id, delivery_tag)
+
+    get_data_updater_process(realm, encoded_device_id, message_tracker)
+    |> GenServer.cast({:handle_internal, path, payload, message_id, timestamp})
   end
 
   def handle_data(

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/server.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/server.ex
@@ -55,9 +55,19 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
     end
   end
 
+  # TODO remove this when all heartbeats will be moved to internal
   def handle_cast({:handle_heartbeat, message_id, timestamp}, state) do
     if MessageTracker.can_process_message(state.message_tracker, message_id) do
       new_state = Impl.handle_heartbeat(state, message_id, timestamp)
+      {:noreply, new_state}
+    else
+      {:noreply, state}
+    end
+  end
+
+  def handle_cast({:handle_internal, payload, path, message_id, timestamp}, state) do
+    if MessageTracker.can_process_message(state.message_tracker, message_id) do
+      new_state = Impl.handle_internal(state, payload, path, message_id, timestamp)
       {:noreply, new_state}
     else
       {:noreply, state}


### PR DESCRIPTION
Support the new `internal` message type (see https://github.com/astarte-platform/astarte_vmq_plugin/pull/71). For now, only the device heartbeat message is internal. Support the old heartbeat type, too, for the time being.