### PR TITLE
DUP: do not crash when purge properties payload is not zlib deflated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.0.6] - Unreleased
+### Fixed
 - [astarte_appengine_api] Allow to send binaryblobarrays over server owned interfaces.
+- [astarte_data_updater_plant] Do not crash when receiving a malformed purge properties message.
 
 ## [1.0.5] - 2023-09-26
 ### Fixed

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017 - 2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1250,11 +1250,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
     timestamp_ms = div(timestamp, 10_000)
 
-    operation_result = prune_device_properties(new_state, "", timestamp_ms)
-
-    if operation_result != :ok do
-      Logger.debug("Result is #{inspect(operation_result)} further actions should be required.")
-    end
+    :ok = prune_device_properties(new_state, "", timestamp_ms)
 
     MessageTracker.ack_delivery(new_state.message_tracker, message_id)
 
@@ -1278,24 +1274,33 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
     <<_size_header::size(32), zlib_payload::binary>> = payload
 
-    decoded_payload = PayloadsDecoder.safe_inflate(zlib_payload)
+    case PayloadsDecoder.safe_inflate(zlib_payload) do
+      {:ok, decoded_payload} ->
+        :ok = prune_device_properties(new_state, decoded_payload, timestamp_ms)
+        MessageTracker.ack_delivery(new_state.message_tracker, message_id)
 
-    if decoded_payload != :error do
-      operation_result = prune_device_properties(new_state, decoded_payload, timestamp_ms)
+        %{
+          new_state
+          | total_received_msgs: new_state.total_received_msgs + 1,
+            total_received_bytes:
+              new_state.total_received_bytes + byte_size(payload) +
+                byte_size("/producer/properties")
+        }
 
-      if operation_result != :ok do
-        Logger.debug("Result is #{inspect(operation_result)} further actions should be required.")
-      end
+      :error ->
+        Logger.warn("Invalid purge_properties payload", tag: "purge_properties_error")
+
+        {:ok, new_state} = ask_clean_session(new_state, timestamp)
+        MessageTracker.discard(new_state.message_tracker, message_id)
+
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
+          %{},
+          %{realm: new_state.realm}
+        )
+
+        new_state
     end
-
-    MessageTracker.ack_delivery(new_state.message_tracker, message_id)
-
-    %{
-      new_state
-      | total_received_msgs: new_state.total_received_msgs + 1,
-        total_received_bytes:
-          new_state.total_received_bytes + byte_size(payload) + byte_size("/producer/properties")
-    }
   end
 
   def handle_control(state, "/emptyCache", _payload, message_id, timestamp) do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/payloads_decoder.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/payloads_decoder.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 Ispirata Srl
+# Copyright 2018 - 2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 #
 
 defmodule Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder do
+  require Logger
   alias Astarte.Core.Interface
 
   @max_uncompressed_payload_size 10_485_760
@@ -65,7 +66,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder do
   Safely decodes a zlib deflated binary and inflates it.
   This function avoids zip bomb vulnerabilities, and it decodes up to 10_485_760 bytes.
   """
-  @spec safe_inflate(binary) :: binary
+  @spec safe_inflate(binary) :: {:ok, binary} | :error
   def safe_inflate(zlib_payload) do
     z = :zlib.open()
     :ok = :zlib.inflateInit(z)
@@ -77,7 +78,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder do
         acc + byte_size(output_block)
       end)
 
-    deflated_payload =
+    inflated_result =
       if uncompressed_size < @max_uncompressed_payload_size do
         output_acc =
           List.foldl(output_list, <<>>, fn output_block, acc ->
@@ -92,7 +93,16 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder do
     :zlib.inflateEnd(z)
     :zlib.close(z)
 
-    deflated_payload
+    inflated_result
+  catch
+    # :zlib functions might throw errors, catch them so we do not crash
+    :error, error ->
+      _ =
+        Logger.warn("Received invalid deflated zlib payload: #{inspect(error)}",
+          tag: "inflate_fail"
+        )
+
+      :error
   end
 
   defp safe_inflate_loop(z, output_acc, size_acc, :continue) do
@@ -116,7 +126,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder do
   end
 
   defp safe_inflate_loop(_z, output_acc, _size_acc, :finished) do
-    output_acc
+    {:ok, output_acc}
   end
 
   @doc """

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/payloads_decoder_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/payloads_decoder_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 Ispirata Srl
+# Copyright 2018 - 2023 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -160,17 +160,17 @@ defmodule Astarte.DataUpdaterPlant.PayloadsDecoderTest do
     short_message = "SHORT MESSAGE"
     compressed = simple_deflate(short_message)
 
-    assert PayloadsDecoder.safe_inflate(compressed) == short_message
+    assert PayloadsDecoder.safe_inflate(compressed) == {:ok, short_message}
 
     empty_message = ""
     compressed = simple_deflate(empty_message)
 
-    assert PayloadsDecoder.safe_inflate(compressed) == empty_message
+    assert PayloadsDecoder.safe_inflate(compressed) == {:ok, empty_message}
 
     rand_bytes = :crypto.strong_rand_bytes(10_485_760 - 1)
     compressed = simple_deflate(rand_bytes)
 
-    assert PayloadsDecoder.safe_inflate(compressed) == rand_bytes
+    assert PayloadsDecoder.safe_inflate(compressed) == {:ok, rand_bytes}
 
     rand_bytes_bigger = :crypto.strong_rand_bytes(10_485_760)
     compressed = simple_deflate(rand_bytes_bigger)
@@ -185,11 +185,16 @@ defmodule Astarte.DataUpdaterPlant.PayloadsDecoderTest do
 
     compressed = simple_deflate(zeroed_bytes)
 
-    assert PayloadsDecoder.safe_inflate(compressed) == zeroed_bytes
+    assert PayloadsDecoder.safe_inflate(compressed) == {:ok, zeroed_bytes}
 
     compressed = simple_deflate(zeroed_bytes <> <<0>>)
 
     assert PayloadsDecoder.safe_inflate(compressed) == :error
+  end
+
+  test "zlib inflate does not crash with a payload that is not zlib deflated" do
+    non_zlib_deflated_bytes = <<120, 185, 188, 158, 201, 217, 87, 12, 0, 251>>
+    assert PayloadsDecoder.safe_inflate(non_zlib_deflated_bytes) == :error
   end
 
   test "device properties paths payload decode" do


### PR DESCRIPTION
Due to a quirk in OTP's zlib library, the `safe_inflate/1` function can actually throw an error if the payload is malformed.
> In all functions errors, {'EXIT',{Reason,Backtrace}}, can be thrown, where Reason describes the error.


The unhandled error made the `DataUpdater` process crash, resulting in the malformed purge properties message being requeued and so on and so forth.
Fix this behaviour by wrapping relevant `:zlib` calls in a try-catch block.