### PR TITLE
Metrics: expose API calls details in services

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/plug/telemetry_request_count_plug.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/plug/telemetry_request_count_plug.ex
@@ -1,0 +1,53 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.AppEngine.APIWeb.Plug.Telemetry.RequestCount do
+  def init(_opts) do
+    nil
+  end
+
+  def call(conn, _opts) do
+    # The computation of request_size can take a non-negligible amount of time
+    # in the API request/response cycle, so we run it in another process.
+    Task.start(fn ->
+      :telemetry.execute(
+        [:astarte, :appengine, :api, :requests],
+        %{
+          bytes: request_size(conn.params)
+        },
+        %{
+          realm: conn.params["realm_name"]
+        }
+      )
+    end)
+
+    conn
+  end
+
+  defp request_size(request) when is_map(request) do
+    Enum.reduce(request, 0, fn {k, v}, acc -> acc + byte_size(k) + request_size(v) end)
+  end
+
+  defp request_size(request) when is_list(request) do
+    Enum.reduce(request, 0, fn e, acc -> acc + request_size(e) end)
+  end
+
+  defp request_size(request) do
+    byte_size(request)
+  end
+end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/plug/telemetry_response_count_plug.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/plug/telemetry_response_count_plug.ex
@@ -16,16 +16,26 @@
 # limitations under the License.
 #
 
-defmodule Astarte.AppEngine.APIWeb.Plug.Telemetry.CallsCount do
-  def init(opts) do
-    opts
+defmodule Astarte.AppEngine.APIWeb.Plug.Telemetry.ResponseCount do
+  import Plug.Conn
+
+  def init(_opts) do
+    nil
   end
 
-  def call(conn, _opts) do
-    :telemetry.execute([:astarte, :appengine, :api, :calls], %{}, %{
-      realm: conn.params["realm_name"]
-    })
+  def call(conn, _default) do
+    register_before_send(conn, fn conn ->
+      :telemetry.execute(
+        [:astarte, :appengine, :api, :responses],
+        %{
+          bytes: IO.iodata_length(conn.resp_body)
+        },
+        %{
+          realm: conn.params["realm_name"]
+        }
+      )
 
-    conn
+      conn
+    end)
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
@@ -23,7 +23,8 @@ defmodule Astarte.AppEngine.APIWeb.Router do
     plug :accepts, ["json"]
     plug LogRealm
     plug Astarte.AppEngine.APIWeb.Plug.AuthorizePath
-    plug Astarte.AppEngine.APIWeb.Plug.Telemetry.CallsCount
+    plug Astarte.AppEngine.APIWeb.Plug.Telemetry.RequestCount
+    plug Astarte.AppEngine.APIWeb.Plug.Telemetry.ResponseCount
   end
 
   pipeline :swagger do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
@@ -87,9 +87,6 @@ defmodule Astarte.AppEngine.APIWeb.Telemetry do
         tags: [:status],
         tag_values: &extract_status/1
       ),
-      counter("astarte.appengine.api.calls.count",
-        tags: [:realm]
-      ),
       counter("phoenix.router_dispatch.stop.count",
         tags: [:method, :route],
         tag_values: &extract_router_tags/1
@@ -125,6 +122,22 @@ defmodule Astarte.AppEngine.APIWeb.Telemetry do
         "astarte.appengine.service.health",
         tags: [:consistency_level],
         description: "Database connection state: 1 if able to query, 0 if not."
+      ),
+      counter("astarte.appengine.api.requests.count",
+        tags: [:realm],
+        description: "The number of HTTP requests sent to the service."
+      ),
+      sum("astarte.appengine.api.requests.bytes",
+        tags: [:realm],
+        description: "The total size of bytes received via HTTP requests."
+      ),
+      counter("astarte.appengine.api.responses.count",
+        tags: [:realm],
+        description: "The number of HTTP responses sent by the service."
+      ),
+      sum("astarte.appengine.api.responses.bytes",
+        tags: [:realm],
+        description: "The total size of bytes sent via HTTP responses."
       )
     ]
   end

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/plug/telemetry_response_count_plug.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/plug/telemetry_response_count_plug.ex
@@ -1,0 +1,39 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Housekeeping.APIWeb.Plug.Telemetry.ResponseCount do
+  import Plug.Conn
+
+  def init(_opts) do
+    nil
+  end
+
+  def call(conn, _default) do
+    register_before_send(conn, fn conn ->
+      :telemetry.execute(
+        [:astarte, :housekeeping, :api, :responses],
+        %{
+          bytes: IO.iodata_length(conn.resp_body)
+        },
+        %{}
+      )
+
+      conn
+    end)
+  end
+end

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/router.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/router.ex
@@ -22,7 +22,8 @@ defmodule Astarte.Housekeeping.APIWeb.Router do
   pipeline :api do
     plug :accepts, ["json"]
     plug Astarte.Housekeeping.APIWeb.Plug.AuthorizePath
