### PR TITLE
Data Updater Plant: Add metrics for device total connection time

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -1901,6 +1901,15 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   defp execute_time_based_actions(state, timestamp, db_client) do
+    if state.connected && state.last_seen_message > 0 do
+      # timestamps are handled as microseconds*10, so we need to divide by 10 when saving as a metric for a coherent data
+      :telemetry.execute(
+        [:astarte, :data_updater_plant, :service, :connected_devices],
+        %{duration: Integer.floor_div(timestamp - state.last_seen_message, 10)},
+        %{realm: state.realm, status: :ok}
+      )
+    end
+
     state
     |> Map.put(:last_seen_message, timestamp)
     |> reload_groups_on_expiry(timestamp, db_client)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant_web/telemetry.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant_web/telemetry.ex
@@ -97,6 +97,9 @@ defmodule Astarte.DataUpdaterPlantWeb.Telemetry do
       last_value("astarte.data_updater_plant.service.health",
         tags: [:status],
         description: "Service state: 1 if good, 0 if not."
+      ),
+      sum("astarte.data_updater_plant.service.connected_devices.duration",
+        tags: [:realm]
       )
     ]
   end


### PR DESCRIPTION
Add device connection time as metric, based on latest device message/connection/disconnection/heartbeat
Expressed in microseconds

resolve #898
