### PR TITLE
Add support for double values in payload cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.6] - Unreleased
 ### Fixed
 - [astarte_appengine_api] Allow to send binaryblobarrays over server owned interfaces.
+- [astarte_appengine_api] Doubles and DoubleArrays without decimal part are no longer saved as 
+  integer, but a trailing zero is added.
 - [astarte_data_updater_plant] Do not crash when receiving a malformed purge properties message.
 - [astarte_pairing_api] Gracefully handle HTTP requests with malformed payload.
 - [astarte_housekeeping_api] Gracefully handle HTTP requests with malformed payload.

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -747,6 +747,22 @@ defmodule Astarte.AppEngine.API.Device do
     end
   end
 
+  # conversion adding 0.0 is required because anyvalue comes from a json value,
+  # that does not distinguish from double or int and automatically strip out trailing decimal zeroes
+  defp cast_value(:double, anyvalue) do
+    {:ok, anyvalue + 0.0}
+  end
+
+  defp cast_value(:doublearray, values) do
+    case map_while_ok(values, &cast_value(:double, &1)) do
+      {:ok, mapped_values} ->
+        {:ok, mapped_values}
+
+      _ ->
+        {:error, :unexpected_value_type, expected: :doublearray}
+    end
+  end
+
   defp cast_value(_anytype, anyvalue) do
     {:ok, anyvalue}
   end


### PR DESCRIPTION
Add cast to double in case of update of a server owned property, before sending data to device

Resolves first and second part of https://github.com/astarte-platform/astartectl/issues/239
