### PR TITLE
Set and enforce a maximum storage TTL for datastreams 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_housekeeping_api] Allow to customize the RPC call timeout with
   `HOUSEKEEPING_API_RPC_TIMEOUT` (default: 5 seconds).
 - Add API usage metrics.
+- Add support for setting the maximum datastream storage retention period in a
+  realm (in seconds). Existing realms are not affected by this change.
+- [astarte_housekeeping_api] Allow to read and set a realm's maximum datastream
+  storage retention period using the realm fetch and update API, respectively.
 
 ### Changed
 - Forward port changes from release 1.1.

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
@@ -45,6 +45,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.State do
     :datastream_maximum_storage_retention,
     :trigger_id_to_policy_name,
     :discard_messages,
-    :last_deletion_in_progress_refresh
+    :last_deletion_in_progress_refresh,
+    :last_datastream_maximum_retention_refresh
   ]
 end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/engine.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/engine.ex
@@ -27,6 +27,7 @@ defmodule Astarte.Housekeeping.Engine do
         public_key_pem,
         replication_factor,
         device_registration_limit,
+        max_retention,
         opts \\ []
       ) do
     _ =
@@ -35,7 +36,8 @@ defmodule Astarte.Housekeeping.Engine do
         tag: "create_realm",
         realm: realm,
         replication_factor: replication_factor,
-        device_registration_limit: device_registration_limit
+        device_registration_limit: device_registration_limit,
+        datastream_maximum_storage_retention: max_retention
       )
 
     Queries.create_realm(
@@ -43,6 +45,7 @@ defmodule Astarte.Housekeeping.Engine do
       public_key_pem,
       replication_factor,
       device_registration_limit,
+      max_retention,
       opts
     )
   end
@@ -99,14 +102,15 @@ defmodule Astarte.Housekeeping.Engine do
 
   @doc """
   Updates a given realm using the provided values map. Fails if realm does not exists or values are invalid.
-  At the moment, updates to jwt_public_key_pem and device_registration_limit are supported.
+  At the moment, updates to jwt_public_key_pem, device_registration_limit and datastream_maximum_storage_retention are supported.
   Returns a tuple:
   - either {:ok, updated_realm} where updated_realm is a map describing the realm
   - or {:error, reason} where reason is an atom describing the error.
   """
   @spec update_realm(String.t(), %{
           :jwt_public_key_pem => String.t(),
-          :device_registration_limit => any(),
+          :device_registration_limit => non_neg_integer() | :remove_limit | nil,
+          :datastream_maximum_storage_retention => non_neg_integer() | nil,
           optional(any()) => any()
         }) ::
           {:ok, map()}
@@ -130,12 +134,14 @@ defmodule Astarte.Housekeeping.Engine do
   defp do_update_realm(realm_name, update_attrs) do
     %{
       jwt_public_key_pem: new_jwt_public_key_pem,
-      device_registration_limit: new_limit
+      device_registration_limit: new_limit,
+      datastream_maximum_storage_retention: new_retention
     } = update_attrs
 
     with realm when is_map(realm) <- Queries.get_realm(realm_name),
          :ok <- update_jwt_public_key_pem(realm_name, new_jwt_public_key_pem),
-         :ok <- update_device_registration_limit(realm_name, new_limit) do
+         :ok <- update_device_registration_limit(realm_name, new_limit),
+         :ok <- update_datastream_maximum_storage_retention(realm_name, new_retention) do
       updated_realm = merge_realm_status(realm, update_attrs)
 
       _ = Logger.info("Successful update of realm #{realm_name}", tag: "realm_update_success")
@@ -176,6 +182,31 @@ defmodule Astarte.Housekeeping.Engine do
     :ok
   end
 
+  defp update_datastream_maximum_storage_retention(realm_name, new_retention)
+       when is_integer(new_retention) and new_retention != 0 do
+    _ =
+      Logger.info("Updating datastream maximum storage retention",
+        tag: "update_datastream_maximum_storage_retention"
+      )
+
+    set_datastream_maximum_storage_retention(realm_name, new_retention)
+  end
+
+  # ScyllaDB considers TTL=0 as unset, see
+  # https://opensource.docs.scylladb.com/stable/cql/time-to-live.html#notes
+  defp update_datastream_maximum_storage_retention(realm_name, 0) do
+    _ =
+      Logger.info("Removing datastream maximum storage retention",
+        tag: "remove_datastream_maximum_storage_retention"
+      )
+
+    delete_datastream_maximum_storage_retention(realm_name)
+  end
+
+  defp update_datastream_maximum_storage_retention(_realm_name, nil) do
+    :ok
+  end
+
   defp delete_device_registration_limit(realm_name) do
     case Queries.delete_device_registration_limit(realm_name) do
       {:ok, %Xandra.Void{}} ->
@@ -189,6 +220,22 @@ defmodule Astarte.Housekeeping.Engine do
           )
 
         {:error, :delete_device_registration_limit_fail}
+    end
+  end
+
+  defp delete_datastream_maximum_storage_retention(realm_name) do
+    case Queries.delete_datastream_maximum_storage_retention(realm_name) do
+      {:ok, %Xandra.Void{}} ->
+        :ok
+
+      {:error, reason} ->
+        _ =
+          Logger.warning(
+            "Cannot delete datastream maximum storage retention, error #{inspect(reason)}",
+            tag: "delete_datastream_maximum_storage_retention"
+          )
+
+        {:error, :delete_datastream_maximum_storage_retention_fail}
     end
   end
 
