### PR TITLE
chore(docker-compose): bump version 2.3 -> 3.8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3.8'
 services:
   astarte-housekeeping:
     image: astarte/astarte_housekeeping:1.1.0


### PR DESCRIPTION
bump to latest available version.
minimum docker engine version is 19.03.0, which also happens to be the recommended version for astarte 1.1

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
