### PR TITLE
AppEngine: match number of returned result with downsample_to in corner cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   AMQP queues to flow seamlessy.
 - [astarte_appengine_api] Don't crash when retrieving the interface version
   in a device whose introspection is empty.
+- [astarte_appengine_api] Return the number of results specified by `downsample_to`
+  when there are more samples than the default query limit.
+  Fix [#824](https://github.com/astarte-platform/astarte/issues/824).
+- [astarte_appengine_api] Return the number of results specified by `downsample_to`
+  when used in combination with `format=disjoint_tables`.
+  Fix [#149](https://github.com/astarte-platform/astarte/issues/149).
 
 ## [1.1.0] - 2023-06-20
 ### Fixed

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -1224,7 +1224,9 @@ defmodule Astarte.AppEngine.API.Device.Queries do
   def get_results_count(client, count_query, opts) do
     with {:ok, result} <- DatabaseQuery.call(client, count_query),
          [{_count_key, count}] <- DatabaseResult.head(result) do
-      min(count, opts.limit)
+      limit = opts.limit || Config.max_results_limit!()
+
+      min(count, limit)
     else
       error ->
         _ =


### PR DESCRIPTION
Return the number of results specified by `downsample_to` when:
- there are more samples than the default query limit.
- `format=disjoint_tables` is used.

This is obtained by checking that the actual result size is taken into consideration when downsampling.
Note that if `downsample_to` > query limit, result may still not be accurate.

Fixes #149 and #824.