@@ -208,6 +255,23 @@ defmodule Astarte.Housekeeping.Engine do
     end
   end
 
+  defp set_datastream_maximum_storage_retention(realm_name, new_retention)
+       when is_integer(new_retention) do
+    case Queries.set_datastream_maximum_storage_retention(realm_name, new_retention) do
+      {:ok, %Xandra.Void{}} ->
+        :ok
+
+      {:error, reason} ->
+        _ =
+          Logger.warning(
+            "Cannot set datastream maximum storage retention, error #{inspect(reason)}",
+            tag: "set_datastream_maximum_storage_retention"
+          )
+
+        {:error, :set_datastream_maximum_storage_retention_fail}
+    end
+  end
+
   defp is_realm_update_valid?(update_attrs) do
     # TODO from ScyllaDB >= 5.3, replication can be altered
     update_valid? =
@@ -224,6 +288,8 @@ defmodule Astarte.Housekeeping.Engine do
     update_valid?
   end
 
+  # If device_registration_limit is nil, it means it was not present in the update
+  # payload. Act accordingly.
   defp merge_realm_status(old_realm, %{device_registration_limit: nil} = update_attrs) do
     attrs = Map.delete(update_attrs, :device_registration_limit)
     merge_realm_status(old_realm, attrs)
@@ -232,6 +298,23 @@ defmodule Astarte.Housekeeping.Engine do
   defp merge_realm_status(old_realm, %{device_registration_limit: :remove_limit} = update_attrs) do
     attrs = Map.delete(update_attrs, :device_registration_limit)
     merge_realm_status(%{old_realm | device_registration_limit: nil}, attrs)
+  end
+
+  # If datastream_maximum_storage_retention is nil, it means it was not present in the update
+  # payload. Act accordingly.
+  defp merge_realm_status(old_realm, %{datastream_maximum_storage_retention: nil} = update_attrs) do
+    attrs = Map.delete(update_attrs, :datastream_maximum_storage_retention)
+    merge_realm_status(old_realm, attrs)
+  end
+
+  # Differently from device_registration_limit, datastream_maximum_storage_retention
+  # uses 0 to unset the value. This follows the convention used by ScyllaDB/Cassandra.
+  defp merge_realm_status(
+         old_realm,
+         %{datastream_maximum_storage_retention: 0} = update_attrs
+       ) do
+    attrs = Map.delete(update_attrs, :datastream_maximum_storage_retention)
+    merge_realm_status(%{old_realm | datastream_maximum_storage_retention: nil}, attrs)
   end
 
   defp merge_realm_status(old_realm, update_attrs) do

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/rpc/handler.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/rpc/handler.ex
@@ -36,8 +36,8 @@ defmodule Astarte.Housekeeping.RPC.Handler do
     GetRealmsList,
     GetRealmsListReply,
     Reply,
-    UpdateRealm,
-    SetLimit
+    SetLimit,
+    UpdateRealm
   }
 
   require Logger
@@ -91,6 +91,7 @@ defmodule Astarte.Housekeeping.RPC.Handler do
             replication_class: :NETWORK_TOPOLOGY_STRATEGY,
             datacenter_replication_factors: datacenter_replication_factors,
             device_registration_limit: device_registration_limit,
+            datastream_maximum_storage_retention: datastream_maximum_storage_retention,
             async_operation: async
           }}
        ) do
@@ -102,6 +103,7 @@ defmodule Astarte.Housekeeping.RPC.Handler do
              pub_key,
              datacenter_replication_factors_map,
              device_registration_limit,
+             datastream_maximum_storage_retention,
              async: async
            ) do
       generic_ok(async)
@@ -137,12 +139,18 @@ defmodule Astarte.Housekeeping.RPC.Handler do
             jwt_public_key_pem: pub_key,
             replication_factor: replication_factor,
             device_registration_limit: device_registration_limit,
+            datastream_maximum_storage_retention: datastream_maximum_storage_retention,
             async_operation: async
           }}
        ) do
     with {:ok, false} <- Astarte.Housekeeping.Engine.is_realm_existing(realm),
          :ok <-
-           Engine.create_realm(realm, pub_key, replication_factor, device_registration_limit,
+           Engine.create_realm(
+             realm,
+             pub_key,
+             replication_factor,
+             device_registration_limit,
+             datastream_maximum_storage_retention,
              async: async
            ) do
       generic_ok(async)
@@ -177,14 +185,16 @@ defmodule Astarte.Housekeeping.RPC.Handler do
           jwt_public_key_pem: public_key,
           replication_class: "SimpleStrategy",
           replication_factor: replication_factor,
-          device_registration_limit: limit
+          device_registration_limit: limit,
+          datastream_maximum_storage_retention: retention
         } ->
           %GetRealmReply{
             realm_name: realm_name_reply,
             jwt_public_key_pem: public_key,
             replication_class: :SIMPLE_STRATEGY,
             replication_factor: replication_factor,
-            device_registration_limit: limit
+            device_registration_limit: limit,
+            datastream_maximum_storage_retention: retention
           }
           |> encode_reply(:get_realm_reply)
           |> ok_wrap
@@ -194,14 +204,16 @@ defmodule Astarte.Housekeeping.RPC.Handler do
           jwt_public_key_pem: public_key,
           replication_class: "NetworkTopologyStrategy",
           datacenter_replication_factors: datacenter_replication_factors,
