### PR TITLE
BREAKING: Incoming introspection event introspection map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update Erlang/OTP to 26.1.
 - Update container base image to Debian `Bookworm`.
 - Container user has changed from `root` to `nobody`.
+- BREAKING: incoming_introspection events display introspection as a map rather
+  than a plaintext string. Revert to the old behaviour by setting
+  `DATA_UPDATER_PLANT_GENERATE_LEGACY_INCOMING_INTROSPECTION_EVENTS` to `true`.
+  See https://github.com/astarte-platform/astarte_core/pull/77.
 
 ## [1.1.1] - 2023-11-15
 ### Fixed

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -220,6 +220,14 @@ defmodule Astarte.DataUpdaterPlant.Config do
           type: :integer,
           default: 60 * 60 * 1_000
 
+  @envdoc "Generate incoming_introspection events in the old (pre-1.2) string-based format. Defaults to false."
+  app_env :generate_legacy_incoming_introspection_events,
+          :astarte_data_updater_plant,
+          :generate_legacy_introspection_events,
+          os_env: "DATA_UPDATER_PLANT_GENERATE_LEGACY_INCOMING_INTROSPECTION_EVENTS",
+          type: :boolean,
+          default: false
+
   @doc """
   Returns the AMQP data consumer connection options
   """

--- a/apps/astarte_data_updater_plant/mix.lock
+++ b/apps/astarte_data_updater_plant/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "3.3.0", "056d9f4bac96c3ab5a904b321e70e78b91ba594766a1fc2f32afd9c016d9f43b", [:mix], [{:amqp_client, "~> 3.9", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "8d3ae139d2646c630d674a1b8d68c7f85134f9e8b2a1c3dd5621616994b10a8b"},
   "amqp_client": {:hex, :amqp_client, "3.12.10", "dcc0d5d0037fa2b486c6eb8b52695503765b96f919e38ca864a7b300b829742d", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "16a23959899a82d9c2534ed1dcf1fa281d3b660fb7f78426b880647f0a53731f"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "685ca10c7a07cc9806f2c6fc7ec2ed1b4d23cbec", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "5335b0d6e9cd33c302a69c3ac905787515244750", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "45d4d20ae662751f47f4b8f2f9d5e302d5485ea9", []},
   "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "5adf50beffa0bac18d99ebe378bc677c7669a767", []},
   "castore": {:hex, :castore, "0.1.16", "2675f717adc700475345c5512c381ef9273eb5df26bdd3f8c13e2636cf4cc175", [:mix], [], "hexpm", "28ed2c43d83b5c25d35c51bc0abf229ac51359c170cba76171a462ced2e4b651"},

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
@@ -30,6 +30,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
   alias Astarte.Core.Triggers.SimpleEvents.InterfaceAddedEvent
   alias Astarte.Core.Triggers.SimpleEvents.InterfaceRemovedEvent
   alias Astarte.Core.Triggers.SimpleEvents.InterfaceMinorUpdatedEvent
+  alias Astarte.Core.Triggers.SimpleEvents.InterfaceVersion
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.AMQPTriggerTarget
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.DataTrigger
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.DeviceTrigger
@@ -76,6 +77,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     received_bytes = 4_500_000
     existing_introspection_map = %{"com.test.LCDMonitor" => 1, "com.test.SimpleStreamTest" => 1}
     existing_introspection_string = "com.test.LCDMonitor:1:0;com.test.SimpleStreamTest:1:0"
+
+    existing_introspection_proto_map = %{
+      "com.test.LCDMonitor" => %InterfaceVersion{major: 1, minor: 0},
+      "com.test.SimpleStreamTest" => %InterfaceVersion{major: 1, minor: 0}
+    }
 
     insert_opts = [
       introspection: existing_introspection_map,
@@ -288,7 +294,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
              event: {
                :incoming_introspection_event,
                %IncomingIntrospectionEvent{
-                 introspection: existing_introspection_string
+                 introspection_map: existing_introspection_proto_map
                }
              },
              timestamp: timestamp_ms,

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
@@ -17,6 +17,8 @@
 #
 
 defmodule Astarte.TriggerEngine.EventsConsumer do
+  alias Astarte.Core.Triggers.SimpleEvents.IncomingIntrospectionEvent
+  alias Astarte.Core.Triggers.SimpleEvents.InterfaceVersion
   alias Astarte.Core.Triggers.SimpleEvents.SimpleEvent
   alias Astarte.Core.Triggers.Trigger
   alias Astarte.DataAccess.Database
@@ -161,12 +163,15 @@ defmodule Astarte.TriggerEngine.EventsConsumer do
          },
          _timestamp_ms
        ) do
