### PR TITLE
Doc: bump Elixir version

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -29,10 +29,10 @@ jobs:
       with:
         repository: astarte-platform/docs
         path: docs
-    - uses: erlef/setup-beam@v1.7.0
+    - uses: erlef/setup-beam@v1.15.0
       with:
-        otp-version: "23.2"
-        elixir-version: "1.11.4"
+        otp-version: "25.3.2"
+        elixir-version: "1.14.5"
     - name: Install Dependencies
       working-directory: ./astarte/doc
       run: mix deps.get

--- a/doc/mix.exs
+++ b/doc/mix.exs
@@ -11,7 +11,7 @@ defmodule Doc.MixProject do
     [
       app: :doc,
       version: "1.0.4",
-      elixir: "~> 1.4",
+      elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       name: "Astarte",


### PR DESCRIPTION
Time to move to a newer version of Elixir (i.e. 1.14) for the documentation project.
Contextually, bump versions in docs-workflow.