-          device_registration_limit: limit
+          device_registration_limit: limit,
+          datastream_maximum_storage_retention: retention
         } ->
           %GetRealmReply{
             realm_name: realm_name_reply,
             jwt_public_key_pem: public_key,
             replication_class: :NETWORK_TOPOLOGY_STRATEGY,
             datacenter_replication_factors: datacenter_replication_factors,
-            device_registration_limit: limit
+            device_registration_limit: limit,
+            datastream_maximum_storage_retention: retention
           }
           |> encode_reply(:get_realm_reply)
           |> ok_wrap
@@ -292,14 +304,16 @@ defmodule Astarte.Housekeeping.RPC.Handler do
         jwt_public_key_pem: public_key,
         replication_class: "SimpleStrategy",
         replication_factor: replication_factor,
-        device_registration_limit: device_registration_limit
+        device_registration_limit: device_registration_limit,
+        datastream_maximum_storage_retention: datastream_maximum_storage_retention
       } ->
         %GetRealmReply{
           realm_name: realm_name_reply,
           jwt_public_key_pem: public_key,
           replication_class: :SIMPLE_STRATEGY,
           replication_factor: replication_factor,
-          device_registration_limit: device_registration_limit
+          device_registration_limit: device_registration_limit,
+          datastream_maximum_storage_retention: datastream_maximum_storage_retention
         }
         |> encode_reply(:get_realm_reply)
         |> ok_wrap
@@ -309,7 +323,8 @@ defmodule Astarte.Housekeeping.RPC.Handler do
         jwt_public_key_pem: public_key,
         replication_class: "NetworkTopologyStrategy",
         datacenter_replication_factors: datacenter_replication_factors,
-        device_registration_limit: device_registration_limit
+        device_registration_limit: device_registration_limit,
+        datastream_maximum_storage_retention: datastream_maximum_storage_retention
       } ->
         datacenter_replication_factors_list = Enum.into(datacenter_replication_factors, [])
 
@@ -318,7 +333,8 @@ defmodule Astarte.Housekeeping.RPC.Handler do
           jwt_public_key_pem: public_key,
           replication_class: :NETWORK_TOPOLOGY_STRATEGY,
           datacenter_replication_factors: datacenter_replication_factors_list,
-          device_registration_limit: device_registration_limit
+          device_registration_limit: device_registration_limit,
+          datastream_maximum_storage_retention: datastream_maximum_storage_retention
         }
         |> encode_reply(:get_realm_reply)
         |> ok_wrap

--- a/apps/astarte_housekeeping/mix.lock
+++ b/apps/astarte_housekeeping/mix.lock
@@ -3,7 +3,7 @@
   "amqp_client": {:hex, :amqp_client, "3.12.10", "dcc0d5d0037fa2b486c6eb8b52695503765b96f919e38ca864a7b300b829742d", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "16a23959899a82d9c2534ed1dcf1fa281d3b660fb7f78426b880647f0a53731f"},
   "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "685ca10c7a07cc9806f2c6fc7ec2ed1b4d23cbec", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "45d4d20ae662751f47f4b8f2f9d5e302d5485ea9", []},
-  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "5adf50beffa0bac18d99ebe378bc677c7669a767", []},
+  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "9b20db0077d99461f11a380e964689465aa566fa", []},
   "castore": {:hex, :castore, "0.1.16", "2675f717adc700475345c5512c381ef9273eb5df26bdd3f8c13e2636cf4cc175", [:mix], [], "hexpm", "28ed2c43d83b5c25d35c51bc0abf229ac51359c170cba76171a462ced2e4b651"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/engine_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/engine_test.exs
@@ -45,7 +45,7 @@ defmodule Astarte.Housekeeping.EngineTest do
 
   describe "Realm update" do
     test "succeeds when realm exists and valid update values are given" do
-      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, [])
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
 
       new_public_key = "new_public_key"
 
@@ -58,12 +58,13 @@ defmodule Astarte.Housekeeping.EngineTest do
               %{
                 realm_name: @realm1,
                 jwt_public_key_pem: ^new_public_key,
-                device_registration_limit: 1
+                device_registration_limit: 1,
+                datastream_maximum_storage_retention: 1
               }} = Engine.update_realm(@realm1, update_values)
     end
 
     test "succeeds when realm exists and empty update values are given" do
-      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, [])
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
 
       update_values = %UpdateRealm{
         realm: @realm1
@@ -73,12 +74,13 @@ defmodule Astarte.Housekeeping.EngineTest do
               %{
                 realm_name: @realm1,
                 jwt_public_key_pem: "test1publickey",
-                device_registration_limit: 1
+                device_registration_limit: 1,
+                datastream_maximum_storage_retention: 1
               }} = Engine.update_realm(@realm1, update_values)
     end
 
     test "succeeds when realm exists and device_registration_limit is updated" do
-      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, [])
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
 
       new_limit = 100
 
@@ -94,7 +96,7 @@ defmodule Astarte.Housekeeping.EngineTest do
     end
 
     test "succeeds when realm exists and device_registration_limit is removed" do
