### PR TITLE
Metrics: expose the number of bytes sent by Trigger Engine

### DIFF
--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine_web/telemetry.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine_web/telemetry.ex
@@ -60,6 +60,10 @@ defmodule Astarte.TriggerEngineWeb.Telemetry do
         tags: [:realm, :status],
         description: "TriggerEngine total http executed actions."
       ),
+      sum("astarte.trigger_engine.http_action_executed.payload_bytes",
+        tags: [:realm, :status],
+        description: "TriggerEngine total http executed actions payload size, in bytes."
+      ),
       counter("astarte.trigger_engine.consumed_event.count",
         tags: [:realm],
         description: "TriggerEngine consumed events."


### PR DESCRIPTION
Add telemetry in order to record the cumulative amount of bytes from triggers payload, resolve #896
Add new astarte.trigger_engine.http_action_executed.payload_bytes metric
Change how triggers are handled to provide accurate metric logging for number of retries and payload size, both are cumulative.
Payload size is recorded even in case of  http error (for example, when configured API returns 500)
