### PR TITLE
TriggerEngine: do not fail when receiving events with `version` unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - Unreleased
+### Fixed
+- [astarte_trigger_engine] Allow to decode events that do not contain the
+  deprecated `version` field. 
+
 ## [1.1.0-rc.0] - 2023-06-09
 ### Changed
 - Update Elixir to 1.14.5 and Erlang/OTP to 25.3.2.

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
@@ -43,8 +43,7 @@ defmodule Astarte.TriggerEngine.EventsConsumer do
       event: {
         event_type,
         event
-      },
-      version: 1
+      }
     } = decoded_payload
 
     timestamp_ms =


### PR DESCRIPTION
The `version` field was deprecated since 1.1.0-rc.0 (see https://github.com/astarte-platform/astarte_core/pull/82/commits/6b397be7bef6f7e44ca37c1750cf2ca1e446e7c7). Do not fail when decoding an event proto that does not contain that field.