### PR TITLE
E2E: Consistent and configurable timeouts

### DIFF
--- a/tools/astarte_e2e/lib/astarte_e2e/client.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/client.ex
@@ -90,6 +90,11 @@ defmodule AstarteE2E.Client do
     |> GenSocketClient.call(:wait_for_connection, :infinity)
   end
 
+  def notify_startup_timeout(realm, device_id) do
+    via_tuple(realm, device_id)
+    |> GenSocketClient.call(:notify_startup_timeout, :infinity)
+  end
+
   defp join_topic(transport, state) do
     topic =
       state
@@ -587,5 +592,10 @@ defmodule AstarteE2E.Client do
 
       {:noreply, new_state}
     end
+  end
+
+  def handle_call(:notify_startup_timeout, from, _transport, state) do
+    ServiceNotifier.notify_timeout()
+    {:reply, :ok, state}
   end
 end

--- a/tools/astarte_e2e/lib/astarte_e2e/scheduler.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/scheduler.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule AstarteE2E.Scheduler do
-  alias AstarteE2E.Utils
+  alias AstarteE2E.{Client, Utils}
   require Logger
 
   use GenServer, restart: :transient
@@ -37,7 +37,18 @@ defmodule AstarteE2E.Scheduler do
 
     check_repetitions = Keyword.fetch!(opts, :check_repetitions)
 
-    state = %{check_repetitions: check_repetitions, check_interval_ms: check_interval_ms}
+    realm = Keyword.fetch(opts, :realm)
+    device_id = Keyword.fetch!(opts, :device_id)
+    timeout = Keyword.fetch!(opts, :timeout)
+
+    state = %{
+      check_repetitions: check_repetitions,
+      check_interval_ms: check_interval_ms,
+      realm: realm,
+      device_id: device_id,
+      timeout: timeout
+    }
+
     Process.send_after(self(), :do_perform_check, check_interval_ms)
 
     {:ok, state}
@@ -57,19 +68,23 @@ defmodule AstarteE2E.Scheduler do
   def handle_info(:do_perform_check, state) do
     Process.send_after(self(), :do_perform_check, state.check_interval_ms)
 
-    case AstarteE2E.perform_check() do
+    check_result = AstarteE2E.perform_check()
+
+    updated_state = update_in(state.timeout, &maybe_timeout(&1, state, check_result))
+
+    case check_result do
       :ok ->
-        handle_successful_job(state)
+        handle_successful_job(updated_state)
 
       {:error, :timeout} ->
-        handle_timed_out_job(state)
+        handle_timed_out_job(updated_state)
 
       {:error, :not_connected} ->
-        {:noreply, state}
+        {:noreply, updated_state}
 
       e ->
         Logger.warn("Unhandled condition #{inspect(e)}. Pretending everything is ok.")
-        {:noreply, state}
+        {:noreply, updated_state}
     end
   end
 
@@ -101,6 +116,20 @@ defmodule AstarteE2E.Scheduler do
         System.stop(1)
         {:stop, :timeout, state}
     end
+  end
+
+  defp maybe_timeout(timeout, state, check_result) do
+    cond do
+      timeout == :inactive or check_result == :ok -> :inactive
+      timeout == {:active, 1} -> call_timeout_and_set_inactive(state)
+      {:active, x} = timeout -> {:active, x - 1}
+    end
+  end
+
+  defp call_timeout_and_set_inactive(state) do
+    %{realm: {:ok, realm}, device_id: device_id} = state
+    Client.notify_startup_timeout(realm, device_id)
+    :inactive
   end
 
   defp via_tuple(realm, device_id) do

--- a/tools/astarte_e2e/lib/astarte_e2e/scheduler.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/scheduler.ex
@@ -55,24 +55,22 @@ defmodule AstarteE2E.Scheduler do
 
   @impl true
   def handle_info(:do_perform_check, state) do
-    return_val =
-      case AstarteE2E.perform_check() do
-        :ok ->
-          handle_successful_job(state)
-
-        {:error, :timeout} ->
-          handle_timed_out_job(state)
-
-        {:error, :not_connected} ->
-          {:noreply, state}
-
-        e ->
-          Logger.warn("Unhandled condition #{inspect(e)}. Pretending everything is ok.")
-          {:noreply, state}
-      end
-
     Process.send_after(self(), :do_perform_check, state.check_interval_ms)
-    return_val
+
+    case AstarteE2E.perform_check() do
+      :ok ->
+        handle_successful_job(state)
+
+      {:error, :timeout} ->
+        handle_timed_out_job(state)
+
+      {:error, :not_connected} ->
+        {:noreply, state}
+
+      e ->
+        Logger.warn("Unhandled condition #{inspect(e)}. Pretending everything is ok.")
+        {:noreply, state}
+    end
   end
 
   defp handle_successful_job(state) do


### PR DESCRIPTION
Sample implementation for #487.

Timeout is now handled by the scheduler instead of happening directly in the service notifier.

Timeouts can be declared as a number of failed checks or as the number of seconds passed, both only affecting the startup. At least one check has to be done because otherwise the timeout would be triggered even in a perfectly working condition. It is not possible to disable timeouts for now, but could be addressed relatively easily if needed.

Timeouts are always called **right after** a check, even when declared as a time span, because the state wouldn't change anyway and it makes it easier to schedule the timeout exactly. If the check happens every 5s and the timeout is set at 10, it will always be called after exactly two checks. This would not be guaranteed by a simple `Process.send_after(self(), :timeout, timeout_s)`, as check calls may take a bit more milliseconds than an exact `check_interval_ms`.

If declaring the timeout at the exact second it was requested, we must check that **both** the declared amount of seconds has passed **and** `div(timeout_s, check_interval_s)` checks have been made, but as I said I have only implemented the required number of checks for now.

As a side note, now consequent checks are scheduled immediately instead of waiting for the previous check to end (5cdb1ffe500bd4c494a667a7f779fca72b5e1f15). This might be outside the scope of this pr but I'll leave it here for now, as I believe fixing the scheduling **is** the scope of this pr. 
<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
