### PR TITLE
Change notation for the base Astarte API URL

### DIFF
--- a/doc/pages/user/010-interacting_with_astarte.md
+++ b/doc/pages/user/010-interacting_with_astarte.md
@@ -74,6 +74,6 @@ When using `astartectl` or any other client, you can also pass a Realm Private K
 
 ### Accessing the APIs
 
-In a standard Astarte installation, AppEngine API and Realm Management API are usually accessible at `api.<your astarte domain>/appengine` and `api.<your astarte domain>/realmmanagement`.
+In a standard Astarte installation, AppEngine API and Realm Management API are usually accessible at `<astarte base API URL>/appengine` and `<astarte base API URL>/realmmanagement`.
 
 If your Astarte installation has Swagger UI enabled, you can use the `/swagger` endpoint to access it, and to issue API calls straight from your browser to follow this guide.

--- a/doc/pages/user/050-query_device.md
+++ b/doc/pages/user/050-query_device.md
@@ -36,7 +36,7 @@ Clicking on the Device ID will take you to its details page.
 
 ### Query Device status using AppEngine API
 
-`GET api.<your astarte domain>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA`
+`GET <astarte base API URL>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA`
 
 ```json
 {
@@ -88,7 +88,7 @@ Clicking on the Device ID will take you to its details page.
 
 Through the API, it is also possible to get the Introspection of the device only:
 
-`GET api.<your astarte domain>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA/interfaces`
+`GET <astarte base API URL>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA/interfaces`
 
 ```json
 {
@@ -106,7 +106,7 @@ number of string values associated to a corresponding string key.
 To set, modify and delete `attributes`, a `PATCH` on the device endpoint is required:
 
 ```
-PATCH api.<your astarte domain>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA
+PATCH <astarte base API URL>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA
 ```
 
 In the request body, the `data` JSON object should have a `attributes` key which bears a dictionary
@@ -122,19 +122,19 @@ or use `astartectl` to perform the same operation on the command line. Some exam
 
 `astartectl` invocation: `astartectl appengine devices data-snapshot f0VMRgIBAQAAAAAAAAAAAA com.example.ExampleInterface`
 
-AppEngine API invocation: `GET api.<your astarte domain>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA/interfaces/com.example.ExampleInterface`
+AppEngine API invocation: `GET <astarte base API URL>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA/interfaces/com.example.ExampleInterface`
 
 ### Get last sent value from an `individual` `device` `datastream` interface
 
 `astartectl` invocation: `astartectl appengine devices data-snapshot f0VMRgIBAQAAAAAAAAAAAA com.example.TestInterface`
 
-AppEngine API invocation: `GET api.<your astarte domain>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA/interfaces/com.example.TestInterface/myValue?limit=1`
+AppEngine API invocation: `GET <astarte base API URL>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA/interfaces/com.example.TestInterface/myValue?limit=1`
 
 ### Set values in an `individual` `server` `datastream` interface
 
 `astartectl` invocation: `astartectl appengine devices send-data f0VMRgIBAQAAAAAAAAAAAA com.example.OtherTestInterface /myOtherValue <value>`
 
-AppEngine API invocation: `POST api.<your astarte domain>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA/interfaces/com.example.OtherTestInterface/myOtherValue`
+AppEngine API invocation: `POST <astarte base API URL>/appengine/v1/test/devices/f0VMRgIBAQAAAAAAAAAAAA/interfaces/com.example.OtherTestInterface/myOtherValue`
 Request body: `{"data": <value>}`
 
 ### API Query semantics

--- a/doc/pages/user/062-using_trigger_delivery_policies.md
+++ b/doc/pages/user/062-using_trigger_delivery_policies.md
@@ -17,7 +17,7 @@ At any time, you can list existing Trigger Delivery Policies in a Realm and fetc
 
 To list all existing Trigger Delivery Policies in a Realm:
 
-`GET api.<your astarte domain>/realmmanagement/v1/<realm name>/policies`
+`GET <astarte base API URL>/realmmanagement/v1/<realm name>/policies`
 
 ```json
 {
@@ -32,7 +32,7 @@ To list all existing Trigger Delivery Policies in a Realm:
 
 To get a Trigger Delivery Policy definition:
 
-`GET api.<your astarte domain>/realmmanagement/v1/<realm name>/policies/simple_trigger_delivery_policy`
+`GET <astarte base API URL>/realmmanagement/v1/<realm name>/policies/simple_trigger_delivery_policy`
 
 ```json
 {
@@ -57,7 +57,7 @@ The name of the Trigger Delivery Policy must be unique within the Realm, or an e
 
 ### Installing a Trigger Delivery Policy using Realm Management APIs
 
-`POST api.<your astarte domain>/realmmanagement/v1/<realm name>/policies`
+`POST <astarte base API URL>/realmmanagement/v1/<realm name>/policies`
 
 The POST request must have the following request body, with content type `application/json`
 
@@ -83,7 +83,7 @@ A Trigger Delivery Policy can be deleted only if no Triggers linked to it are pr
 
 ### Deleting a Trigger Delivery Policy using Realm Management APIs
 
-`DELETE api.<your astarte domain>/realmmanagement/v1/<realm name>/policies/simple_trigger_delivery_policy`
+`DELETE <astarte base API URL>/realmmanagement/v1/<realm name>/policies/simple_trigger_delivery_policy`
 
 ## Trigger Delivery Policy examples
 


### PR DESCRIPTION
Changed notation for the base Astarte API URL instead api.<your astarte domain> in <astarte base AP I URL>

Closes #738