### PR TITLE
fix(appengine): remove cassandra warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Return the number of results specified by `downsample_to`
   when used in combination with `format=disjoint_tables`.
   Fix [#149](https://github.com/astarte-platform/astarte/issues/149).
+- [astarte_appengine_api] Fix log noise with cassandra during health checks.
+  Fix [#817](https://github.com/astarte-platform/astarte/issues/817).
 
 ### Changed
 - [doc] Update the documentation structure. Pages dealing with administrative tasks involving the


### PR DESCRIPTION
modify the health check to use queries which do not generate warnings from cassandra.
akin to https://github.com/astarte-platform/astarte/pull/571.

closes #817.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
