### PR TITLE
CI: update tools in E2E workflow

### DIFF
--- a/.github/workflows/astarte-end-to-end-test-workflow.yaml
+++ b/.github/workflows/astarte-end-to-end-test-workflow.yaml
@@ -42,12 +42,13 @@ jobs:
         ./wait-for-astarte-docker-compose
     - name: Install astartectl
       run: |
-        wget https://github.com/astarte-platform/astartectl/releases/download/v0.11.1/astartectl_linux_amd64 -O astartectl
+        wget https://github.com/astarte-platform/astartectl/releases/download/v22.11.02/astartectl_22.11.02_linux_x86_64.tar.gz
+        tar xf astartectl_22.11.02_linux_x86_64.tar.gz
         chmod +x astartectl
     - name: Create realm
       run: |
         ./astartectl utils gen-keypair test
-        ./astartectl housekeeping realms create test --housekeeping-url http://localhost:4001/ -p test_public.pem -k compose/astarte-keys/housekeeping_private.pem
+        ./astartectl housekeeping realms create test --housekeeping-url http://localhost:4001/ --realm-public-key test_public.pem -k compose/astarte-keys/housekeeping_private.pem -y
         echo "E2E_REALM=test" >> $GITHUB_ENV
         sleep 5
     - name: Install e2e test interfaces


### PR DESCRIPTION
Update astartectl and wait-for-astarte-docker-compose in order to enable e2e tests to safely run again.
