### PR TITLE
feat(docker-compose): add aliases to traefik

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,6 +210,14 @@ services:
     volumes:
       # So that Traefik can listen to the Docker events
       - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      default:
+        aliases:
+          # Create traefik aliases for its hosts, so that other containers
+          # in the same network can curl them.
+          - api.astarte.localhost
+          - dashboard.astarte.localhost
+          - grafana.astarte.localhost
 
   # RabbitMQ
   rabbitmq:


### PR DESCRIPTION
Adds aliases to the traefik service, so that other containers in the same network can curl them.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