-      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, [])
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
 
       update_values = %UpdateRealm{
         device_registration_limit: :remove_limit
@@ -108,7 +110,7 @@ defmodule Astarte.Housekeeping.EngineTest do
     end
 
     test "succeeds when realm exists and device_registration_limit is not set" do
-      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, [])
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
 
       update_values = %UpdateRealm{
         device_registration_limit: nil
@@ -118,6 +120,50 @@ defmodule Astarte.Housekeeping.EngineTest do
               %{
                 realm_name: @realm1,
                 device_registration_limit: 1
+              }} = Engine.update_realm(@realm1, update_values)
+    end
+
+    test "succeeds when realm exists and datastream_maximum_storage_retention is updated" do
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
+
+      new_retention = 100
+
+      update_values = %UpdateRealm{
+        datastream_maximum_storage_retention: new_retention
+      }
+
+      assert {:ok,
+              %{
+                realm_name: @realm1,
+                datastream_maximum_storage_retention: ^new_retention
+              }} = Engine.update_realm(@realm1, update_values)
+    end
+
+    test "succeeds when realm exists and datastream_maximum_storage_retention is removed" do
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
+
+      update_values = %UpdateRealm{
+        datastream_maximum_storage_retention: 0
+      }
+
+      assert {:ok,
+              %{
+                realm_name: @realm1,
+                datastream_maximum_storage_retention: nil
+              }} = Engine.update_realm(@realm1, update_values)
+    end
+
+    test "succeeds when realm exists and datastream_maximum_storage_retention is not set" do
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
+
+      update_values = %UpdateRealm{
+        datastream_maximum_storage_retention: nil
+      }
+
+      assert {:ok,
+              %{
+                realm_name: @realm1,
+                datastream_maximum_storage_retention: 1
               }} = Engine.update_realm(@realm1, update_values)
     end
 
@@ -133,7 +179,7 @@ defmodule Astarte.Housekeeping.EngineTest do
     end
 
     test "fails when update values are invalid" do
-      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, [])
+      :ok = Queries.create_realm(@realm1, "test1publickey", 1, 1, 1, [])
 
       update_values = %UpdateRealm{
         realm: @realm1,

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/non_negative_integer_or_unset_type.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/non_negative_integer_or_unset_type.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2023 SECO Mind srl
+# Copyright 2024 SECO Mind srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,11 +16,11 @@
 # limitations under the License.
 #
 
-defmodule Astarte.Housekeeping.API.Realms.DeviceRegistrationLimitType do
+defmodule Astarte.Housekeeping.API.Realms.NonNegativeIntegerOrUnsetType do
   use Ecto.Type
   def type, do: :any
 
-  def cast(:remove_limit), do: {:ok, :remove_limit}
+  def cast(:unset), do: {:ok, :unset}
 
   def cast(n) when is_integer(n) do
     if n >= 0, do: {:ok, n}, else: :error
@@ -29,10 +29,10 @@ defmodule Astarte.Housekeeping.API.Realms.DeviceRegistrationLimitType do
   def cast(_), do: :error
 
   # load and dump are not meaningful for our use-case
-  def load(:remove_limit), do: {:ok, :remove_limit}
+  def load(:unset), do: {:ok, :unset}
   def load(n) when is_integer(n), do: {:ok, n}
   def load(_), do: :error
-  def dump(:remove_limit), do: {:ok, :remove_limit}
+  def dump(:unset), do: {:ok, :unset}
   def dump(n) when is_integer(n), do: {:ok, n}
   def dump(_), do: :error
 end

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/realm.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/realm.ex
@@ -20,7 +20,7 @@ defmodule Astarte.Housekeeping.API.Realms.Realm do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Astarte.Housekeeping.API.Realms.DeviceRegistrationLimitType
+  alias Astarte.Housekeeping.API.Realms.NonNegativeIntegerOrUnsetType
 
   @default_replication_factor 1
   @default_replication_class "SimpleStrategy"
@@ -30,7 +30,8 @@ defmodule Astarte.Housekeeping.API.Realms.Realm do
     :replication_factor,
     :replication_class,
     :datacenter_replication_factors,
-    :device_registration_limit
+    :device_registration_limit,
+    :datastream_maximum_storage_retention
     | @required_fields
   ]
 
@@ -43,7 +44,8 @@ defmodule Astarte.Housekeeping.API.Realms.Realm do
     field :replication_factor, :integer
     field :replication_class, :string
     field :datacenter_replication_factors, {:map, :integer}
-    field :device_registration_limit, DeviceRegistrationLimitType
+    field :device_registration_limit, NonNegativeIntegerOrUnsetType
+    field :datastream_maximum_storage_retention, NonNegativeIntegerOrUnsetType
   end
 
   def changeset(realm, params \\ %{}) do

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
@@ -49,7 +49,8 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
           jwt_public_key_pem: pem,
           replication_class: "SimpleStrategy",
           replication_factor: replication_factor,
-          device_registration_limit: device_registration_limit
+          device_registration_limit: device_registration_limit,
+          datastream_maximum_storage_retention: datastream_maximum_storage_retention
         },
         opts
       ) do
@@ -59,7 +60,8 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
       jwt_public_key_pem: pem,
       replication_class: :SIMPLE_STRATEGY,
       replication_factor: replication_factor,
-      device_registration_limit: device_registration_limit
+      device_registration_limit: device_registration_limit,
+      datastream_maximum_storage_retention: datastream_maximum_storage_retention
     }
     |> encode_call(:create_realm)
     |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
@@ -73,7 +75,8 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
           jwt_public_key_pem: pem,
           replication_class: "NetworkTopologyStrategy",
           datacenter_replication_factors: replication_factors_map,
-          device_registration_limit: device_registration_limit
+          device_registration_limit: device_registration_limit,
+          datastream_maximum_storage_retention: datastream_maximum_storage_retention
         },
         opts
       ) do
@@ -83,7 +86,8 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
       jwt_public_key_pem: pem,
       replication_class: :NETWORK_TOPOLOGY_STRATEGY,
       datacenter_replication_factors: Enum.to_list(replication_factors_map),
