### PR TITLE
Astarte: update /version endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_housekeeping_api] Allow to read and set a realm's device registration
   limit using the realm fetch and update API, respectively.
 - [astarte_appengine_api] Show deletion status in device details.
+- [astarte_appengine_api] Add /version endpoint which returns the microservice
+  application version.
+- [astarte_realm_management_api] Add /version endpoint which returns
+  the microservice application version.
+- [astarte_pairing_api] Add /version endpoint which returns the microservice
+  application version.
+- [astarte_housekeeping_api] Add /version endpoint which returns
+  the microservice application version.
 - [astarte_housekeeping_api] Allow to customize the RPC call timeout with
   `HOUSEKEEPING_API_RPC_TIMEOUT` (default: 5 seconds).
 - Add API usage metrics.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/device_status_by_alias_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/device_status_by_alias_controller.ex
@@ -23,8 +23,6 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusByAliasController do
   alias Astarte.AppEngine.API.Device.DeviceStatus
   alias Astarte.AppEngine.APIWeb.DeviceStatusView
 
-  plug Astarte.AppEngine.APIWeb.Plug.LogDeviceAlias
-
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
 
   # TODO: should we allow to POST/create device aliases here by posting something like a DeviceAlias JSON object?

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/device_status_by_group_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/device_status_by_group_controller.ex
@@ -24,9 +24,6 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusByGroupController do
   alias Astarte.AppEngine.API.Groups
   alias Astarte.AppEngine.APIWeb.DeviceStatusView
 