-    plug Astarte.Housekeeping.APIWeb.Plug.Telemetry.CallsCount
+    plug Astarte.Housekeeping.APIWeb.Plug.Telemetry.RequestCount
+    plug Astarte.Housekeeping.APIWeb.Plug.Telemetry.ResponseCount
   end
 
   scope "/v1", Astarte.Housekeeping.APIWeb do

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/telemetry.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/telemetry.ex
@@ -97,7 +97,18 @@ defmodule Astarte.Housekeeping.APIWeb.Telemetry do
       last_value("astarte.housekeeping.service.health",
         description: "Service state: 1 if health is good, 0 if not."
       ),
-      counter("astarte.housekeeping.api.calls.count")
+      counter("astarte.housekeeping.api.requests.count",
+        description: "The number of HTTP requests sent to the service."
+      ),
+      sum("astarte.housekeeping.api.requests.bytes",
+        description: "The total size of bytes received via HTTP requests."
+      ),
+      counter("astarte.housekeeping.api.responses.count",
+        description: "The number of HTTP responses sent by the service."
+      ),
+      sum("astarte.housekeeping.api.responses.bytes",
+        description: "The total size of bytes sent via HTTP responses."
+      )
     ]
   end
 

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/plug/telemetry_request_count_plug.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/plug/telemetry_request_count_plug.ex
@@ -1,0 +1,49 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.APIWeb.Plug.Telemetry.RequestCount do
+  def init(_opts) do
+    nil
+  end
+
+  def call(conn, _opts) do
+    # The computation of request_size can take a non-negligible amount of time
+    # in the API request/response cycle, so we run it in another process.
+    Task.start(fn ->
+      :telemetry.execute(
+        [:astarte, :pairing, :api, :requests],
+        %{
+          bytes: request_size(conn.params)
+        },
+        %{
+          realm: conn.params["realm_name"]
+        }
+      )
+    end)
+
+    conn
+  end
+
+  defp request_size(request) when is_map(request) do
+    Enum.reduce(request, 0, fn {k, v}, acc -> acc + byte_size(k) + request_size(v) end)
+  end
+
+  defp request_size(request) do
+    byte_size(request)
+  end
+end

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/plug/telemetry_response_count_plug.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/plug/telemetry_response_count_plug.ex
@@ -16,16 +16,26 @@
 # limitations under the License.
 #
 
-defmodule Astarte.Pairing.APIWeb.Plug.Telemetry.CallsCount do
-  def init(opts) do
-    opts
+defmodule Astarte.Pairing.APIWeb.Plug.Telemetry.ResponseCount do
+  import Plug.Conn
+
+  def init(_opts) do
+    nil
   end
 
-  def call(conn, _opts) do
-    :telemetry.execute([:astarte, :pairing, :api, :calls], %{}, %{
-      realm: conn.params["realm_name"]
-    })
+  def call(conn, _default) do
+    register_before_send(conn, fn conn ->
+      :telemetry.execute(
+        [:astarte, :pairing, :api, :responses],
+        %{
+          bytes: IO.iodata_length(conn.resp_body)
+        },
+        %{
+          realm: conn.params["realm_name"]
+        }
+      )
 
-    conn
+      conn
+    end)
   end
 end

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
@@ -22,7 +22,8 @@ defmodule Astarte.Pairing.APIWeb.Router do
   pipeline :api do
     plug :accepts, ["json"]
     plug Astarte.Pairing.APIWeb.Plug.LogRealm
-    plug Astarte.Pairing.APIWeb.Plug.Telemetry.CallsCount
+    plug Astarte.Pairing.APIWeb.Plug.Telemetry.RequestCount
+    plug Astarte.Pairing.APIWeb.Plug.Telemetry.ResponseCount
   end
 
   scope "/v1/:realm_name", Astarte.Pairing.APIWeb do

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/telemetry.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/telemetry.ex
@@ -98,8 +98,21 @@ defmodule Astarte.Pairing.APIWeb.Telemetry do
         "astarte.pairing.service.health",
         description: "Service state: 1 if good, 0 if not."
       ),
