### PR TITLE
RM: do not fail to delete device if there are no individual interfaces

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/device_remover.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/device_remover.ex
@@ -36,10 +36,10 @@ defmodule Astarte.RealmManagement.DeviceRemoval.DeviceRemover do
     encoded_device_id = Device.encode_device_id(device_id)
     _ = Logger.info("Starting to remove device #{encoded_device_id}", tag: "device_delete_start")
 
-    Queries.retrieve_individual_datastreams_keys!(realm_name, device_id)
+    retrieve_individual_datastreams_keys!(realm_name, device_id)
     |> Enum.each(&delete_individual_datastreams_from_key!(realm_name, &1))
 
-    Queries.retrieve_individual_properties_keys!(realm_name, device_id)
+    retrieve_individual_properties_keys!(realm_name, device_id)
     |> Enum.each(&delete_individual_properties_from_key!(realm_name, &1))
 
     retrieve_object_datastream_keys!(realm_name, device_id)
@@ -58,6 +58,22 @@ defmodule Astarte.RealmManagement.DeviceRemoval.DeviceRemover do
     Queries.remove_device_from_deletion_in_progress!(realm_name, device_id)
     _ = Logger.info("Successfully removed device #{encoded_device_id}", tag: "device_delete_ok")
     :ok
+  end
+
+  defp retrieve_individual_datastreams_keys!(realm_name, device_id) do
+    if Queries.table_exist?(realm_name, "individual_datastreams") do
+      Queries.retrieve_individual_datastreams_keys!(realm_name, device_id)
+    else
+      []
+    end
+  end
+
+  defp retrieve_individual_properties_keys!(realm_name, device_id) do
+    if Queries.table_exist?(realm_name, "individual_properties") do
+      Queries.retrieve_individual_properties_keys!(realm_name, device_id)
+    else
+      []
+    end
   end
 
   defp delete_individual_datastreams_from_key!(realm_name, key) do

--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -1711,6 +1711,27 @@ defmodule Astarte.RealmManagement.Queries do
     end
   end
 
+  def table_exist?(realm_name, table_name) do
+    Xandra.Cluster.run(
+      :xandra_device_deletion,
+      fn conn ->
+        statement = """
+        SELECT COUNT(*)
+        FROM system_schema.tables
+        WHERE keyspace_name = :keyspace_name
+        AND table_name = :table_name
+        """
+
+        params = %{keyspace_name: realm_name, table_name: table_name}
+
+        prepared = Xandra.prepare!(conn, statement)
+        page = Xandra.execute!(conn, prepared, params)
+        [%{count: table_count}] = Enum.to_list(page)
+        table_count != 0
+      end
+    )
+  end
+
   def insert_device_into_deletion_in_progress(realm_name, device_id) do
     Xandra.Cluster.run(
       :xandra_device_deletion,


### PR DESCRIPTION
Device deletion was stuck in a loop when `individual_datastreams` and `individual_properties` tables were still not configured. Add a check for the presence of the two tables before trying to delete data from them. If they are not configured, move on.

Closes #885 .
