### PR TITLE
Realm Management: do not crash on synchronous operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Return the number of results specified by `downsample_to`
   when used in combination with `format=disjoint_tables`.
   Fix [#149](https://github.com/astarte-platform/astarte/issues/149).
+- [astarte-realm_management] Do not crash when some synchronous operations
+  (e.g. interface install) succeed.
 
 ## [1.1.0] - 2023-06-20
 ### Fixed

--- a/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
@@ -174,6 +174,14 @@ defmodule Astarte.RealmManagement.RPC.Handler do
     {:ok, Reply.encode(%Reply{error: false, reply: {:generic_ok_reply, msg}})}
   end
 
+  def encode_reply(_call_atom, :ok) do
+    msg = %GenericOkReply{
+      async_operation: false
+    }
+
+    {:ok, Reply.encode(%Reply{error: false, reply: {:generic_ok_reply, msg}})}
+  end
+
   def encode_reply(_call_atom, {:error, :retry}) do
     {:error, :retry}
   end


### PR DESCRIPTION
Successful synchronous operations (e.g. installation of an interface) may have led to a crash when the response was not encoded. Add back a removed clause to the encoding reply function to fix it.