-      device_registration_limit: device_registration_limit
+      device_registration_limit: device_registration_limit,
+      datastream_maximum_storage_retention: datastream_maximum_storage_retention
     }
     |> encode_call(:create_realm)
     |> @rpc_client.rpc_call(@destination)
@@ -97,7 +101,8 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
         replication_class: replication_class,
         replication_factor: replication_factor,
         datacenter_replication_factors: replication_factors_map,
-        device_registration_limit: limit
+        device_registration_limit: limit,
+        datastream_maximum_storage_retention: max_retention
       }) do
     %UpdateRealm{
       realm: realm_name,
@@ -105,7 +110,9 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
       replication_class: replication_class_to_atom(replication_class),
       replication_factor: replication_factor,
       datacenter_replication_factors: replication_factors_map,
-      device_registration_limit: device_registration_limit_to_proto(limit)
+      device_registration_limit: device_registration_limit_to_proto(limit),
+      datastream_maximum_storage_retention:
+        datastream_maximum_storage_retention_to_proto(max_retention)
     }
     |> encode_call(:update_realm)
     |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
@@ -192,7 +199,8 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
             jwt_public_key_pem: pem,
             replication_class: :SIMPLE_STRATEGY,
             replication_factor: replication_factor,
-            device_registration_limit: device_registration_limit
+            device_registration_limit: device_registration_limit,
+            datastream_maximum_storage_retention: max_retention
           }}
        ) do
     {:ok,
@@ -201,7 +209,9 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
        jwt_public_key_pem: pem,
        replication_class: "SimpleStrategy",
        replication_factor: replication_factor,
-       device_registration_limit: device_registration_limit
+       device_registration_limit: device_registration_limit,
+       datastream_maximum_storage_retention:
+         datastream_maximum_storage_retention_from_proto(max_retention)
      }}
   end
 
@@ -212,7 +222,8 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
             jwt_public_key_pem: pem,
             replication_class: :NETWORK_TOPOLOGY_STRATEGY,
             datacenter_replication_factors: datacenter_replication_factors,
-            device_registration_limit: device_registration_limit
+            device_registration_limit: device_registration_limit,
+            datastream_maximum_storage_retention: max_retention
           }}
        ) do
     {:ok,
@@ -221,7 +232,9 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
        jwt_public_key_pem: pem,
        replication_class: "NetworkTopologyStrategy",
        datacenter_replication_factors: Enum.into(datacenter_replication_factors, %{}),
-       device_registration_limit: device_registration_limit
+       device_registration_limit: device_registration_limit,
+       datastream_maximum_storage_retention:
+         datastream_maximum_storage_retention_from_proto(max_retention)
      }}
   end
 
@@ -239,6 +252,20 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
          {:generic_error_reply, %GenericErrorReply{error_name: "connected_devices_present"}}
        ) do
     {:error, :connected_devices_present}
+  end
+
+  defp extract_reply(
+         {:generic_error_reply,
+          %GenericErrorReply{error_name: "delete_datastream_maximum_storage_retention_fail"}}
+       ) do
+    {:error, :delete_datastream_maximum_storage_retention_fail}
+  end
+
+  defp extract_reply(
+         {:generic_error_reply,
+          %GenericErrorReply{error_name: "set_datastream_maximum_storage_retention_fail"}}
+       ) do
+    {:error, :set_datastream_maximum_storage_retention_fail}
   end
 
   defp extract_reply({:generic_error_reply, error_struct = %GenericErrorReply{}}) do
@@ -271,10 +298,16 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
   defp replication_class_to_atom("SimpleStrategy"), do: :SIMPLE_STRATEGY
   defp replication_class_to_atom(nil), do: nil
 
-  defp device_registration_limit_to_proto(:remove_limit), do: {:remove_limit, %RemoveLimit{}}
+  defp device_registration_limit_to_proto(:unset), do: {:remove_limit, %RemoveLimit{}}
   defp device_registration_limit_to_proto(nil), do: nil
 
   defp device_registration_limit_to_proto(n) when is_integer(n) do
     {:set_limit, %SetLimit{value: n}}
   end
+
+  defp datastream_maximum_storage_retention_to_proto(:unset), do: 0
+  defp datastream_maximum_storage_retention_to_proto(nil), do: nil
+  defp datastream_maximum_storage_retention_to_proto(n) when is_integer(n), do: n
+  defp datastream_maximum_storage_retention_from_proto(0), do: nil
+  defp datastream_maximum_storage_retention_from_proto(n) when is_integer(n), do: n
 end

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/fallback_controller.ex
@@ -62,6 +62,20 @@ defmodule Astarte.Housekeeping.APIWeb.FallbackController do
     |> render(:"404")
   end
 
+  def call(conn, {:error, :delete_datastream_maximum_storage_retention_fail}) do
+    conn
+    |> put_status(:service_unavailable)
+    |> put_view(ErrorView)
+    |> render(:"503")
+  end
+
+  def call(conn, {:error, :set_datastream_maximum_storage_retention_fail}) do
+    conn
+    |> put_status(:service_unavailable)
+    |> put_view(ErrorView)
+    |> render(:"503")
+  end
+
   def call(conn, {:error, :unauthorized}) do
     conn
     |> put_status(:unauthorized)

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/realm_controller.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/controllers/realm_controller.ex
@@ -78,10 +78,12 @@ defmodule Astarte.Housekeeping.APIWeb.RealmController do
 
   defp normalize_update_attrs(update_attrs) when is_map(update_attrs) do
     update_attrs