-      counter("astarte.pairing.api.calls.count",
-        tags: [:realm]
+      counter("astarte.pairing.api.requests.count",
+        tags: [:realm],
+        description: "The number of HTTP requests sent to the service."
+      ),
+      sum("astarte.pairing.api.requests.bytes",
+        tags: [:realm],
+        description: "The total size of bytes received via HTTP requests."
+      ),
+      counter("astarte.pairing.api.responses.count",
+        tags: [:realm],
+        description: "The number of HTTP responses sent by the service."
+      ),
+      sum("astarte.pairing.api.responses.bytes",
+        tags: [:realm],
+        description: "The total size of bytes sent via HTTP responses."
       )
     ]
   end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/plug/telemetry_request_count_plug.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/plug/telemetry_request_count_plug.ex
@@ -1,0 +1,53 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagement.APIWeb.Plug.Telemetry.RequestCount do
+  def init(opts) do
+    opts
+  end
+
+  def call(conn, _opts) do
+    # The computation of request_size can take a non-negligible amount of time
+    # in the API request/response cycle, so we run it in another process.
+    Task.start(fn ->
+      :telemetry.execute(
+        [:astarte, :realm_management, :api, :requests],
+        %{
+          bytes: request_size(conn.params)
+        },
+        %{
+          realm: conn.params["realm_name"]
+        }
+      )
+    end)
+
+    conn
+  end
+
+  defp request_size(request) when is_map(request) do
+    Enum.reduce(request, 0, fn {k, v}, acc -> acc + byte_size(k) + request_size(v) end)
+  end
+
+  defp request_size(request) when is_list(request) do
+    Enum.reduce(request, 0, fn e, acc -> acc + request_size(e) end)
+  end
+
+  defp request_size(request) do
+    byte_size(request)
+  end
+end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/plug/telemetry_response_count_plug.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/plug/telemetry_response_count_plug.ex
@@ -16,16 +16,26 @@
 # limitations under the License.
 #
 
-defmodule Astarte.RealmManagement.APIWeb.Plug.Telemetry.CallsCount do
-  def init(opts) do
-    opts
+defmodule Astarte.RealmManagement.APIWeb.Plug.Telemetry.ResponseCount do
+  import Plug.Conn
+
+  def init(_opts) do
+    nil
   end
 
-  def call(conn, _opts) do
-    :telemetry.execute([:astarte, :realm_management, :api, :calls], %{}, %{
-      realm: conn.params["realm_name"]
-    })
+  def call(conn, _default) do
+    register_before_send(conn, fn conn ->
+      :telemetry.execute(
+        [:astarte, :realm_management, :api, :responses],
+        %{
+          bytes: IO.iodata_length(conn.resp_body)
+        },
+        %{
+          realm: conn.params["realm_name"]
+        }
+      )
 
-    conn
+      conn
+    end)
   end
 end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/router.ex
@@ -21,7 +21,8 @@ defmodule Astarte.RealmManagement.APIWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
-    plug Astarte.RealmManagement.APIWeb.Plug.Telemetry.CallsCount
+    plug Astarte.RealmManagement.APIWeb.Plug.Telemetry.RequestCount
+    plug Astarte.RealmManagement.APIWeb.Plug.Telemetry.ResponseCount
   end
 
   scope "/v1/:realm_name", Astarte.RealmManagement.APIWeb do

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/telemetry.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/telemetry.ex
@@ -98,8 +98,21 @@ defmodule Astarte.RealmManagement.APIWeb.Telemetry do
         "astarte.realm_management.service.health",
         description: "Service state: 1 if good, 0 if not."
       ),
-      counter("astarte.realm_management.api.calls.count",
-        tags: [:realm]
+      counter("astarte.realm_management.api.requests.count",
+        tags: [:realm],
+        description: "The number of HTTP requests sent to the service."
+      ),
+      sum("astarte.realm_management.api.requests.bytes",
+        tags: [:realm],
+        description: "The total size of bytes received via HTTP requests."
+      ),
+      counter("astarte.realm_management.api.responses.count",
+        tags: [:realm],
+        description: "The number of HTTP responses sent by the service."
+      ),
+      sum("astarte.realm_management.api.responses.bytes",
+        tags: [:realm],
+        description: "The total size of bytes sent via HTTP responses."
       )
     ]
   end


### PR DESCRIPTION
Add the total number of bytes exchanged via HTTP to metrics (both sent and received).
In general, each API service now exposes four new metrics:
- `<service_name>_requests_count`
- `<service_name>_requests_bytes`
- `<service_name>_responses_count`
- `<service_name>_responses_bytes`

Values are tagged by realm name, except for Housekeeping API.

In order not to slow down the handling of incoming calls, count and byte size are computed in a different process.