### PR TITLE
Forward port changes from 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   aggregated interfaces.
 - [astarte_appengine_api] Handle non-array values POSTed to an array endpoint gracefully instead of
   crashing with an Internal Server Error
-  
+- [astarte_appengine_api] Handle updates of objects with invalid keys gracefully instead of crashing
+  with an Internal Server Error.
+
 ### Changed
 - [doc] Update the documentation structure. Pages dealing with administrative tasks involving the
   Astarte Operator and Kubernetes are moved to the
@@ -105,11 +107,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - [astarte_appengine_api] Correctly serialize events containing datetime and array values.
-- [astarte_appengine_api] Do not fail when querying `datastream` interfaces data with `since`, 
-`to`, `sinceAfter` params if result is empty. Fix [#552](https://github.com/astarte-platform/astarte/issues/552). 
+- [astarte_appengine_api] Do not fail when querying `datastream` interfaces data with `since`,
+`to`, `sinceAfter` params if result is empty. Fix [#552](https://github.com/astarte-platform/astarte/issues/552).
 - [astarte_appengine_api] Consider microseconds when using timestamps.
   Fix [#620](https://github.com/astarte-platform/astarte/issues/620).
-- [astarte_appengine_api] Don't crash when removing an alias with non-existing tag. 
+- [astarte_appengine_api] Don't crash when removing an alias with non-existing tag.
   Fix [495](https://github.com/astarte-platform/astarte/issues/495).
 - [astarte_trigger_engine] Correctly serialize events containing datetime and array values.
 - [astarte_data_updater_plant] Don't crash when receiving `binaryblobarray` and `datetimearray`
@@ -146,7 +148,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [astarte_appengine_api] Don't crash when an interface contains `null` values, just show them as
   `null` in the resulting JSON.
-- [astarte_realm_management] Fix log noise due to Cassandra warnings when checking health 
+- [astarte_realm_management] Fix log noise due to Cassandra warnings when checking health
   (see [#420](https://github.com/astarte-platform/astarte/issues/420)).
 
 ## [1.0.0-beta.2] - 2021-03-24
@@ -239,7 +241,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [realm_management] Avoid deleting all interfaces sharing the same name by mistake, only the v0
   interface can be deleted.
-- [data_updater_plant] Use a reasonable backoff time (at most around 5 minutes) when publishing 
+- [data_updater_plant] Use a reasonable backoff time (at most around 5 minutes) when publishing
   to RabbitMQ.
 
 ## [0.11.4] - 2021-01-26

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -195,6 +195,13 @@ defmodule Astarte.AppEngine.APIWeb.FallbackController do
     |> put_status(:bad_request)
     |> put_view(Astarte.AppEngine.APIWeb.ErrorView)
     |> render(:"422_invalid_attributes")
+  end
+
+  def call(conn, {:error, :unexpected_object_key}) do
+    conn
+    |> put_status(:bad_request)
+    |> put_view(Astarte.AppEngine.APIWeb.ErrorView)
+    |> render(:"422_unexpected_object_key")
   end
 
   # This is called when no JWT token is present

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -92,6 +92,10 @@ defmodule Astarte.AppEngine.APIWeb.ErrorView do
 
   def render("422_invalid_attributes.json", _assigns) do
     %{errors: %{detail: "Invalid attributes"}}
+  end
+
+  def render("422_unexpected_object_key.json", _assigns) do
+    %{errors: %{detail: "Unexpected object key"}}
   end
 
   def render("500.json", _assigns) do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,6 +41,12 @@ defmodule Astarte.AppEngine.API.DeviceTest do
       minor: 0,
       exchanged_msgs: 4230,
       exchanged_bytes: 2_010_000
+    },
+    "com.example.ServerOwnedTestObject" => %InterfaceInfo{
+      major: 1,
+      minor: 0,
+      exchanged_msgs: 100,
+      exchanged_bytes: 30_000
     },
     "com.example.TestObject" => %InterfaceInfo{
       major: 1,
@@ -162,6 +168,7 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
     assert Enum.sort(result) == [
              "com.example.PixelsConfiguration",
+             "com.example.ServerOwnedTestObject",
              "com.example.TestObject",
              "com.test.LCDMonitor",
              "com.test.SimpleStreamTest"
@@ -1312,6 +1319,24 @@ defmodule Astarte.AppEngine.API.DeviceTest do
                %{"enable" => "true", "samplingPeriod" => 10},
                par
              ) == {:error, :unexpected_value_type, expected: :boolean}
+    end
+
+    test "fails with unexpected key" do
+      test_realm = "autotestrealm"
+      device_id = "fmloLzG5T5u0aOUfIkL8KA"
+      interface = "org.astarte-platform.genericsensors.ServerOwnedAggregateObj"
+      path = "/my_path"
+      value = %{"enable" => true, "samplingPeriod" => 10, "invalidKey" => true}
+      par = nil
+
+      assert Device.update_interface_values(
+               test_realm,
+               device_id,
+               interface,
+               path,
+               value,
+               par
+             ) == {:error, :unexpected_object_key}
     end
 
     test "fails with invalid path" do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_alias_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_alias_controller_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,12 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusByAliasControllerTest do
       "minor" => 0,
       "exchanged_msgs" => 4230,
       "exchanged_bytes" => 2_010_000
+    },
+    "com.example.ServerOwnedTestObject" => %{
+      "major" => 1,
+      "minor" => 0,
+      "exchanged_msgs" => 100,
+      "exchanged_bytes" => 30_000
     },
     "com.example.TestObject" => %{
       "major" => 1,

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_group_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_group_controller_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2019 Ispirata Srl
+# Copyright 2019-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,6 +40,12 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusByGroupControllerTest do
       "minor" => 0,
       "exchanged_msgs" => 4230,
       "exchanged_bytes" => 2_010_000
+    },
+    "com.example.ServerOwnedTestObject" => %{
+      "major" => 1,
+      "minor" => 0,
+      "exchanged_msgs" => 100,
+      "exchanged_bytes" => 30_000
     },
     "com.example.TestObject" => %{
       "major" => 1,

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_controller_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,6 +29,12 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusControllerTest do
       "minor" => 0,
       "exchanged_msgs" => 4230,
       "exchanged_bytes" => 2_010_000
+    },
+    "com.example.ServerOwnedTestObject" => %{
+      "major" => 1,
+      "minor" => 0,
+      "exchanged_msgs" => 100,
+      "exchanged_bytes" => 30_000
     },
     "com.example.TestObject" => %{
       "major" => 1,

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_by_device_alias_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_by_device_alias_controller_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 Ispirata Srl
+# Copyright 2018-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByDeviceAliasControllerTest do
 
       assert Enum.sort(json_response(conn, 200)["data"]) == [
                "com.example.PixelsConfiguration",
+               "com.example.ServerOwnedTestObject",
                "com.example.TestObject",
                "com.test.LCDMonitor",
                "com.test.SimpleStreamTest"
@@ -121,6 +122,28 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByDeviceAliasControllerTest do
         )
 
       assert json_response(object_conn, 200)["data"] == expected_reply
+    end
+  end
+
+  describe "update" do
+    test "returns an error when given invalid keys", %{conn: conn} do
+      conn =
+        put(
+          conn,
+          interface_values_by_device_alias_path(
+            conn,
+            :update,
+            "autotestrealm",
+            "device_a",
+            "com.example.ServerOwnedTestObject",
+            ["my_path"]
+          ),
+          %{
+            data: %{"string" => "aaa", "invalidKey" => true}
+          }
+        )
+
+      assert json_response(conn, 400)["errors"] == %{"detail" => "Unexpected object key"}
     end
   end
 end

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_by_group_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_by_group_controller_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2019 Ispirata Srl
+# Copyright 2019-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -104,6 +104,7 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupControllerTest do
 
       assert Enum.sort(json_response(conn, 200)["data"]) == [
                "com.example.PixelsConfiguration",
+               "com.example.ServerOwnedTestObject",
                "com.example.TestObject",
                "com.test.LCDMonitor",
                "com.test.SimpleStreamTest"
@@ -209,6 +210,29 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupControllerTest do
         )
 
       assert json_response(object_conn, 200)["data"] == expected_reply
+    end
+  end
+
+  describe "update" do
+    test "returns an error when given invalid keys", %{conn: conn} do
+      conn =
+        put(
+          conn,
+          interface_values_by_group_path(
+            conn,
+            :update,
+            @realm,
+            @group_name,
+            @device_id,
+            "com.example.ServerOwnedTestObject",
+            ["my_path"]
+          ),
+          %{
+            data: %{"string" => "aaa", "invalidKey" => true}
+          }
+        )
+
+      assert json_response(conn, 400)["errors"] == %{"detail" => "Unexpected object key"}
     end
   end
 end

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_controller_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -72,6 +72,7 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesControllerTest do
 
       assert Enum.sort(json_response(conn, 200)["data"]) == [
                "com.example.PixelsConfiguration",
+               "com.example.ServerOwnedTestObject",
                "com.example.TestObject",
                "com.test.LCDMonitor",
                "com.test.SimpleStreamTest"
@@ -154,6 +155,28 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesControllerTest do
         )
 
       assert json_response(object_conn, 200)["data"] == expected_reply
+    end
+  end
+
+  describe "update" do
+    test "returns an error when given invalid keys", %{conn: conn} do
+      conn =
+        put(
+          conn,
+          interface_values_path(
+            conn,
+            :update,
+            "autotestrealm",
+            "f0VMRgIBAQAAAAAAAAAAAA",
+            "com.example.ServerOwnedTestObject",
+            ["my_path"]
+          ),
+          %{
+            data: %{"string" => "aaa", "invalidKey" => true}
+          }
+        )
+
+      assert json_response(conn, 400)["errors"] == %{"detail" => "Unexpected object key"}
     end
   end
 end

--- a/doc/mix.exs
+++ b/doc/mix.exs
@@ -1,7 +1,13 @@
 defmodule Doc.MixProject do
   use Mix.Project
 
+  @source_ref "release-1.0"
+
   def project do
+    source_version =
+      String.replace_prefix(@source_ref, "release-", "")
+      |> String.replace("master", "snapshot")
+
     [
       app: :doc,
       version: "1.1.0-rc.0",
@@ -9,7 +15,8 @@ defmodule Doc.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "Astarte",
-      homepage_url: "http://astarte-platform.org",
+      homepage_url: "https://docs.astarte-platform.org/astarte/#{source_version}/",
+      source_url: "https://github.com/astarte-platform/astarte",
       docs: docs()
     ]
   end
@@ -23,12 +30,12 @@ defmodule Doc.MixProject do
     [
       main: "001-intro_user",
       logo: "images/mascot.png",
-      source_url: "https://git.ispirata.com/Astarte-NG/%{path}#L%{line}",
       # It's in the docs repo root
       javascript_config_path: "../common_vars.js",
       extras: Path.wildcard("pages/*/*.md"),
       assets: "images/",
       api_reference: false,
+      source_ref: "#{@source_ref}/doc",
       groups_for_extras: [
         "Architecture, Design and Concepts": ~r"/architecture/",
         "User Guide": ~r"/user/",

--- a/doc/pages/administrator/070-manage_realms.md
+++ b/doc/pages/administrator/070-manage_realms.md
@@ -16,4 +16,4 @@ You can then use `housekeeping.key` to authenticate against Housekeeping API.
 ## Work in progress
 
 This guide is not yet complete, as this part is a moving target within `astartectl`. Please refer to the
-[API Documentation](api/) to manage Realms manually once here.
+[API Documentation](api/001-intro_api.md) to manage Realms manually once here.

--- a/doc/pages/architecture/030-interface.md
+++ b/doc/pages/architecture/030-interface.md
@@ -163,6 +163,8 @@ Make sure that the differences between two distinct interface names are not limi
 the presence of hyphens. This situation leads to a collision in the interface names which brings to
 an error in the interface installation process.
 
+### Limitations
+
 A valid interface must resolve a path univocally to a single endpoint. Take the following example:
 
 ```json
@@ -219,6 +221,14 @@ of a valid aggregated interface mapping:
         },
     [...]
 ```
+
+Additional limitations (which stem from the MQTT protocol specification) can be outlined. When using
+parametric endpoints, the actual values used in place of parameter placeholders must fulfill the
+following requirements:
+* endpoint parameters must be UTF-8 encoded strings;
+* endpoint parameters must not contain the following characters: `+` and `#`. In particular, those
+  characters are treated as wildcards for MQTT topics and therefore must be avoided;
+* endpoint parameters must not contain the `/` character.
 
 ## Aggregation
 


### PR DESCRIPTION
Fix handling of  `:unexpected_object_key` in AppEngine API and restore missing documentation.