### PR TITLE
Update docker images to `Debian bookworm` and add non-root user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_housekeeping] Support the new PATCH-based API for realm update.
 - Update Elixir to 1.15.7.
 - Update Erlang/OTP to 26.1.
+- Update container base image to Debian `Bookworm`.
 
 ## [1.1.1] - 2023-11-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update Elixir to 1.15.7.
 - Update Erlang/OTP to 26.1.
 - Update container base image to Debian `Bookworm`.
+- Container user has changed from `root` to `nobody`.
 
 ## [1.1.1] - 2023-11-15
 ### Fixed

--- a/apps/astarte_appengine_api/Dockerfile
+++ b/apps/astarte_appengine_api/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -44,5 +46,8 @@ RUN apt-get -qq install openssl ca-certificates
 ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_appengine_api .
+
+# Change to non-root user
+USER nobody
 
 CMD ["./bin/astarte_appengine_api", "start"]

--- a/apps/astarte_appengine_api/Dockerfile
+++ b/apps/astarte_appengine_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_data_updater_plant/Dockerfile
+++ b/apps/astarte_data_updater_plant/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_data_updater_plant/Dockerfile
+++ b/apps/astarte_data_updater_plant/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -44,5 +46,8 @@ RUN apt-get -qq install openssl ca-certificates
 ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_data_updater_plant .
+
+# Change to non-root user
+USER nobody
 
 CMD ["./bin/astarte_data_updater_plant", "start"]

--- a/apps/astarte_housekeeping/Dockerfile
+++ b/apps/astarte_housekeeping/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -45,6 +47,9 @@ ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_housekeeping .
 COPY --from=builder /app/entrypoint.sh .
+
+# Change to non-root user
+USER nobody
 
 ENTRYPOINT ["/bin/bash", "entrypoint.sh"]
 CMD ["start"]

--- a/apps/astarte_housekeeping/Dockerfile
+++ b/apps/astarte_housekeeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_housekeeping_api/Dockerfile
+++ b/apps/astarte_housekeeping_api/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -44,5 +46,8 @@ RUN apt-get -qq install openssl ca-certificates
 ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_housekeeping_api .
+
+# Change to non-root user
+USER nobody
 
 CMD ["./bin/astarte_housekeeping_api", "start"]

--- a/apps/astarte_housekeeping_api/Dockerfile
+++ b/apps/astarte_housekeeping_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_pairing/Dockerfile
+++ b/apps/astarte_pairing/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -44,5 +46,8 @@ RUN apt-get -qq install openssl ca-certificates
 ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_pairing .
+
+# Change to non-root user
+USER nobody
 
 CMD ["./bin/astarte_pairing", "start"]

--- a/apps/astarte_pairing/Dockerfile
+++ b/apps/astarte_pairing/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_pairing_api/Dockerfile
+++ b/apps/astarte_pairing_api/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -44,5 +46,8 @@ RUN apt-get -qq install openssl ca-certificates
 ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_pairing_api .
+
+# Change to non-root user
+USER nobody
 
 CMD ["./bin/astarte_pairing_api", "start"]

--- a/apps/astarte_pairing_api/Dockerfile
+++ b/apps/astarte_pairing_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_realm_management/Dockerfile
+++ b/apps/astarte_realm_management/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_realm_management/Dockerfile
+++ b/apps/astarte_realm_management/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -44,5 +46,8 @@ RUN apt-get -qq install openssl ca-certificates
 ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_realm_management .
+
+# Change to non-root user
+USER nobody
 
 CMD ["./bin/astarte_realm_management", "start"]

--- a/apps/astarte_realm_management_api/Dockerfile
+++ b/apps/astarte_realm_management_api/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -44,5 +46,8 @@ RUN apt-get -qq install openssl ca-certificates
 ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_realm_management_api .
+
+# Change to non-root user
+USER nobody
 
 CMD ["./bin/astarte_realm_management_api", "start"]

--- a/apps/astarte_realm_management_api/Dockerfile
+++ b/apps/astarte_realm_management_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_trigger_engine/Dockerfile
+++ b/apps/astarte_trigger_engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -28,7 +28,7 @@ ADD . .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /app
 
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install openssl ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod

--- a/apps/astarte_trigger_engine/Dockerfile
+++ b/apps/astarte_trigger_engine/Dockerfile
@@ -32,6 +32,8 @@ FROM debian:bookworm-slim
 
 WORKDIR /app
 
+RUN chown -R nobody /app
+
 RUN apt-get -qq update
 
 # Set the locale
@@ -44,5 +46,8 @@ RUN apt-get -qq install openssl ca-certificates
 ARG BUILD_ENV=prod
 
 COPY --from=builder /app/_build/$BUILD_ENV/rel/astarte_trigger_engine .
+
+# Change to non-root user
+USER nobody
 
 CMD ["./bin/astarte_trigger_engine", "start"]


### PR DESCRIPTION
- Update docker images to Debian "bookworm".
- Contextually, move from libssl1.1 to the default Debian libssl package
- Add `USER nobody` to the Dockerfiles.

Closes #806, #807 


<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
