### PR TITLE
fix(api)!: only accept json content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 - Forward port changes from release 1.1.
 
+### Fixed
+- [all] API now only accepts json requests
+
 ## [1.1.0] - 2023-06-20
 ### Fixed
 - [astarte_trigger_engine] Allow to decode events that do not contain the

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/endpoint.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/endpoint.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,8 +44,7 @@ defmodule Astarte.AppEngine.APIWeb.Endpoint do
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
-    pass: ["*/*"],
+    parsers: [:json],
     json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/endpoint.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/endpoint.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,8 +45,7 @@ defmodule Astarte.Housekeeping.APIWeb.Endpoint do
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
-    pass: ["*/*"],
+    parsers: [:json],
     json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/endpoint.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/endpoint.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,8 +47,7 @@ defmodule Astarte.Pairing.APIWeb.Endpoint do
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
-    pass: ["*/*"],
+    parsers: [:json],
     json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/endpoint.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/endpoint.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -45,8 +45,7 @@ defmodule Astarte.RealmManagement.APIWeb.Endpoint do
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :multipart, :json],
-    pass: ["*/*"],
+    parsers: [:json],
     json_decoder: Phoenix.json_library()
 
   plug Plug.MethodOverride


### PR DESCRIPTION
1. Clients can not send urlencoded/multipart requests. 
BREAKING CHANGE: this means that eg an appengine request on the endpoint
`interface_values_path  POST    /v1/:realm_name/devices/:device_id/interfaces/:interface/*path_token`
which previously _could_ be successful with an urlencoded body of `data=2` will not be successful anymore.

2. Remove `pass: ["*/*"]`  
From the [Plug.Parsers documentation](https://hexdocs.pm/plug/Plug.Parsers.html), "This plug will raise Plug.Parsers.UnsupportedMediaTypeError by default if the request cannot be parsed by any of the given types and the MIME type has not been explicitly accepted with the :pass option".
I believe this to be the desired behavior, as the application should return error code 415 if it is not parsable by one of the specified parsers.

Closes #263 

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
