### PR TITLE
RM: take maximum storage retention into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   realm (in seconds). Existing realms are not affected by this change.
 - [astarte_housekeeping_api] Allow to read and set a realm's maximum datastream
   storage retention period using the realm fetch and update API, respectively.
+- [astarte_realm_management_api] Allow to read realm's maximum datastream
+  storage retention period with the `/config/datastream_maximum_storage_retention`
+  endpoint.
 
 ### Changed
 - Forward port changes from release 1.1.
@@ -44,7 +47,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   `DATA_UPDATER_PLANT_GENERATE_LEGACY_INCOMING_INTROSPECTION_EVENTS` to `true`.
   See https://github.com/astarte-platform/astarte_core/pull/77.
 - BREAKING: [astarte_realm_management] do not allow installation of interfaces
-  where database_retention_ttl exceeds the max database retention for the realm (if set).
+  where database_retention_ttl exceeds the realm's maximum datastream storage
+  retention period, if set.
 
 ## [1.1.1] - 2023-11-15
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   than a plaintext string. Revert to the old behaviour by setting
   `DATA_UPDATER_PLANT_GENERATE_LEGACY_INCOMING_INTROSPECTION_EVENTS` to `true`.
   See https://github.com/astarte-platform/astarte_core/pull/77.
+- BREAKING: [astarte_realm_management] do not allow installation of interfaces
+  where database_retention_ttl exceeds the max database retention for the realm (if set).
 
 ## [1.1.1] - 2023-11-15
 ### Fixed

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -1073,4 +1073,27 @@ defmodule Astarte.RealmManagement.Engine do
         {:error, reason}
     end
   end
+
+  @doc """
+  Retrieves the maximum datastream storage retention of a realm.
+  Returns either `{:ok, limit}` or `{:error, reason}`.
+  The limit is a strictly positive integer (if set), 0 if unset.
+  """
+  @spec get_datastream_maximum_storage_retention(String.t()) ::
+          {:ok, non_neg_integer()} | {:error, atom()}
+  def get_datastream_maximum_storage_retention(realm_name) do
+    case Queries.get_datastream_maximum_storage_retention(realm_name) do
+      {:ok, value} ->
+        {:ok, value}
+
+      {:error, reason} ->
+        _ =
+          Logger.warning(
+            "Cannot get maximum datastream storage retention for realm #{realm_name}",
+            tag: "get_datastream_maximum_storage_retention_fail"
+          )
+
+        {:error, reason}
+    end
+  end
 end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -72,6 +72,7 @@ defmodule Astarte.RealmManagement.Engine do
          {:ok, json_obj} <- Jason.decode(interface_json),
          interface_changeset <- InterfaceDocument.changeset(%InterfaceDocument{}, json_obj),
          {:ok, interface_doc} <- Ecto.Changeset.apply_action(interface_changeset, :insert),
+         :ok <- verify_mappings_max_storage_retention(realm_name, interface_doc),
          interface_descriptor <- InterfaceDescriptor.from_interface(interface_doc),
          %InterfaceDescriptor{name: name, major_version: major} <- interface_descriptor,
          {:interface_avail, {:ok, false}} <-
@@ -118,6 +119,9 @@ defmodule Astarte.RealmManagement.Engine do
 
       {:interface_avail, {:ok, true}} ->
         {:error, :already_installed_interface}
+
+      {:error, :maximum_database_retention_exceeded} ->
+        {:error, :maximum_database_retention_exceeded}
 
       {:error, :interface_name_collision} ->
         {:error, :interface_name_collision}
@@ -935,6 +939,24 @@ defmodule Astarte.RealmManagement.Engine do
         Engine.execute_trigger_policy_deletion(client, policy_name)
       end
     end
+  end
+
+  defp verify_mappings_max_storage_retention(realm_name, interface) do
+    with {:ok, max_retention} <- get_datastream_maximum_storage_retention(realm_name) do
+      if mappings_retention_valid?(interface.mappings, max_retention) do
+        :ok
+      else
+        {:error, :maximum_database_retention_exceeded}
+      end
+    end
+  end
+
+  defp mappings_retention_valid?(_mappings, 0), do: true
+
+  defp mappings_retention_valid?(mappings, max_retention) do
+    Enum.all?(mappings, fn %Mapping{database_retention_ttl: retention} ->
+      retention <= max_retention
+    end)
   end
 
   defp verify_trigger_policy_not_exists(client, policy_name) do

