### PR TITLE
AppEngine: display device deletion status in details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   using the `/config/device_registration_limit` endpoint.
 - [astarte_housekeeping_api] Allow to read and set a realm's device registration
   limit using the realm fetch and update API, respectively.
+- [astarte_appengine_api] Show deletion status in device details.
 
 ### Changed
 - Forward port changes from release 1.1.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
@@ -40,6 +40,7 @@ defmodule Astarte.AppEngine.API.Device.DeviceStatus do
     field :total_received_bytes, :integer
     field :previous_interfaces, {:array, :map}
     field :groups, {:array, :string}
+    field :deletion_in_progress, :boolean, default: false
   end
 
   @doc false

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/device_status_view.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/device_status_view.ex
@@ -66,7 +66,8 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusView do
       previous_interfaces:
         render_many(device_status.previous_interfaces, DeviceStatusView, "interface_info.json",
           as: :interface_info
-        )
+        ),
+      deletion_in_progress: device_status.deletion_in_progress
     }
   end
 

--- a/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml
+++ b/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml
@@ -1154,6 +1154,9 @@ components:
                   The number of exchanged bytes of this interface. Note that exchanged bytes
                   are the same for all (interface, major) combinations, i.e. com.my.Interface v1.2
                   will have the same exchanged_bytes of com.my.Interface v1.x for every value of x
+        deletion_in_progress:
+          type: boolean
+          description: True if the device is currently being deleted, false otherwise.
       example:
         id: hm8AjtbN5P2mxo_gfXSfvQ
         aliases:
@@ -1191,6 +1194,7 @@ components:
             minor: 1
             exchanged_msgs: 5
             exchanged_bytes: 102
+        deletion_in_progress: false
     CreateGroupConfig:
       type: object
       required:

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
@@ -146,7 +146,8 @@ defmodule Astarte.AppEngine.API.DeviceTest do
     total_received_bytes: 4_500_000,
     total_received_msgs: 45000,
     previous_interfaces: @expected_previous_interfaces,
-    groups: []
+    groups: [],
+    deletion_in_progress: false
   }
 
   setup do
@@ -1817,6 +1818,9 @@ defmodule Astarte.AppEngine.API.DeviceTest do
              {:ok, <<12, 172, 90, 121, 159, 75, 205, 70, 75, 207, 181, 143, 77, 48, 4, 0>>}
 
     assert Device.device_alias_to_device_id("autotestrealm", "device_e") ==
+             {:ok, <<122, 19, 105, 108, 245, 109, 67, 96, 156, 116, 151, 73, 43, 116, 20, 148>>}
+
+    assert Device.device_alias_to_device_id("autotestrealm", "device_f") ==
              {:error, :device_not_found}
   end
 
@@ -2062,6 +2066,7 @@ defmodule Astarte.AppEngine.API.DeviceTest do
       "4UQbIokuRufdtbVZt9AsLg",
       "DKxaeZ9LzUZLz7WPTTAEAA",
       "aWag-VlVKC--1S-vfzZ9uQ",
+      "ehNpbPVtQ2CcdJdJK3QUlA",
       "f0VMRgIBAQAAAAAAAAAAAA",
       "olFkumNuZ_J0f_d6-8XCDg"
     ]
@@ -2086,10 +2091,13 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
         "olFkumNuZ_J0f_d6-8XCDg" ->
           assert device.total_received_bytes == 10
+
+        "ehNpbPVtQ2CcdJdJK3QUlA" ->
+          assert device.deletion_in_progress == true
       end
     end
 
-    assert length(devices_with_details) == 5
+    assert length(devices_with_details) == 6
   end
 
   defp retrieve_next_devices_list(
@@ -2123,6 +2131,18 @@ defmodule Astarte.AppEngine.API.DeviceTest do
   test "get_device_status!/2 returns the device_status with given id" do
     assert Device.get_device_status!("autotestrealm", @expected_device_status.id) ==
              {:ok, @expected_device_status}
+  end
+
+  test "get_device_status!/2 returns the device_status with correct deletion_in_progress value" do
+    deleted_device_id = "ehNpbPVtQ2CcdJdJK3QUlA"
+
+    assert {:ok, deleted_device_status} =
+             Device.get_device_status!("autotestrealm", deleted_device_id)
+
+    assert %{
+             id: ^deleted_device_id,
+             deletion_in_progress: true
+           } = deleted_device_status
   end
 
   defp unpack_interface_values({:ok, %InterfaceValues{data: values}}) do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_alias_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_alias_controller_test.exs
@@ -83,7 +83,8 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusByAliasControllerTest do
     "total_received_bytes" => 4_500_000,
     "total_received_msgs" => 45000,
     "previous_interfaces" => @expected_previous_interfaces,
-    "groups" => []
+    "groups" => [],
+    "deletion_in_progress" => false
   }
 
   setup_all do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_group_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_group_controller_test.exs
@@ -94,7 +94,8 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusByGroupControllerTest do
     "total_received_bytes" => 4_500_000,
     "total_received_msgs" => 45000,
     "previous_interfaces" => @expected_previous_interfaces,
-    "groups" => [@group_name]
+    "groups" => [@group_name],
+    "deletion_in_progress" => false
   }
 
   setup_all do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_controller_test.exs
@@ -83,7 +83,8 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusControllerTest do
     "total_received_bytes" => 4_500_000,
     "total_received_msgs" => 45000,
     "previous_interfaces" => @expected_previous_interfaces,
-    "groups" => []
+    "groups" => [],
+    "deletion_in_progress" => false
   }
 
   setup_all do
@@ -253,6 +254,7 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusControllerTest do
           "4UQbIokuRufdtbVZt9AsLg",
           "DKxaeZ9LzUZLz7WPTTAEAA",
           "aWag-VlVKC--1S-vfzZ9uQ",
+          "ehNpbPVtQ2CcdJdJK3QUlA",
           "f0VMRgIBAQAAAAAAAAAAAA",
           "olFkumNuZ_J0f_d6-8XCDg"
         ],


### PR DESCRIPTION
 Deletion status is be displayed both for detailed device list and for device status.
 Device details now include the `deletion_in_progress` field. In case of database error, it defaults to `false` (as done for the `connected` field).
 
 Note that this implies one more query for each device, as the deletion status is stored in the deletion_in_progress table.
 
 Close #881.