-    |> Map.replace_lazy(:device_registration_limit, &normalize_device_registration_limit/1)
-    |> Map.replace_lazy("device_registration_limit", &normalize_device_registration_limit/1)
+    |> Map.replace_lazy(:device_registration_limit, &normalize_integer_or_nil/1)
+    |> Map.replace_lazy("device_registration_limit", &normalize_integer_or_nil/1)
+    |> Map.replace_lazy(:datastream_maximum_storage_retention, &normalize_integer_or_nil/1)
+    |> Map.replace_lazy("datastream_maximum_storage_retention", &normalize_integer_or_nil/1)
   end
 
-  defp normalize_device_registration_limit(value) when is_nil(value), do: :remove_limit
-  defp normalize_device_registration_limit(value), do: value
+  defp normalize_integer_or_nil(value) when is_nil(value), do: :unset
+  defp normalize_integer_or_nil(value), do: value
 end

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/error_view.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/error_view.ex
@@ -47,6 +47,14 @@ defmodule Astarte.Housekeeping.APIWeb.ErrorView do
     %{errors: %{detail: "Realm still contains connected devices"}}
   end
 
+  def render("set_datastream_maximum_storage_retention_fail.json", _assigns) do
+    %{errors: %{detail: "Failed to set datastream_maximum_storage_retention"}}
+  end
+
+  def render("delete_datastream_maximum_storage_retention_fail.json", _assigns) do
+    %{errors: %{detail: "Failed to delete datastream_maximum_storage_retention"}}
+  end
+
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/realm_view.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/realm_view.ex
@@ -40,7 +40,8 @@ defmodule Astarte.Housekeeping.APIWeb.RealmView do
         jwt_public_key_pem: realm.jwt_public_key_pem,
         replication_class: "SimpleStrategy",
         replication_factor: realm.replication_factor,
-        device_registration_limit: realm.device_registration_limit
+        device_registration_limit: realm.device_registration_limit,
+        datastream_maximum_storage_retention: realm.datastream_maximum_storage_retention
       }
     }
   end
@@ -52,7 +53,8 @@ defmodule Astarte.Housekeeping.APIWeb.RealmView do
         jwt_public_key_pem: realm.jwt_public_key_pem,
         replication_class: "NetworkTopologyStrategy",
         datacenter_replication_factors: realm.datacenter_replication_factors,
-        device_registration_limit: realm.device_registration_limit
+        device_registration_limit: realm.device_registration_limit,
+        datastream_maximum_storage_retention: realm.datastream_maximum_storage_retention
       }
     }
   end