--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -2312,22 +2312,19 @@ defmodule Astarte.RealmManagement.Queries do
   end
 
   defp do_get_datastream_maximum_storage_retention(conn, realm_name) do
-    # TODO: validate realm name
-    statement = """
+    query = """
     SELECT blobAsInt(value)
-    FROM :realm_name.kv_store
+    FROM #{realm_name}.kv_store
     WHERE group='realm_config' AND key='datastream_maximum_storage_retention'
     """
 
-    query = String.replace(statement, ":realm_name", realm_name)
-
     with {:ok, prepared} <- Xandra.prepare(conn, query),
-         {:ok, page} <- Xandra.execute(conn, prepared, %{}) do
+         {:ok, %Xandra.Page{} = page} <- Xandra.execute(conn, prepared) do
       case Enum.fetch(page, 0) do
         {:ok, %{"system.blobasint(value)": value}} ->
           {:ok, value}
 
-        :error ->
+        _ ->
           {:ok, 0}
       end
     else

--- a/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
@@ -25,6 +25,8 @@ defmodule Astarte.RealmManagement.RPC.Handler do
     DeleteTrigger,
     GenericErrorReply,
     GenericOkReply,
+    GetDatastreamMaximumStorageRetention,
+    GetDatastreamMaximumStorageRetentionReply,
     GetDeviceRegistrationLimit,
     GetDeviceRegistrationLimitReply,
     GetHealth,
@@ -83,6 +85,18 @@ defmodule Astarte.RealmManagement.RPC.Handler do
     }
 
     {:ok, Reply.encode(%Reply{error: false, reply: {:get_device_registration_limit_reply, msg}})}
+  end
+
+  def encode_reply(:get_datastream_maximum_storage_retention_reply, {:ok, retention}) do
+    msg = %GetDatastreamMaximumStorageRetentionReply{
+      datastream_maximum_storage_retention: retention
+    }
+
+    {:ok,
+     Reply.encode(%Reply{
+       error: false,
+       reply: {:get_datastream_maximum_storage_retention_reply, msg}
+     })}
   end
 
   def encode_reply(:get_interface_source, {:ok, reply}) do
@@ -231,6 +245,15 @@ defmodule Astarte.RealmManagement.RPC.Handler do
               encode_reply(
                 :get_device_registration_limit_reply,
                 Engine.get_device_registration_limit(realm_name)
+              )
+
+            {:get_datastream_maximum_storage_retention,
+             %GetDatastreamMaximumStorageRetention{realm_name: realm_name}} ->
+              _ = Logger.metadata(realm: realm_name)
+
+              encode_reply(
+                :get_datastream_maximum_storage_retention_reply,
+                Engine.get_datastream_maximum_storage_retention(realm_name)
               )
 
             {:install_interface,

--- a/apps/astarte_realm_management/mix.lock
+++ b/apps/astarte_realm_management/mix.lock
@@ -3,7 +3,7 @@
   "amqp_client": {:hex, :amqp_client, "3.12.10", "dcc0d5d0037fa2b486c6eb8b52695503765b96f919e38ca864a7b300b829742d", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "16a23959899a82d9c2534ed1dcf1fa281d3b660fb7f78426b880647f0a53731f"},
   "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "685ca10c7a07cc9806f2c6fc7ec2ed1b4d23cbec", []},
   "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "45d4d20ae662751f47f4b8f2f9d5e302d5485ea9", []},
-  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "5adf50beffa0bac18d99ebe378bc677c7669a767", []},
+  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "9b20db0077d99461f11a380e964689465aa566fa", []},
   "castore": {:hex, :castore, "0.1.18", "deb5b9ab02400561b6f5708f3e7660fc35ca2d51bfc6a940d2f513f89c2975fc", [:mix], [], "hexpm", "61bbaf6452b782ef80b33cdb45701afbcf0a918a45ebe7e73f1130d661e66a06"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "connection": {:hex, :connection, "1.1.0", "ff2a49c4b75b6fb3e674bfc5536451607270aac754ffd1bdfe175abe4a6d7a68", [:mix], [], "hexpm", "722c1eb0a418fbe91ba7bd59a47e28008a189d47e37e0e7bb85585a016b2869c"},

--- a/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
@@ -587,6 +587,27 @@ defmodule Astarte.RealmManagement.EngineTest do
   }
   """
 
