### PR TITLE
Appengine: fix type for exchanged_bytes metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_pairing_api] Gracefully handle HTTP requests with malformed payload.
 - [astarte_housekeeping_api] Gracefully handle HTTP requests with malformed payload.
 - [astarte_realm_management_api] Gracefully handle HTTP requests with malformed payload.
+- [astarte_appengine_api] Expose exchanged_bytes metrics as `sum` (instead of `counter`).
 
 ## [1.0.5] - 2023-09-26
 ### Fixed

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
@@ -97,7 +97,7 @@ defmodule Astarte.AppEngine.APIWeb.Telemetry do
         tags: [:realm],
         description: "AppEngine sent messages count."
       ),
-      counter("astarte.appengine.device.message_sent.exchanged_bytes",
+      sum("astarte.appengine.device.message_sent.exchanged_bytes",
         tags: [:realm],
         description: "AppEngine exchanged bytes count."
       ),


### PR DESCRIPTION
Exchanged bytes should increase according to the byte size of a message. Thus, switch from "counter" to "sum".