### PR TITLE
data_updater: remove async startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Fix log noise with cassandra during health checks.
   Fix [#817](https://github.com/astarte-platform/astarte/issues/817).
 - [astarte_pairing] Fix crash when using a custom CA certificate.
+- [astarte_data_updater_plant] Remove asynchronous startup of Data Updater, which could lead to Data
+  Updater stalling in some corner cases.
 
 ### Changed
 - [doc] Update the documentation structure. Pages dealing with administrative tasks involving the

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/server.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/server.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017-2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,8 +29,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
   def init({realm, device_id, message_tracker}) do
     timeout = Config.data_updater_deactivation_interval_ms!()
 
-    send(self(), {:initialize, realm, device_id, message_tracker})
-    {:ok, nil, timeout}
+    {:ok, Impl.init_state(realm, device_id, message_tracker), timeout}
   end
 
   def handle_cast({:handle_connection, ip_address, message_id, timestamp}, state) do
@@ -140,12 +139,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
     timeout = Config.data_updater_deactivation_interval_ms!()
 
     {:reply, state, state, timeout}
-  end
-
-  def handle_info({:initialize, realm, device_id, message_tracker}, nil) do
-    timeout = Config.data_updater_deactivation_interval_ms!()
-
-    {:noreply, Impl.init_state(realm, device_id, message_tracker), timeout}
   end
 
   def handle_info({:DOWN, _, :process, pid, :normal}, %{message_tracker: pid} = state) do


### PR DESCRIPTION
This feature could cause more harm than good, since DataUpdater was actually totally unmonitored and unlinked between its start and when the :initialize info was handled, which could lead to undetected crashes.

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
