### PR TITLE
{Pairing, Housekeeping, RM} API: Handle `Bad Request`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - [astarte_appengine_api] Allow to send binaryblobarrays over server owned interfaces.
 - [astarte_data_updater_plant] Do not crash when receiving a malformed purge properties message.
+- [astarte_pairing_api] Gracefully handle HTTP requests with malformed payload.
 
 ## [1.0.5] - 2023-09-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_data_updater_plant] Do not crash when receiving a malformed purge properties message.
 - [astarte_pairing_api] Gracefully handle HTTP requests with malformed payload.
 - [astarte_housekeeping_api] Gracefully handle HTTP requests with malformed payload.
+- [astarte_realm_management_api] Gracefully handle HTTP requests with malformed payload.
 
 ## [1.0.5] - 2023-09-26
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Allow to send binaryblobarrays over server owned interfaces.
 - [astarte_data_updater_plant] Do not crash when receiving a malformed purge properties message.
 - [astarte_pairing_api] Gracefully handle HTTP requests with malformed payload.
+- [astarte_housekeeping_api] Gracefully handle HTTP requests with malformed payload.
 
 ## [1.0.5] - 2023-09-26
 ### Fixed

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/error_view.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/error_view.ex
@@ -19,6 +19,10 @@
 defmodule Astarte.Housekeeping.APIWeb.ErrorView do
   use Astarte.Housekeeping.APIWeb, :view
 
+  def render("400.json", _assigns) do
+    %{errors: %{detail: "Bad request"}}
+  end
+
   def render("404.json", _assigns) do
     %{errors: %{detail: "Page not found"}}
   end

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/views/error_view.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/views/error_view.ex
@@ -19,6 +19,10 @@
 defmodule Astarte.Pairing.APIWeb.ErrorView do
   use Astarte.Pairing.APIWeb, :view
 
+  def render("400.json", _assigns) do
+    %{errors: %{detail: "Bad request"}}
+  end
+
   def render("401.json", _assigns) do
     %{errors: %{detail: "Unauthorized"}}
   end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/error_view.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/error_view.ex
@@ -19,6 +19,10 @@
 defmodule Astarte.RealmManagement.APIWeb.ErrorView do
   use Astarte.RealmManagement.APIWeb, :view
 
+  def render("400.json", _assigns) do
+    %{errors: %{detail: "Bad request"}}
+  end
+
   def render("404.json", _assigns) do
     %{errors: %{detail: "Not found"}}
   end


### PR DESCRIPTION
Do not return an error 400 with message `"Internal server error"` if a request has an unparsable payload (e.g. a badly written CSR).
Return the more semantically correct `"Bad request"` message instead.