+  @test_interface_h_0 """
+  {
+    "interface_name": "com.astarte.SomeInterface",
+    "version_major": 0,
+    "version_minor": 1,
+    "type": "datastream",
+    "ownership": "device",
+    "description": "Interface description.",
+    "doc": "Interface documentation.",
+    "mappings": [
+        {
+            "endpoint": "/aaa/a",
+            "type": "double",
+            "database_retention_policy": "use_ttl",
+            "database_retention_ttl": 60,
+            "explicit_timestamp": true
+        }
+    ]
+  }
+  """
+
   @test_trigger_policy_1 """
     {
       "name": "aname",
@@ -831,6 +852,47 @@ defmodule Astarte.RealmManagement.EngineTest do
              {:ok, [[major_version: 0, minor_version: 3]]}
 
     assert Engine.delete_interface("autotestrealm", "com.ObjectAggregation", 0) == :ok
+  end
+
+  @tag pr: 913
+  test "success to install interface when datastream_maximum_storage_retention equal to 0" do
+    DatabaseTestHelper.seed_realm_test_data!(
+      realm_name: "autotestrealm",
+      datastream_maximum_storage_retention: 0
+    )
+
+    assert Engine.install_interface("autotestrealm", @test_interface_h_0) == :ok
+  end
+
+  @tag pr: 913
+  test "success to install interface when database_retention_ttl lower than the maximum" do
+    DatabaseTestHelper.seed_realm_test_data!(
+      realm_name: "autotestrealm",
+      datastream_maximum_storage_retention: 70
+    )
+
+    assert Engine.install_interface("autotestrealm", @test_interface_h_0) == :ok
+  end
+
+  @tag pr: 913
+  test "success to install interface when database_retention_ttl equal the maximum" do
+    DatabaseTestHelper.seed_realm_test_data!(
+      realm_name: "autotestrealm",
+      datastream_maximum_storage_retention: 60
+    )
+
+    assert Engine.install_interface("autotestrealm", @test_interface_h_0) == :ok
+  end
+
+  @tag pr: 913
+  test "fail to install interface when database_retention_ttl is higher than the maximum" do
+    DatabaseTestHelper.seed_realm_test_data!(
+      realm_name: "autotestrealm",
+      datastream_maximum_storage_retention: 10
+    )
+
+    assert Engine.install_interface("autotestrealm", @test_interface_h_0) ==
+             {:error, :maximum_database_retention_exceeded}
   end
 
   test "delete datastream interface" do

--- a/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
@@ -1495,6 +1495,25 @@ defmodule Astarte.RealmManagement.EngineTest do
     assert {:error, :realm_not_found} = Engine.get_device_registration_limit(realm_name)
   end
 
+  test "retrieve datastream_maximum_storage_retention for an existing realm" do
+    retention = 10
+    realm_name = "autotestrealm"
+
+    DatabaseTestHelper.seed_realm_test_data!(
+      realm_name: realm_name,
+      datastream_maximum_storage_retention: retention
+    )
+
+    assert {:ok, ^retention} = Engine.get_datastream_maximum_storage_retention(realm_name)
+  end
+
+  test "fail to retrieve datastream_maximum_storage_retention if realm does not exist" do
+    realm_name = "realm#{System.unique_integer([:positive])}"
+
+    assert {:error, _} =
+             Engine.get_datastream_maximum_storage_retention(realm_name)
+  end
+
   defp unpack_source({:ok, source}) when is_binary(source) do
     interface_obj = Jason.decode!(source)
 

--- a/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
@@ -856,4 +856,22 @@ defmodule Astarte.RealmManagement.QueriesTest do
     realm_name = "realm#{System.unique_integer([:positive])}"
     assert {:error, :realm_not_found} = Queries.get_device_registration_limit(realm_name)
   end
+
+  test "retrieve datastream_maximum_storage_retention for an existing realm" do
+    retention = 10
+
+    DatabaseTestHelper.seed_realm_test_data!(
+      realm_name: @realm_name,
+      datastream_maximum_storage_retention: retention
+    )
+
+    assert {:ok, ^retention} = Queries.get_datastream_maximum_storage_retention(@realm_name)
+  end
+
+  test "fail to retrieve datastream_maximum_storage_retention if realm does not exist" do
+    realm_name = "realm#{System.unique_integer([:positive])}"
+
+    assert {:error, _} =
+             Queries.get_datastream_maximum_storage_retention(realm_name)
+  end
 end

--- a/apps/astarte_realm_management/test/support/database_fixtures.ex
+++ b/apps/astarte_realm_management/test/support/database_fixtures.ex
@@ -185,7 +185,8 @@ defmodule Astarte.RealmManagement.DatabaseFixtures do
   def realm_values do
     [
       realm_name: "realm#{System.unique_integer([:positive])}",
-      device_registration_limit: System.unique_integer([:positive])
+      device_registration_limit: System.unique_integer([:positive]),
+      datastream_maximum_storage_retention: System.unique_integer([:positive])
     ]
   end
 

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/realm_config/realm_config.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/realm_config/realm_config.ex
@@ -30,6 +30,10 @@ defmodule Astarte.RealmManagement.API.RealmConfig do
     RealmManagement.get_device_registration_limit(realm)
   end
 
+  def get_datastream_maximum_storage_retention(realm) do
+    RealmManagement.get_datastream_maximum_storage_retention(realm)
+  end
+
   def update_auth_config(realm, new_config_params) do
     with %Ecto.Changeset{valid?: true} = changeset <-
            AuthConfig.changeset(%AuthConfig{}, new_config_params),

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
@@ -23,6 +23,8 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
     DeleteTrigger,
     GenericErrorReply,
     GenericOkReply,
+    GetDatastreamMaximumStorageRetention,
+    GetDatastreamMaximumStorageRetentionReply,
     GetDeviceRegistrationLimit,
     GetDeviceRegistrationLimitReply,
     GetHealth,
@@ -148,6 +150,16 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
       realm_name: realm_name
     }
     |> encode_call(:get_device_registration_limit)
+    |> @rpc_client.rpc_call(@destination)
+    |> decode_reply()
+    |> extract_reply()
+  end
+
+  def get_datastream_maximum_storage_retention(realm_name) do
+    %GetDatastreamMaximumStorageRetention{
+      realm_name: realm_name
+    }
+    |> encode_call(:get_datastream_maximum_storage_retention)
     |> @rpc_client.rpc_call(@destination)
     |> decode_reply()
     |> extract_reply()
@@ -403,6 +415,22 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
           %GetDeviceRegistrationLimitReply{device_registration_limit: limit}}
        ) do
     {:ok, limit}
+  end
+
+  defp extract_reply(
+         {:get_datastream_maximum_storage_retention_reply,
+          %GetDatastreamMaximumStorageRetentionReply{
+            datastream_maximum_storage_retention: 0
+          }}
+       ) do
+    {:ok, nil}
+  end
+
+  defp extract_reply(
+         {:get_datastream_maximum_storage_retention_reply,
+          %GetDatastreamMaximumStorageRetentionReply{} = reply}
+       ) do
+    {:ok, reply.datastream_maximum_storage_retention}
   end
 
   defp extract_reply({:error, :rpc_error}) do

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/fallback_controller.ex
@@ -87,6 +87,13 @@ defmodule Astarte.RealmManagement.APIWeb.FallbackController do
     |> render(:overlapping_mappings)
   end
 
+  def call(conn, {:error, :maximum_database_retention_exceeded}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(Astarte.RealmManagement.APIWeb.ErrorView)
+    |> render(:maximum_database_retention_exceeded)
+  end
+
   def call(conn, {:error, :trigger_policy_not_found}) do
     conn
     |> put_status(:not_found)

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/realm_config_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/realm_config_controller.ex
@@ -36,6 +36,15 @@ defmodule Astarte.RealmManagement.APIWeb.RealmConfigController do
     end
   end
 
+  def show(conn, %{"realm_name" => realm_name, "group" => "datastream_maximum_storage_retention"}) do
+    with {:ok, datastream_maximum_storage_retention} =
+           RealmConfig.get_datastream_maximum_storage_retention(realm_name) do
+      render(conn, "show.json",
+        datastream_maximum_storage_retention: datastream_maximum_storage_retention
+      )
+    end
+  end
+
   def update(conn, %{"realm_name" => realm_name, "group" => "auth", "data" => new_config}) do
     with :ok <- RealmConfig.update_auth_config(realm_name, new_config) do
       send_resp(conn, :no_content, "")

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/error_view.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/error_view.ex
@@ -63,6 +63,10 @@ defmodule Astarte.RealmManagement.APIWeb.ErrorView do
     %{errors: %{detail: "Overlapping endpoints in interface mappings"}}
   end
 
+  def render("maximum_database_retention_exceeded.json", _assigns) do
+    %{errors: %{detail: "database_retention_ttl exceeds the maximum storage retention"}}
+  end
+
   def render("invalid_device_id.json", _assigns) do
     %{errors: %{detail: "The provided id is not a valid device id"}}
   end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/realm_config_view.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/realm_config_view.ex
@@ -32,6 +32,12 @@ defmodule Astarte.RealmManagement.APIWeb.RealmConfigView do
     }
   end
 
+  def render("show.json", %{datastream_maximum_storage_retention: ttl}) do
+    %{
+      data: ttl
+    }
+  end
+
   def render("auth_config.json", %{auth_config: auth_config}) do
     %{jwt_public_key_pem: auth_config.jwt_public_key_pem}
   end

--- a/apps/astarte_realm_management_api/mix.lock
+++ b/apps/astarte_realm_management_api/mix.lock
@@ -2,7 +2,7 @@
   "amqp": {:hex, :amqp, "3.3.0", "056d9f4bac96c3ab5a904b321e70e78b91ba594766a1fc2f32afd9c016d9f43b", [:mix], [{:amqp_client, "~> 3.9", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "8d3ae139d2646c630d674a1b8d68c7f85134f9e8b2a1c3dd5621616994b10a8b"},
   "amqp_client": {:hex, :amqp_client, "3.12.10", "dcc0d5d0037fa2b486c6eb8b52695503765b96f919e38ca864a7b300b829742d", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "16a23959899a82d9c2534ed1dcf1fa281d3b660fb7f78426b880647f0a53731f"},
   "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "685ca10c7a07cc9806f2c6fc7ec2ed1b4d23cbec", []},
-  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "5adf50beffa0bac18d99ebe378bc677c7669a767", []},
+  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "9b20db0077d99461f11a380e964689465aa566fa", []},
   "castore": {:hex, :castore, "0.1.22", "4127549e411bedd012ca3a308dede574f43819fe9394254ca55ab4895abfa1a2", [:mix], [], "hexpm", "c17576df47eb5aa1ee40cc4134316a99f5cad3e215d5c77b8dd3cfef12a22cac"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "cors_plug": {:hex, :cors_plug, "2.0.3", "316f806d10316e6d10f09473f19052d20ba0a0ce2a1d910ddf57d663dac402ae", [:mix], [{:plug, "~> 1.8", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm", "ee4ae1418e6ce117fc42c2ba3e6cbdca4e95ecd2fe59a05ec6884ca16d469aea"},

--- a/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
+++ b/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
@@ -97,6 +97,26 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+  '/{realm_name}/config/datastream_maximum_storage_retention':
+    parameters:
+      - $ref: '#/components/parameters/Realm'
+    get:
+      tags:
+        - config
+      summary: Get datastream maximum storage retention
+      description: Get the maximum storage retention for datastreams belonging to the realm, in seconds.
+      operationId: getDatastreamMaximumStorageRetention
+      security:
+        - JWT: []
+      responses:
+        '200':
+          $ref: '#/components/responses/GetDatastreamMaximumStorageRetention'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
   '/{realm_name}/interfaces':
     parameters:
       - $ref: '#/components/parameters/Realm'
@@ -537,6 +557,17 @@ components:
             properties:
               data:
                 $ref: '#/components/schemas/DeviceRegistrationLimit'
+    GetDatastreamMaximumStorageRetention:
+      description: Success
+      content:
+        application/json:
+          schema:
+            type: object
+            required:
+              - data
+            properties:
+              data:
+                $ref: '#/components/schemas/DatastreamMaximumStorageRetention'
     GetInterface:
       description: Success
       content:
@@ -934,6 +965,10 @@ components:
     DeviceRegistrationLimit:
       type: integer
       minimum: 0
+      example: 100
+    DatastreamMaximumStorageRetention:
+      type: integer
+      minimum: 1
       example: 100
     Interface:
       type: object

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/realm_config/realm_config_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/realm_config/realm_config_test.exs
@@ -79,5 +79,12 @@ defmodule Astarte.RealmManagement.API.RealmConfigTest do
 
       assert {:ok, ^limit} = RealmConfig.get_device_registration_limit(@realm)
     end
+
+    test "get_datastream_maximum_storage_retention/1 returns the retention for an existing realm" do
+      retention = 10
+      DB.put_datastream_maximum_storage_retention(@realm, retention)
+
+      assert {:ok, ^retention} = RealmConfig.get_datastream_maximum_storage_retention(@realm)
+    end
   end
 end

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/realm_config_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/realm_config_controller_test.exs
@@ -112,4 +112,14 @@ defmodule Astarte.RealmManagement.APIWeb.RealmControllerTest do
 
     assert json_response(conn, 200)["data"] == limit
   end
+
+  test "returns the datastream_maximum_storage_retention on show", %{conn: conn} do
+    retention = 10
+    DB.put_datastream_maximum_storage_retention(@realm, retention)
+
+    conn =
+      get(conn, realm_config_path(conn, :show, @realm, "datastream_maximum_storage_retention"))
+
+    assert json_response(conn, 200)["data"] == retention
+  end
 end

--- a/apps/astarte_realm_management_api/test/support/astarte_realm_management_mock.ex
+++ b/apps/astarte_realm_management_api/test/support/astarte_realm_management_mock.ex
@@ -2,6 +2,8 @@ defmodule Astarte.RealmManagement.Mock do
   alias Astarte.RPC.Protocol.RealmManagement.{
     Call,
     DeleteInterface,
+    GetDatastreamMaximumStorageRetention,
+    GetDatastreamMaximumStorageRetentionReply,
     GenericErrorReply,
     GenericOkReply,
     GetInterfaceSource,
@@ -259,6 +261,19 @@ defmodule Astarte.RealmManagement.Mock do
 
     %GetDeviceRegistrationLimitReply{device_registration_limit: value}
     |> encode_reply(:get_device_registration_limit_reply)
+    |> ok_wrap
+  end
+
+  defp execute_rpc(
+         {:get_datastream_maximum_storage_retention,
+          %GetDatastreamMaximumStorageRetention{
+            realm_name: realm_name
+          }}
+       ) do
+    value = DB.get_datastream_maximum_storage_retention(realm_name)
+
+    %GetDatastreamMaximumStorageRetentionReply{datastream_maximum_storage_retention: value}
+    |> encode_reply(:get_datastream_maximum_storage_retention_reply)
     |> ok_wrap
   end
 

--- a/apps/astarte_realm_management_api/test/support/astarte_realm_management_mock_db.ex
+++ b/apps/astarte_realm_management_api/test/support/astarte_realm_management_mock_db.ex
@@ -89,6 +89,10 @@ defmodule Astarte.RealmManagement.Mock.DB do
     Agent.get(__MODULE__, &Map.get(&1, "device_registration_limit_#{realm}"))
   end
 
+  def get_datastream_maximum_storage_retention(realm) do
+    Agent.get(__MODULE__, &Map.get(&1, "datastream_maximum_storage_retention_#{realm}"))
+  end
+
   def install_interface(realm, %Interface{name: name, major_version: major} = interface) do
     if get_interface(realm, name, major) != nil do
       {:error, :already_installed_interface}
@@ -128,6 +132,13 @@ defmodule Astarte.RealmManagement.Mock.DB do
 
   def put_device_registration_limit(realm, limit) do
     Agent.update(__MODULE__, &Map.put(&1, "device_registration_limit_#{realm}", limit))
+  end
+
+  def put_datastream_maximum_storage_retention(realm, retention) do
+    Agent.update(
+      __MODULE__,
+      &Map.put(&1, "datastream_maximum_storage_retention_#{realm}", retention)
+    )
   end
 
   def install_trigger_policy(realm, %Policy{name: name} = policy) do


### PR DESCRIPTION
Since we ~~will~~ allow to set/edit datastream max retention period in Housekeeping, add a way to retrieve its value in RM, too.

Moreover, as of today there are no checks  on whether an interface contains only mappings with `database_retention_ttl` lower than the maximum storage TTL allowed for the realm, making it possible to bypass the maximum allowed retention. Add this check on interface install and update. 
This change can be breaking, as some interfaces won't be installed anymore if the max allowed retention for the realm is set.

In the backend and RPC we use the Scylla [convention](https://opensource.docs.scylladb.com/stable/cql/time-to-live.html#notes) that TTL=0 means no TTL. However, the value given to the user if no maximum storage retention TTL is set will be the more understandable `null`.