--- a/apps/astarte_housekeeping_api/mix.lock
+++ b/apps/astarte_housekeeping_api/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "3.3.0", "056d9f4bac96c3ab5a904b321e70e78b91ba594766a1fc2f32afd9c016d9f43b", [:mix], [{:amqp_client, "~> 3.9", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "8d3ae139d2646c630d674a1b8d68c7f85134f9e8b2a1c3dd5621616994b10a8b"},
   "amqp_client": {:hex, :amqp_client, "3.12.10", "dcc0d5d0037fa2b486c6eb8b52695503765b96f919e38ca864a7b300b829742d", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "16a23959899a82d9c2534ed1dcf1fa281d3b660fb7f78426b880647f0a53731f"},
-  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "5adf50beffa0bac18d99ebe378bc677c7669a767", []},
+  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "9b20db0077d99461f11a380e964689465aa566fa", []},
   "castore": {:hex, :castore, "0.1.22", "4127549e411bedd012ca3a308dede574f43819fe9394254ca55ab4895abfa1a2", [:mix], [], "hexpm", "c17576df47eb5aa1ee40cc4134316a99f5cad3e215d5c77b8dd3cfef12a22cac"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "cors_plug": {:hex, :cors_plug, "2.0.3", "316f806d10316e6d10f09473f19052d20ba0a0ce2a1d910ddf57d663dac402ae", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "ee4ae1418e6ce117fc42c2ba3e6cbdca4e95ecd2fe59a05ec6884ca16d469aea"},

--- a/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
+++ b/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
@@ -245,7 +245,7 @@ components:
               data:
                 $ref: '#/components/schemas/RealmPatch'
       description: >-
-        A JSON Merge Patch containing the property changes that should be applied to the realm.
+        A JSON Merge Patch containing the property changes that should be applied to the realm. Explicitly set a property to null to remove it.
       required: true
   schemas:
     Realm:
@@ -289,6 +289,11 @@ components:
           minimum: 0
           example: 100
           description: "Optional upper bound to the number of devices that can be registered in the realm."
+        datastream_maximum_storage_retention:
+          type: integer
+          minimum: 1
+          example: 100
+          description: "Optional upper bound to the retention period of all datastreams in the realm, in seconds."
       example:
         realm_name: myrealm
         jwt_public_key_pem: |
@@ -338,6 +343,11 @@ components:
           minimum: 0
           example: 100
           description: "Optional upper bound to the number of devices that can be registered in the realm."
+        datastream_maximum_storage_retention:
+          type: integer
+          minimum: 1
+          example: 100
+          description: "Optional upper bound to the retention period of all datastreams in the realm, in seconds."
       example:
         jwt_public_key_pem: |
             -----BEGIN PUBLIC KEY-----

--- a/apps/astarte_housekeeping_api/test/astarte_housekeeping_api/realms/realms_test.exs
+++ b/apps/astarte_housekeeping_api/test/astarte_housekeeping_api/realms/realms_test.exs
@@ -46,7 +46,8 @@ defmodule Astarte.Housekeeping.API.RealmsTest do
     @valid_attrs %{
       realm_name: "mytestrealm",
       jwt_public_key_pem: @pubkey,
-      device_registration_limit: 42
+      device_registration_limit: 42,
+      datastream_maximum_storage_retention: 42
     }
     @device_registration_limit_attrs %{
       realm_name: "mytestrealm",
@@ -194,12 +195,12 @@ defmodule Astarte.Housekeeping.API.RealmsTest do
              } = realm
     end
 
-    test "update_realm/2 with device registration limit set to :remove_limit removes the limit" do
+    test "update_realm/2 with device registration limit set to :unset removes the limit" do
       %Realm{realm_name: realm_name, device_registration_limit: device_registration_limit} =
         realm = realm_fixture()
 
       assert device_registration_limit != nil
-      update_attrs = Map.put(@update_attrs, :device_registration_limit, :remove_limit)
+      update_attrs = Map.put(@update_attrs, :device_registration_limit, :unset)
       assert {:ok, realm} = Realms.update_realm(realm_name, update_attrs)
 
       assert %Realm{
@@ -212,6 +213,40 @@ defmodule Astarte.Housekeeping.API.RealmsTest do
     test "update_realm/2 with device registration limit set to an invalid value fails" do
       %Realm{realm_name: realm_name} = realm = realm_fixture()
       update_attrs = Map.put(@update_attrs, :device_registration_limit, -10)
+      assert {:error, %Ecto.Changeset{}} = Realms.update_realm(realm_name, update_attrs)
+    end
+
+    test "update_realm/2 with valid data and datastream maximum storage retention set to a valid value updates the realm" do
+      %Realm{realm_name: realm_name} = realm_fixture()
+      retention = 10
+      update_attrs = Map.put(@update_attrs, :datastream_maximum_storage_retention, retention)
+      assert {:ok, realm} = Realms.update_realm(realm_name, update_attrs)
+
+      assert %Realm{
+               realm_name: "mytestrealm",
+               jwt_public_key_pem: @update_pubkey,
+               datastream_maximum_storage_retention: ^retention
+             } = realm
+    end
+
+    test "update_realm/2 with datastream maximum storage retention set to :unset removes the limit" do
+      %Realm{realm_name: realm_name, datastream_maximum_storage_retention: retention} =
+        realm_fixture()
+
+      assert retention != nil
+      update_attrs = Map.put(@update_attrs, :datastream_maximum_storage_retention, :unset)
+      assert {:ok, realm} = Realms.update_realm(realm_name, update_attrs)
+
+      assert %Realm{
+               realm_name: "mytestrealm",
+               jwt_public_key_pem: @update_pubkey,
+               datastream_maximum_storage_retention: nil
+             } = realm
+    end
+
+    test "update_realm/2 with datastream maximum storage retention set to an invalid value fails" do
+      %Realm{realm_name: realm_name} = realm_fixture()
+      update_attrs = Map.put(@update_attrs, :datastream_maximum_storage_retention, -10)
       assert {:error, %Ecto.Changeset{}} = Realms.update_realm(realm_name, update_attrs)
     end
 

--- a/apps/astarte_housekeeping_api/test/astarte_housekeeping_api_web/controllers/realm_controller_test.exs
+++ b/apps/astarte_housekeeping_api/test/astarte_housekeeping_api_web/controllers/realm_controller_test.exs
@@ -121,7 +121,8 @@ defmodule Astarte.Housekeeping.APIWeb.RealmControllerTest do
                "jwt_public_key_pem" => @create_attrs["data"]["jwt_public_key_pem"],
                "replication_class" => "SimpleStrategy",
                "replication_factor" => 1,
-               "device_registration_limit" => nil
+               "device_registration_limit" => nil,
+               "datastream_maximum_storage_retention" => nil
              }
            }
   end
@@ -138,7 +139,8 @@ defmodule Astarte.Housekeeping.APIWeb.RealmControllerTest do
                "jwt_public_key_pem" => @explicit_replication_attrs["data"]["jwt_public_key_pem"],
                "replication_class" => "SimpleStrategy",
                "replication_factor" => @explicit_replication_attrs["data"]["replication_factor"],
-               "device_registration_limit" => nil
+               "device_registration_limit" => nil,
+               "datastream_maximum_storage_retention" => nil
              }
            }
   end
@@ -156,7 +158,8 @@ defmodule Astarte.Housekeeping.APIWeb.RealmControllerTest do
                "replication_class" => "NetworkTopologyStrategy",
                "datacenter_replication_factors" =>
                  @network_topology_attrs["data"]["datacenter_replication_factors"],
-               "device_registration_limit" => nil
+               "device_registration_limit" => nil,
+               "datastream_maximum_storage_retention" => nil
              }
            }
   end
@@ -222,6 +225,23 @@ defmodule Astarte.Housekeeping.APIWeb.RealmControllerTest do
            } = updated_realm
   end
 
+  test "updates chosen realm maximum storage retention", %{conn: conn} do
+    %Realm{realm_name: realm_name} = realm = fixture(:realm)
+    limit = 10
+
+    conn =
+      patch(conn, realm_path(conn, :update, realm), %{
+        "data" => %{"datastream_maximum_storage_retention" => limit}
+      })
+
+    assert %{"data" => updated_realm} = json_response(conn, 200)
+
+    assert %{
+             "realm_name" => ^realm_name,
+             "datastream_maximum_storage_retention" => ^limit
+           } = updated_realm
+  end
+
   test "removes chosen realm device registration limit", %{conn: conn} do
     %Realm{realm_name: realm_name} = realm = fixture(:realm)
 
