### PR TITLE
fix(pairing): don't crash with custom CA certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Fix [#149](https://github.com/astarte-platform/astarte/issues/149).
 - [astarte_appengine_api] Fix log noise with cassandra during health checks.
   Fix [#817](https://github.com/astarte-platform/astarte/issues/817).
+- [astarte_pairing] Fix crash when using a custom CA certificate.
 
 ### Changed
 - [doc] Update the documentation structure. Pages dealing with administrative tasks involving the

--- a/apps/astarte_pairing/lib/astarte_pairing/config.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/config.ex
@@ -50,7 +50,7 @@ defmodule Astarte.Pairing.Config do
     type: :binary
 
   def init! do
-    if {:ok, nil} = ca_cert() do
+    if {:ok, nil} == ca_cert() do
       case CFSSLCredentials.ca_cert() do
         {:ok, cert} ->
           put_ca_cert(cert)


### PR DESCRIPTION
fix the typo trying to match `ca_cert`, which lead to a crash in the case a custom certificate was given.