-  plug Astarte.AppEngine.APIWeb.Plug.LogGroupName
-  plug Astarte.AppEngine.APIWeb.Plug.LogDeviceId
-
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
 
   def index(

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/device_status_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/device_status_controller.ex
@@ -22,8 +22,6 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusController do
   alias Astarte.AppEngine.API.Device.DevicesList
   alias Astarte.AppEngine.API.Device.DeviceStatus
 
-  plug Astarte.AppEngine.APIWeb.Plug.LogDeviceId
-
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
 
   def index(conn, %{"realm_name" => realm_name, "details" => "true"} = params) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/groups_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/groups_controller.ex
@@ -22,8 +22,6 @@ defmodule Astarte.AppEngine.APIWeb.GroupsController do
   alias Astarte.AppEngine.API.Groups
   alias Astarte.AppEngine.API.Groups.Group
 
-  plug Astarte.AppEngine.APIWeb.Plug.LogGroupName
-
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
 
   def index(conn, %{"realm_name" => realm_name}) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_by_device_alias_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_by_device_alias_controller.ex
@@ -23,11 +23,6 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByDeviceAliasController do
   alias Astarte.AppEngine.API.Device.InterfaceValues
   alias Astarte.AppEngine.APIWeb.InterfaceValuesView
 
-  plug Astarte.AppEngine.APIWeb.Plug.JoinPath
-  plug Astarte.AppEngine.APIWeb.Plug.LogDeviceAlias
-  plug Astarte.AppEngine.APIWeb.Plug.LogInterface
-  plug Astarte.AppEngine.APIWeb.Plug.LogPath
-
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
 
   def index(conn, %{"realm_name" => realm_name, "device_alias" => device_alias}) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_by_group_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_by_group_controller.ex
@@ -24,12 +24,6 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupController do
   alias Astarte.AppEngine.API.Groups
   alias Astarte.AppEngine.APIWeb.InterfaceValuesView
 
-  plug Astarte.AppEngine.APIWeb.Plug.JoinPath
-  plug Astarte.AppEngine.APIWeb.Plug.LogGroupName
-  plug Astarte.AppEngine.APIWeb.Plug.LogDeviceId
-  plug Astarte.AppEngine.APIWeb.Plug.LogInterface
-  plug Astarte.AppEngine.APIWeb.Plug.LogPath
-
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
 
   def index(conn, %{

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_controller.ex
@@ -20,11 +20,6 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesController do
   alias Astarte.AppEngine.API.Device
   alias Astarte.AppEngine.API.Device.InterfaceValues
 
-  plug Astarte.AppEngine.APIWeb.Plug.JoinPath
-  plug Astarte.AppEngine.APIWeb.Plug.LogDeviceId
-  plug Astarte.AppEngine.APIWeb.Plug.LogInterface
-  plug Astarte.AppEngine.APIWeb.Plug.LogPath
-
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
 
   def index(conn, %{"realm_name" => realm_name, "device_id" => device_id}) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
@@ -130,6 +130,10 @@ defmodule Astarte.AppEngine.APIWeb.Router do
       disable_validator: true
   end
 
+  scope "/version", Astarte.AppEngine.APIWeb do
+    get "/", VersionController, :show
+  end
+
   defp maybe_halt_swagger(conn, _opts) do
     if Application.get_env(:astarte_appengine_api, :swagger_ui, false) do
       conn

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
@@ -19,10 +19,28 @@ defmodule Astarte.AppEngine.APIWeb.Router do
   use Astarte.AppEngine.APIWeb, :router
   alias Astarte.AppEngine.APIWeb.Plug.LogRealm
 
-  pipeline :api do
+  pipeline :realm_api do
     plug :accepts, ["json"]
     plug LogRealm
     plug Astarte.AppEngine.APIWeb.Plug.AuthorizePath
+  end
+
+  pipeline :device_api do
+    plug Astarte.AppEngine.APIWeb.Plug.LogDeviceId
+  end
+
+  pipeline :device_group_api do
+    plug Astarte.AppEngine.APIWeb.Plug.LogGroupName
+  end
+
+  pipeline :device_alias_api do
+    plug Astarte.AppEngine.APIWeb.Plug.LogDeviceAlias
+  end
+
+  pipeline :interface_value_api do
+    plug Astarte.AppEngine.APIWeb.Plug.JoinPath
+    plug Astarte.AppEngine.APIWeb.Plug.LogInterface
+    plug Astarte.AppEngine.APIWeb.Plug.LogPath
   end
 
   pipeline :swagger do
@@ -30,7 +48,7 @@ defmodule Astarte.AppEngine.APIWeb.Router do
   end
 
   scope "/v1/:realm_name", Astarte.AppEngine.APIWeb do
-    pipe_through :api
+    pipe_through :realm_api
 
     get "/version", VersionController, :show
 
@@ -38,87 +56,117 @@ defmodule Astarte.AppEngine.APIWeb.Router do
       get "/devices", StatsController, :show_devices_stats
     end
 
-    resources "/devices", DeviceStatusController,
-      only: [:index, :show, :update],
-      param: "device_id"
+    scope "/devices" do
+      pipe_through :device_api
 
-    resources "/devices-by-alias", DeviceStatusByAliasController,
-      only: [:index, :show, :update],
-      param: "device_alias"
+      resources "/", DeviceStatusController,
+        only: [:index, :show, :update],
+        param: "device_id"
 
-    resources "/devices/:device_id/interfaces", InterfaceValuesController,
-      only: [:index, :show],
-      param: "interface"
+      scope "/:device_id/interfaces" do
+        pipe_through :interface_value_api
 
-    get "/devices/:device_id/interfaces/:interface/*path_tokens", InterfaceValuesController, :show
+        resources "/", InterfaceValuesController,
+          only: [:index, :show],
+          param: "interface"
 
-    put "/devices/:device_id/interfaces/:interface/*path_tokens",
-        InterfaceValuesController,
-        :update
+        get "/:interface/*path_tokens", InterfaceValuesController, :show
 
-    post "/devices/:device_id/interfaces/:interface/*path_tokens",
-         InterfaceValuesController,
-         :update
+        put "/:interface/*path_tokens",
+            InterfaceValuesController,
+            :update
 
-    delete "/devices/:device_id/interfaces/:interface/*path_tokens",
-           InterfaceValuesController,
-           :delete
+        post "/:interface/*path_tokens",
+             InterfaceValuesController,
+             :update
 
-    resources "/devices-by-alias/:device_alias/interfaces",
-              InterfaceValuesByDeviceAliasController,
-              only: [:index, :show],
-              param: "interface"
+        delete "/:interface/*path_tokens",
+               InterfaceValuesController,
+               :delete
+      end
+    end
 
-    get "/devices-by-alias/:device_alias/interfaces/:interface/*path_tokens",
-        InterfaceValuesByDeviceAliasController,
-        :show
+    scope "/devices-by-alias" do
+      pipe_through :device_alias_api
 
-    put "/devices-by-alias/:device_alias/interfaces/:interface/*path_tokens",
-        InterfaceValuesByDeviceAliasController,
-        :update
+      resources "/", DeviceStatusByAliasController,
+        only: [:index, :show, :update],
+        param: "device_alias"
 
-    post "/devices-by-alias/:device_alias/interfaces/:interface/*path_tokens",
-         InterfaceValuesByDeviceAliasController,
-         :update
+      scope "/:device_alias/interfaces" do
+        pipe_through :interface_value_api
 
-    delete "/devices-by-alias/:device_alias/interfaces/:interface/*path_tokens",
-           InterfaceValuesByDeviceAliasController,
-           :delete
+        resources "/",
+                  InterfaceValuesByDeviceAliasController,
+                  only: [:index, :show],
+                  param: "interface"
 
-    get "/groups", GroupsController, :index
-    post "/groups", GroupsController, :create
-    get "/groups/:group_name", GroupsController, :show
-    post "/groups/:group_name/devices", GroupsController, :add_device
-    delete "/groups/:group_name/devices/:device_id", GroupsController, :remove_device
+        get "/:interface/*path_tokens",
+            InterfaceValuesByDeviceAliasController,
+            :show
 
-    get "/groups/:group_name/devices", DeviceStatusByGroupController, :index
-    get "/groups/:group_name/devices/:device_id", DeviceStatusByGroupController, :show
+        put "/:interface/*path_tokens",
+            InterfaceValuesByDeviceAliasController,
+            :update
 
-    patch "/groups/:group_name/devices/:device_id", DeviceStatusByGroupController, :update
+        post "/:interface/*path_tokens",
+             InterfaceValuesByDeviceAliasController,
+             :update
 
-    get "/groups/:group_name/devices/:device_id/interfaces",
-        InterfaceValuesByGroupController,
-        :index
+        delete "/:interface/*path_tokens",
+               InterfaceValuesByDeviceAliasController,
+               :delete
+      end
+    end
 
-    get "/groups/:group_name/devices/:device_id/interfaces/:interface",
-        InterfaceValuesByGroupController,
-        :show
+    scope "/groups" do
+      pipe_through :device_group_api
 
-    get "/groups/:group_name/devices/:device_id/interfaces/:interface/*path_tokens",
-        InterfaceValuesByGroupController,
-        :show
+      get "/", GroupsController, :index
+      post "/", GroupsController, :create
 
-    put "/groups/:group_name/devices/:device_id/interfaces/:interface/*path_tokens",
-        InterfaceValuesByGroupController,
-        :update
+      scope "/:group_name" do
+        get "/", GroupsController, :show
+        get "/devices", DeviceStatusByGroupController, :index
+        post "/devices", GroupsController, :add_device
 
-    post "/groups/:group_name/devices/:device_id/interfaces/:interface/*path_tokens",
-         InterfaceValuesByGroupController,
-         :update
+        scope "/devices/:device_id" do
+          pipe_through :device_api
 
-    delete "/groups/:group_name/devices/:device_id/interfaces/:interface/*path_tokens",
-           InterfaceValuesByGroupController,
-           :delete
+          get "/", DeviceStatusByGroupController, :show
+          patch "/", DeviceStatusByGroupController, :update
+          delete "/", GroupsController, :remove_device
+
+          scope "/interfaces" do
+            pipe_through :interface_value_api
+
+            get "/",
+                InterfaceValuesByGroupController,
+                :index
+
+            get "/:interface",
+                InterfaceValuesByGroupController,
+                :show
+
+            get "/:interface/*path_tokens",
+                InterfaceValuesByGroupController,
+                :show
+
+            put "/:interface/*path_tokens",
+                InterfaceValuesByGroupController,
+                :update
+
+            post "/:interface/*path_tokens",
+                 InterfaceValuesByGroupController,
+                 :update
+
+            delete "/:interface/*path_tokens",
+                   InterfaceValuesByGroupController,
+                   :delete
+          end
+        end
+      end
+    end
   end
 
   scope "/swagger" do

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/router.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/router.ex
@@ -33,4 +33,8 @@ defmodule Astarte.Housekeeping.APIWeb.Router do
 
     patch "/realms/:realm_name", RealmController, :update
   end
+
+  scope "/version", Astarte.Housekeeping.APIWeb do
+    get "/", VersionController, :show
+  end
 end

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/controllers/agent_controller.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/controllers/agent_controller.ex
@@ -24,8 +24,6 @@ defmodule Astarte.Pairing.APIWeb.AgentController do
 
   action_fallback Astarte.Pairing.APIWeb.FallbackController
 
-  plug Astarte.Pairing.APIWeb.Plug.AuthorizePath
-
   def create(conn, %{"realm_name" => realm, "data" => params}) do
     with {:ok, %DeviceRegistrationResponse{} = response} <- Agent.register_device(realm, params) do
       conn

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/controllers/device_controller.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/controllers/device_controller.ex
@@ -29,8 +29,6 @@ defmodule Astarte.Pairing.APIWeb.DeviceController do
 
   @bearer_regex ~r/bearer\:?\s+(.*)$/i
 
-  plug Astarte.Pairing.APIWeb.Plug.LogHwId
-
   action_fallback Astarte.Pairing.APIWeb.FallbackController
 
   def create_credentials(conn, %{

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
@@ -40,4 +40,8 @@ defmodule Astarte.Pairing.APIWeb.Router do
          DeviceController,
          :verify_credentials
   end
+
+  scope "/version", Astarte.Pairing.APIWeb do
+    get "/", VersionController, :show
+  end
 end

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
@@ -19,26 +19,41 @@
 defmodule Astarte.Pairing.APIWeb.Router do
   use Astarte.Pairing.APIWeb, :router
 
-  pipeline :api do
+  pipeline :realm_api do
     plug :accepts, ["json"]
     plug Astarte.Pairing.APIWeb.Plug.LogRealm
   end
 
+  pipeline :agent_api do
+    plug Astarte.Pairing.APIWeb.Plug.AuthorizePath
+  end
+
+  pipeline :devices_api do
+    plug Astarte.Pairing.APIWeb.Plug.LogHwId
+  end
+
   scope "/v1/:realm_name", Astarte.Pairing.APIWeb do
-    pipe_through :api
+    pipe_through :realm_api
 
     get "/version", VersionController, :show
 
-    post "/agent/devices", AgentController, :create
-    delete "/agent/devices/:device_id", AgentController, :delete
+    scope "/agent" do
+      pipe_through :agent_api
 
-    get "/devices/:hw_id", DeviceController, :show_info
+      post "/devices", AgentController, :create
+      delete "/devices/:device_id", AgentController, :delete
+    end
 
-    post "/devices/:hw_id/protocols/:protocol/credentials", DeviceController, :create_credentials
+    scope "/devices" do
+      pipe_through :devices_api
 
-    post "/devices/:hw_id/protocols/:protocol/credentials/verify",
-         DeviceController,
-         :verify_credentials
+      get "/:hw_id", DeviceController, :show_info
+      post "/:hw_id/protocols/:protocol/credentials", DeviceController, :create_credentials
+
+      post "/:hw_id/protocols/:protocol/credentials/verify",
+           DeviceController,
+           :verify_credentials
+    end
   end
 
   scope "/version", Astarte.Pairing.APIWeb do

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/device_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/device_controller.ex
@@ -23,9 +23,6 @@ defmodule Astarte.RealmManagement.APIWeb.DeviceController do
 
   action_fallback Astarte.RealmManagement.APIWeb.FallbackController
 
-  plug Astarte.RealmManagement.APIWeb.Plug.LogRealm
-  plug Astarte.RealmManagement.APIWeb.Plug.AuthorizePath
-
   def delete(conn, %{"realm_name" => realm_name, "device_id" => device_id}) do
     with :ok <- Devices.delete_device(realm_name, device_id) do
       send_resp(conn, :no_content, "")

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/interface_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/interface_controller.ex
@@ -24,9 +24,6 @@ defmodule Astarte.RealmManagement.APIWeb.InterfaceController do
 
   action_fallback Astarte.RealmManagement.APIWeb.FallbackController
 
-  plug Astarte.RealmManagement.APIWeb.Plug.LogRealm
-  plug Astarte.RealmManagement.APIWeb.Plug.AuthorizePath
-
   def index(conn, %{"realm_name" => realm_name}) do
     with {:ok, interfaces} <- Astarte.RealmManagement.API.Interfaces.list_interfaces(realm_name) do
       render(conn, "index.json", interfaces: interfaces)

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/interface_version_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/interface_version_controller.ex
@@ -21,9 +21,6 @@ defmodule Astarte.RealmManagement.APIWeb.InterfaceVersionController do
 
   alias Astarte.RealmManagement.API.Interfaces
 
-  plug Astarte.RealmManagement.APIWeb.Plug.LogRealm
-  plug Astarte.RealmManagement.APIWeb.Plug.AuthorizePath
-
   action_fallback Astarte.RealmManagement.APIWeb.FallbackController
 
   def index(conn, %{"realm_name" => realm_name, "id" => id}) do

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/realm_config_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/realm_config_controller.ex
@@ -24,9 +24,6 @@ defmodule Astarte.RealmManagement.APIWeb.RealmConfigController do
 
   action_fallback Astarte.RealmManagement.APIWeb.FallbackController
 
-  plug Astarte.RealmManagement.APIWeb.Plug.LogRealm
-  plug Astarte.RealmManagement.APIWeb.Plug.AuthorizePath
-
   def show(conn, %{"realm_name" => realm_name, "group" => "auth"}) do
     with {:ok, %AuthConfig{} = auth_config} = RealmConfig.get_auth_config(realm_name) do
       render(conn, "show.json", auth_config: auth_config)

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/trigger_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/trigger_controller.ex
@@ -24,9 +24,6 @@ defmodule Astarte.RealmManagement.APIWeb.TriggerController do
 
   action_fallback Astarte.RealmManagement.APIWeb.FallbackController
 
-  plug Astarte.RealmManagement.APIWeb.Plug.LogRealm
-  plug Astarte.RealmManagement.APIWeb.Plug.AuthorizePath
-
   def index(conn, %{"realm_name" => realm_name}) do
     triggers = Triggers.list_triggers(realm_name)
     render(conn, "index.json", triggers: triggers)

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/trigger_policy_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/trigger_policy_controller.ex
@@ -24,9 +24,6 @@ defmodule Astarte.RealmManagement.APIWeb.TriggerPolicyController do
 
   action_fallback(Astarte.RealmManagement.APIWeb.FallbackController)
 
-  plug(Astarte.RealmManagement.APIWeb.Plug.LogRealm)
-  plug(Astarte.RealmManagement.APIWeb.Plug.AuthorizePath)
-
   def index(conn, %{"realm_name" => realm_name}) do
     policies = Policies.list_trigger_policies(realm_name)
     render(conn, "index.json", policies: policies)

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/version_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/version_controller.ex
@@ -21,9 +21,6 @@ defmodule Astarte.RealmManagement.APIWeb.VersionController do
 
   @version Mix.Project.config()[:version]
 
-  plug Astarte.RealmManagement.APIWeb.Plug.LogRealm
-  plug Astarte.RealmManagement.APIWeb.Plug.AuthorizePath
-
   def show(conn, _params) do
     render(conn, "show.json", %{version: @version})
   end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
@@ -43,4 +43,8 @@ defmodule Astarte.RealmManagement.APIWeb.Router do
 
     delete "/devices/:device_id", DeviceController, :delete
   end
+
+  scope "/version", Astarte.RealmManagement.APIWeb do
+    get "/", VersionController, :show
+  end
 end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
@@ -21,6 +21,8 @@ defmodule Astarte.RealmManagement.APIWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug Astarte.RealmManagement.APIWeb.Plug.LogRealm
+    plug Astarte.RealmManagement.APIWeb.Plug.AuthorizePath
   end
 
   scope "/v1/:realm_name", Astarte.RealmManagement.APIWeb do


### PR DESCRIPTION
Provide third-party applications with information about the version of Astarte microservices they are interacting with, enabling them to adapt their behavior based on the underlying service version.

Standardization of routers for the Astarte API endpoints to have a uniform Phoenix pipeline structure.

Add a ```/version``` endpoint to each microservice API, allowing third-party applications to query and retrieve the microservice version using the GET verb. Authentication is not required for accessing this endpoint. 

Standardize code for Astarte APIs by refactoring the router for endpoints. Remove plugs from controllers and incorporate them into the router pipeline.

By improving code readability in the app, astarte will expose information about the microservice version to third-party applications without authorization.

(#890)

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

[*] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
[*] Make sure to open your PR against the right branch: master / release-VERSION
[*] Add to CHANGELOG.md relevant changes and any other user facing change.
[*] Make sure to sign-off all your commits
[*] GPG signing is appreciated
[*] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
