### PR TITLE
Init nix for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,9 @@ deps
 .rebar3
 apps/*/_checkouts/
 
+# Direnv
+.direnv/
+.envrc
+
 examples/*/node_modules/
 examples/*/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ deps
 .rebar3
 apps/*/_checkouts/
 
+# Nix
+.nix-mix/
+.nix-hex/
+
 # Direnv
 .direnv/
 .envrc

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,98 @@
+{
+  "nodes": {
+    "elixir-utils": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1696521035,
+        "narHash": "sha256-IW9AyjOc48mxXMR3xZzDNWPZRnUfU4eW1H6MyHyYZmQ=",
+        "owner": "noaccOS",
+        "repo": "elixir-utils",
+        "rev": "7babc3e6072fb14463b6aa97c24cb5b57bb4517a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noaccOS",
+        "repo": "elixir-utils",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699343069,
+        "narHash": "sha256-s7BBhyLA6MI6FuJgs4F/SgpntHBzz40/qV0xLPW6A1Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ec750fd01963ab6b20ee1f0cb488754e8036d89d",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixpkgs-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "elixir-utils": "elixir-utils",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,25 @@
+{
+  description = "Open Source IoT platform focused on Data management and processing";
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
+    elixir-utils = {
+      url = github:noaccOS/elixir-utils;
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  outputs = { self, nixpkgs, elixir-utils, flake-utils, ... }:
+    {
+      overlays.default = elixir-utils.lib.asdfOverlay { src = ./.; };
+    } //
+    flake-utils.lib.eachSystem elixir-utils.lib.defaultSystems (system:
+      let pkgs = import nixpkgs { inherit system; overlays = [ self.overlays.default ]; };
+      in {
+        devShells.default = pkgs.elixirDevShell;
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
Init nix's development shell as an alternative to asdf. It can be used from both a standard nix-shell
or a nix develop with flakes.

MIX_HOME and HEX_HOME are set do directories in the project root to avoid conflicts with system packages.

~.envrc is provided for use with direnv, defaulting to the flake version of the shell.~

~To use environment variables in development, eg for testing, it is possible to create a `.env` file with said variables.
The syntax for said file can be found [here](https://github.com/bkeepers/dotenv) but in general it consists of lines of `VAR=value` pairs.~

[elixir-ls](https://github.com/elixir-lsp/elixir-ls) is provided (by default), with hooks tested working  for vscode and emacs (provided you don't hadn't previously installed elixir-ls through emacs' lsp-mode because that one takes priority)

To use the provided lsp server, you need to either
- start your editor from the `nix develop` environment
- have a `.envrc` with either `use flake` or `use nix` and a direnv plugin in your editor ([vscode](https://github.com/direnv/direnv-vscode), [emacs](https://github.com/wbolster/emacs-direnv))

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
