### PR TITLE
Add telemetry counter for Astarte services APIs calls

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/plug/telemetry_calls_counter_plug.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/plug/telemetry_calls_counter_plug.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2023 SECO Mind Srl
+# Copyright 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,16 @@
 # limitations under the License.
 #
 
-defmodule Astarte.Housekeeping.APIWeb.Router do
-  use Astarte.Housekeeping.APIWeb, :router
-
-  pipeline :api do
-    plug :accepts, ["json"]
-    plug Astarte.Housekeeping.APIWeb.Plug.AuthorizePath
-    plug Astarte.Housekeeping.APIWeb.Plug.Telemetry.CallsCount
+defmodule Astarte.AppEngine.APIWeb.Plug.Telemetry.CallsCount do
+  def init(opts) do
+    opts
   end
 
-  scope "/v1", Astarte.Housekeeping.APIWeb do
-    pipe_through :api
+  def call(conn, _opts) do
+    :telemetry.execute([:astarte, :appengine, :api, :calls], %{}, %{
+      realm: conn.params["realm_name"]
+    })
 
-    get "/version", VersionController, :show
-
-    resources "/realms", RealmController, except: [:new, :edit, :update]
-
-    patch "/realms/:realm_name", RealmController, :update
+    conn
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
@@ -23,6 +23,7 @@ defmodule Astarte.AppEngine.APIWeb.Router do
     plug :accepts, ["json"]
     plug LogRealm
     plug Astarte.AppEngine.APIWeb.Plug.AuthorizePath
+    plug Astarte.AppEngine.APIWeb.Plug.Telemetry.CallsCount
   end
 
   pipeline :swagger do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
@@ -87,6 +87,9 @@ defmodule Astarte.AppEngine.APIWeb.Telemetry do
         tags: [:status],
         tag_values: &extract_status/1
       ),
+      counter("astarte.appengine.api.calls.count",
+        tags: [:realm]
+      ),
       counter("phoenix.router_dispatch.stop.count",
         tags: [:method, :route],
         tag_values: &extract_router_tags/1

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/plug/telemetry_calls_counter_plug.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/plug/telemetry_calls_counter_plug.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2023 SECO Mind Srl
+# Copyright 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,14 @@
 # limitations under the License.
 #
 
-defmodule Astarte.Housekeeping.APIWeb.Router do
-  use Astarte.Housekeeping.APIWeb, :router
-
-  pipeline :api do
-    plug :accepts, ["json"]
-    plug Astarte.Housekeeping.APIWeb.Plug.AuthorizePath
-    plug Astarte.Housekeeping.APIWeb.Plug.Telemetry.CallsCount
+defmodule Astarte.Housekeeping.APIWeb.Plug.Telemetry.CallsCount do
+  def init(opts) do
+    opts
   end
 
-  scope "/v1", Astarte.Housekeeping.APIWeb do
-    pipe_through :api
+  def call(conn, _opts) do
+    :telemetry.execute([:astarte, :housekeeping, :api, :calls], %{}, %{})
 
-    get "/version", VersionController, :show
-
-    resources "/realms", RealmController, except: [:new, :edit, :update]
-
-    patch "/realms/:realm_name", RealmController, :update
+    conn
   end
 end

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/telemetry.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/telemetry.ex
@@ -96,7 +96,8 @@ defmodule Astarte.Housekeeping.APIWeb.Telemetry do
       # Custom metrics
       last_value("astarte.housekeeping.service.health",
         description: "Service state: 1 if health is good, 0 if not."
-      )
+      ),
+      counter("astarte.housekeeping.api.calls.count")
     ]
   end
 

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/plug/telemetry_calls_counter_plug.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/plug/telemetry_calls_counter_plug.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2023 SECO Mind Srl
+# Copyright 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,16 @@
 # limitations under the License.
 #
 
-defmodule Astarte.Housekeeping.APIWeb.Router do
-  use Astarte.Housekeeping.APIWeb, :router
-
-  pipeline :api do
-    plug :accepts, ["json"]
-    plug Astarte.Housekeeping.APIWeb.Plug.AuthorizePath
-    plug Astarte.Housekeeping.APIWeb.Plug.Telemetry.CallsCount
+defmodule Astarte.Pairing.APIWeb.Plug.Telemetry.CallsCount do
+  def init(opts) do
+    opts
   end
 
-  scope "/v1", Astarte.Housekeeping.APIWeb do
-    pipe_through :api
+  def call(conn, _opts) do
+    :telemetry.execute([:astarte, :pairing, :api, :calls], %{}, %{
+      realm: conn.params["realm_name"]
+    })
 
-    get "/version", VersionController, :show
-
-    resources "/realms", RealmController, except: [:new, :edit, :update]
-
-    patch "/realms/:realm_name", RealmController, :update
+    conn
   end
 end

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
@@ -22,6 +22,7 @@ defmodule Astarte.Pairing.APIWeb.Router do
   pipeline :api do
     plug :accepts, ["json"]
     plug Astarte.Pairing.APIWeb.Plug.LogRealm
