### PR TITLE
HK API: allow longer timeouts for calls to backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_housekeeping_api] Allow to read and set a realm's device registration
   limit using the realm fetch and update API, respectively.
 - [astarte_appengine_api] Show deletion status in device details.
+- [astarte_housekeeping_api] Allow to customize the RPC call timeout with
+  `HOUSEKEEPING_API_RPC_TIMEOUT` (default: 5 seconds).
 
 ### Changed
 - Forward port changes from release 1.1.

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/config.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/config.ex
@@ -47,6 +47,14 @@ defmodule Astarte.Housekeeping.API.Config do
     type: :unsafe_module,
     default: Astarte.RPC.AMQP.Client
 
+  @envdoc """
+  Timeout for RPC calls to Housekeeping backend, in milliseconds.
+  """
+  app_env :rpc_timeout, :astarte_housekeeping_api, :rpc_timeout,
+    os_env: "HOUSEKEEPING_API_RPC_TIMEOUT",
+    type: :integer,
+    default: 5000
+
   @doc """
   Returns true if the authentication is disabled.
   """

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
@@ -62,7 +62,7 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
       device_registration_limit: device_registration_limit
     }
     |> encode_call(:create_realm)
-    |> @rpc_client.rpc_call(@destination)
+    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
     |> decode_reply()
     |> extract_reply()
   end
@@ -108,7 +108,7 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
       device_registration_limit: device_registration_limit_to_proto(limit)
     }
     |> encode_call(:update_realm)
-    |> @rpc_client.rpc_call(@destination)
+    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
     |> decode_reply()
     |> extract_reply()
   end
@@ -116,7 +116,7 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
   def list_realms do
     %GetRealmsList{}
     |> encode_call(:get_realms_list)
-    |> @rpc_client.rpc_call(@destination)
+    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
     |> decode_reply()
     |> extract_reply()
   end
@@ -126,7 +126,7 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
 
     %DeleteRealm{realm: realm_name, async_operation: async_operation}
     |> encode_call(:delete_realm)
-    |> @rpc_client.rpc_call(@destination)
+    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
     |> decode_reply()
     |> extract_reply()
   end
@@ -134,7 +134,7 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
   def get_health do
     %GetHealth{}
     |> encode_call(:get_health)
-    |> @rpc_client.rpc_call(@destination)
+    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
     |> decode_reply()
     |> extract_reply()
   end
@@ -142,7 +142,7 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
   def get_realm(realm_name) do
     %GetRealm{realm_name: realm_name}
     |> encode_call(:get_realm)
-    |> @rpc_client.rpc_call(@destination)
+    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
     |> decode_reply()
     |> extract_reply()
   end
@@ -150,7 +150,7 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
   def realm_exists?(realm_name) do
     %DoesRealmExist{realm: realm_name}
     |> encode_call(:does_realm_exist)
-    |> @rpc_client.rpc_call(@destination)
+    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
     |> decode_reply()
     |> extract_reply()
   end

--- a/apps/astarte_housekeeping_api/test/support/astarte_housekeeping_mock.ex
+++ b/apps/astarte_housekeeping_api/test/support/astarte_housekeeping_mock.ex
@@ -41,6 +41,10 @@ defmodule Astarte.Housekeeping.Mock do
     handle_rpc(payload)
   end
 
+  def rpc_call(payload, _destination, _timeout) do
+    handle_rpc(payload)
+  end
+
   def handle_rpc(payload) do
     extract_call_tuple(Call.decode(payload))
     |> execute_rpc()


### PR DESCRIPTION
Sometimes, on long operations (e.g. realm creation or deletion), synchronous calls may seem to fail because the underlying RPC to HK backend times out.
Introduce the `HOUSEKEEPING_API_RPC_TIMEOUT` env var to allow setting a longer timeout (in milliseconds). Default to 5  seconds, as before.
