### PR TITLE
Astarte in 5 minutes: use v1.1.0

### DIFF
--- a/doc/pages/tutorials/010-astarte_in_5_minutes.md
+++ b/doc/pages/tutorials/010-astarte_in_5_minutes.md
@@ -62,7 +62,7 @@ Ubuntu 22.04 and macOS 10.15 Catalina, but any other modern operating system sho
 To get our Astarte instance running as fast as possible, we will install Astarte's standalone distribution. It includes a tunable Docker Compose which brings up Astarte and every companion service needed for it to work. To do so, simply clone Astarte's main repository and use its scripts to bring it up:
 
 ```sh
-$ git clone https://github.com/astarte-platform/astarte.git && cd astarte
+$ git clone https://github.com/astarte-platform/astarte.git -b v1.1.0 && cd astarte
 $ docker run -v $(pwd)/compose:/compose astarte/docker-compose-initializer:1.1
 $ docker-compose pull
 $ docker-compose up -d


### PR DESCRIPTION
Ensure that v1.1.0 is checked out.