+    event = maybe_normalize_introspection_event(event)
     values = build_values_map(realm, device_id, event_type, event)
 
     {:ok, :bbmustache.render(template, values, key_type: :binary)}
   end
 
   defp event_to_payload(_realm, device_id, _event_type, event, _action, timestamp_ms) do
+    event = maybe_normalize_introspection_event(event)
+
     with {:ok, timestamp} <- DateTime.from_unix(timestamp_ms, :millisecond) do
       %{
         "timestamp" => timestamp,
@@ -184,6 +189,28 @@ defmodule Astarte.TriggerEngine.EventsConsumer do
   defp build_request_opts(_action) do
     []
   end
+
+  # If introspection = nil, it means we are using the introspection map format
+  # instead of the old one (pre-1.2) where introspection is a string
+  defp maybe_normalize_introspection_event(
+         %IncomingIntrospectionEvent{introspection: nil} = event
+       ) do
+    %IncomingIntrospectionEvent{introspection_map: introspection_map} = event
+
+    Enum.reduce(introspection_map, fn {interface_name, version}, acc ->
+      %InterfaceVersion{
+        major: version_major,
+        minor: version_minor
+      } = version
+
+      Map.put_new(acc, interface_name, %{
+        major: version_major,
+        minor: version_minor
+      })
+    end)
+  end
+
+  defp maybe_normalize_introspection_event(event), do: event
 
   defp execute_action(payload, headers, action) do
     with {:ok, method, url} <- fetch_method_and_url(action),

--- a/apps/astarte_trigger_engine/mix.lock
+++ b/apps/astarte_trigger_engine/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "3.3.0", "056d9f4bac96c3ab5a904b321e70e78b91ba594766a1fc2f32afd9c016d9f43b", [:mix], [{:amqp_client, "~> 3.9", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "8d3ae139d2646c630d674a1b8d68c7f85134f9e8b2a1c3dd5621616994b10a8b"},
   "amqp_client": {:hex, :amqp_client, "3.12.10", "dcc0d5d0037fa2b486c6eb8b52695503765b96f919e38ca864a7b300b829742d", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "16a23959899a82d9c2534ed1dcf1fa281d3b660fb7f78426b880647f0a53731f"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "685ca10c7a07cc9806f2c6fc7ec2ed1b4d23cbec", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "5335b0d6e9cd33c302a69c3ac905787515244750", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "45d4d20ae662751f47f4b8f2f9d5e302d5485ea9", []},
   "bbmustache": {:hex, :bbmustache, "1.11.0", "a6dbfc5cee3e1d7d17aad5f5b8880b4508d974611da8d73e1f6c28bde65d4c47", [:rebar3], [], "hexpm", "7c9cdcf58dc043377ab792a8c7109d8902695fcae3b35c1078a8b38ddcf86e5f"},
   "castore": {:hex, :castore, "0.1.22", "4127549e411bedd012ca3a308dede574f43819fe9394254ca55ab4895abfa1a2", [:mix], [], "hexpm", "c17576df47eb5aa1ee40cc4134316a99f5cad3e215d5c77b8dd3cfef12a22cac"},


### PR DESCRIPTION
Now that astarte_core defines introspection as a map interface_name => %IntrospectionEntry{major: _, minor: _}
rather than a plaintext string in incoming introspection triggers, this should be handled in DUP and TE (see https://github.com/astarte-platform/astarte_core/pull/77).

AMQP trigger events are defined in astarte_core, while HTTP trigger events will return introspection as a JSON map interface_name -> {major, minor} instead of the plain introspection string sent by the device. 

It is possible to revert to the old behaviour by setting the `DATA_UPDATER_PLANT_GENERATE_LEGACY_INCOMING_INTROSPECTION_EVENTS` flag to `true` (default: `false`).
This change is thus BREAKING.