@@ -247,6 +267,34 @@ defmodule Astarte.Housekeeping.APIWeb.RealmControllerTest do
     assert %{
              "realm_name" => ^realm_name,
              "device_registration_limit" => nil
+           } = updated_realm
+  end
+
+  test "removes chosen realm maximum storage retention", %{conn: conn} do
+    %Realm{realm_name: realm_name} = realm = fixture(:realm)
+
+    conn =
+      patch(conn, realm_path(conn, :update, realm), %{
+        "data" => %{"datastream_maximum_storage_retention" => 10}
+      })
+
+    assert %{"data" => updated_realm} = json_response(conn, 200)
+
+    assert %{
+             "realm_name" => ^realm_name,
+             "datastream_maximum_storage_retention" => 10
+           } = updated_realm
+
+    conn =
+      patch(conn, realm_path(conn, :update, realm), %{
+        "data" => %{"datastream_maximum_storage_retention" => nil}
+      })
+
+    assert %{"data" => updated_realm} = json_response(conn, 200)
+
+    assert %{
+             "realm_name" => ^realm_name,
+             "datastream_maximum_storage_retention" => nil
            } = updated_realm
   end
 

--- a/apps/astarte_housekeeping_api/test/support/astarte_housekeeping_mock.ex
+++ b/apps/astarte_housekeeping_api/test/support/astarte_housekeeping_mock.ex
@@ -29,10 +29,10 @@ defmodule Astarte.Housekeeping.Mock do
     GetRealmReply,
     GetRealmsList,
     GetRealmsListReply,
+    RemoveLimit,
     Reply,
-    UpdateRealm,
     SetLimit,
-    RemoveLimit
+    UpdateRealm
   }
 
   alias Astarte.Housekeeping.API.Realms.Realm
@@ -63,7 +63,8 @@ defmodule Astarte.Housekeeping.Mock do
             replication_factor: rep,
             replication_class: class,
             datacenter_replication_factors: dc_repl,
-            device_registration_limit: dev_reg_limit
+            device_registration_limit: dev_reg_limit,
+            datastream_maximum_storage_retention: ds_max_retention
           }}
        ) do
     Astarte.Housekeeping.Mock.DB.put_realm(%Realm{
@@ -72,7 +73,8 @@ defmodule Astarte.Housekeeping.Mock do
       replication_factor: rep,
       replication_class: class,
       datacenter_replication_factors: dc_repl,
-      device_registration_limit: dev_reg_limit
+      device_registration_limit: dev_reg_limit,
+      datastream_maximum_storage_retention: ds_max_retention
     })
 
     %GenericOkReply{async_operation: async}
@@ -88,7 +90,8 @@ defmodule Astarte.Housekeeping.Mock do
             replication_factor: rep,
             replication_class: class,
             datacenter_replication_factors: dc_repl,
-            device_registration_limit: dev_reg_limit
+            device_registration_limit: dev_reg_limit,
+            datastream_maximum_storage_retention: ds_max_retention
           }}
        ) do
     # This is backend logic
@@ -105,13 +108,27 @@ defmodule Astarte.Housekeeping.Mock do
           nil
       end
 
+    retention =
+      case ds_max_retention do
+        nil ->
+          %Realm{} = realm = Astarte.Housekeeping.Mock.DB.get_realm(realm_name)
+          realm.datastream_maximum_storage_retention
+
+        0 ->
+          nil
+
+        n when is_integer(n) ->
+          n
+      end
+
     Astarte.Housekeeping.Mock.DB.put_realm(%Realm{
       realm_name: realm_name,
       jwt_public_key_pem: pem,
       replication_factor: rep,
       replication_class: class,
       datacenter_replication_factors: dc_repl,
-      device_registration_limit: limit
+      device_registration_limit: limit,
+      datastream_maximum_storage_retention: retention
     })
 
     %GetRealmReply{
@@ -120,7 +137,8 @@ defmodule Astarte.Housekeeping.Mock do
       replication_factor: rep,
       replication_class: class,
       datacenter_replication_factors: dc_repl,
-      device_registration_limit: limit
+      device_registration_limit: limit,
+      datastream_maximum_storage_retention: retention
     }
     |> encode_reply(:get_realm_reply)
     |> ok_wrap
@@ -161,7 +179,8 @@ defmodule Astarte.Housekeeping.Mock do
         replication_factor: rep,
         replication_class: class,
         datacenter_replication_factors: dc_repl,
-        device_registration_limit: dev_reg_limit
+        device_registration_limit: dev_reg_limit,
+        datastream_maximum_storage_retention: ds_max_retention
       } ->
         %GetRealmReply{
           realm_name: realm_name,
@@ -169,7 +188,8 @@ defmodule Astarte.Housekeeping.Mock do
           replication_factor: rep,
           replication_class: class,
           datacenter_replication_factors: dc_repl,
-          device_registration_limit: dev_reg_limit
+          device_registration_limit: dev_reg_limit,
+          datastream_maximum_storage_retention: ds_max_retention
         }
         |> encode_reply(:get_realm_reply)
     end


### PR DESCRIPTION
While support for using a maximum period for datastreams data retention in a given realm is already present in DUP/AppEngine since 0.10, there was no support for setting its value.  Add it.
The value (in seconds) can be specified in Housekeeping API at realm creation, or changed with a realm update. When changed, it will apply oly to new data, i.e. data sent after the change.
Defaults to none, as before.