+    plug Astarte.Pairing.APIWeb.Plug.Telemetry.CallsCount
   end
 
   scope "/v1/:realm_name", Astarte.Pairing.APIWeb do

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/telemetry.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/telemetry.ex
@@ -97,6 +97,9 @@ defmodule Astarte.Pairing.APIWeb.Telemetry do
       last_value(
         "astarte.pairing.service.health",
         description: "Service state: 1 if good, 0 if not."
+      ),
+      counter("astarte.pairing.api.calls.count",
+        tags: [:realm]
       )
     ]
   end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/plug/telemetry_calls_counter_plug.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/plug/telemetry_calls_counter_plug.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2023 SECO Mind Srl
+# Copyright 2024 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,22 +16,16 @@
 # limitations under the License.
 #
 
-defmodule Astarte.Housekeeping.APIWeb.Router do
-  use Astarte.Housekeeping.APIWeb, :router
-
-  pipeline :api do
-    plug :accepts, ["json"]
-    plug Astarte.Housekeeping.APIWeb.Plug.AuthorizePath
-    plug Astarte.Housekeeping.APIWeb.Plug.Telemetry.CallsCount
+defmodule Astarte.RealmManagement.APIWeb.Plug.Telemetry.CallsCount do
+  def init(opts) do
+    opts
   end
 
-  scope "/v1", Astarte.Housekeeping.APIWeb do
-    pipe_through :api
+  def call(conn, _opts) do
+    :telemetry.execute([:astarte, :realm_management, :api, :calls], %{}, %{
+      realm: conn.params["realm_name"]
+    })
 
-    get "/version", VersionController, :show
-
-    resources "/realms", RealmController, except: [:new, :edit, :update]
-
-    patch "/realms/:realm_name", RealmController, :update
+    conn
   end
 end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
@@ -24,22 +24,22 @@ defmodule Astarte.RealmManagement.APIWeb.Router do
     plug Astarte.RealmManagement.APIWeb.Plug.Telemetry.CallsCount
   end
 
-  scope "/v1", Astarte.RealmManagement.APIWeb do
+  scope "/v1/:realm_name", Astarte.RealmManagement.APIWeb do
     pipe_through :api
 
-    get "/:realm_name/version", VersionController, :show
+    get "/version", VersionController, :show
 
-    get "/:realm_name/interfaces/:id", InterfaceVersionController, :index
-    resources "/:realm_name/interfaces", InterfaceController, only: [:index, :create]
-    get "/:realm_name/interfaces/:id/:major_version", InterfaceController, :show
-    put "/:realm_name/interfaces/:id/:major_version", InterfaceController, :update
-    delete "/:realm_name/interfaces/:id/:major_version", InterfaceController, :delete
-    get "/:realm_name/config/:group", RealmConfigController, :show
-    put "/:realm_name/config/:group", RealmConfigController, :update
+    get "/interfaces/:id", InterfaceVersionController, :index
+    resources "/interfaces", InterfaceController, only: [:index, :create]
+    get "/interfaces/:id/:major_version", InterfaceController, :show
+    put "/interfaces/:id/:major_version", InterfaceController, :update
+    delete "/interfaces/:id/:major_version", InterfaceController, :delete
+    get "/config/:group", RealmConfigController, :show
+    put "/config/:group", RealmConfigController, :update
 
-    resources "/:realm_name/triggers", TriggerController, except: [:new, :edit]
-    resources "/:realm_name/policies", TriggerPolicyController, except: [:new, :edit]
+    resources "/triggers", TriggerController, except: [:new, :edit]
+    resources "/policies", TriggerPolicyController, except: [:new, :edit]
 
-    delete "/:realm_name/devices/:device_id", DeviceController, :delete
+    delete "/devices/:device_id", DeviceController, :delete
   end
 end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
@@ -21,6 +21,7 @@ defmodule Astarte.RealmManagement.APIWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug Astarte.RealmManagement.APIWeb.Plug.Telemetry.CallsCount
   end
 
   scope "/v1", Astarte.RealmManagement.APIWeb do

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/telemetry.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/telemetry.ex
@@ -97,6 +97,9 @@ defmodule Astarte.RealmManagement.APIWeb.Telemetry do
       last_value(
         "astarte.realm_management.service.health",
         description: "Service state: 1 if good, 0 if not."
+      ),
+      counter("astarte.realm_management.api.calls.count",
+        tags: [:realm]
       )
     ]
   end


### PR DESCRIPTION
Add counter for APIs calls via a Plug, gouped by realm name, for the following services: appengine_api, housekeeping_api, pairing_api, realm_management_api

rewrote of routes for realm_management_api (endpoints has been kept the same)


resolve #897