### PR TITLE
[CI] Fix self reference in Test Container Builds workflow

### DIFF
--- a/.github/workflows/pr-container-build-workflow.yaml
+++ b/.github/workflows/pr-container-build-workflow.yaml
@@ -5,7 +5,7 @@ on:
     paths:
     - '**/Dockerfile'
     - '**/entrypoint.sh'
-    - '.github/pr-container-build-workflow.yaml'
+    - '.github/workflows/pr-container-build-workflow.yaml'
 
 jobs:
   test-build-container:
@@ -25,7 +25,7 @@ jobs:
         - astarte_realm_management_api
         - astarte_trigger_engine
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Building Docker Image
       env:
         CONTAINER_IMAGE_NAME: gh_actions_test


### PR DESCRIPTION
Fix path to `pr-container-build-workflow.yaml`.
Update checkout action to the latest version to remove deprecation warnings.
