### PR TITLE
Gghio/692/trigger name events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- [astarte_trigger_engine] Add `trigger_name` to envent payload
+  and mustache template
 - Add support for limiting the number of registered devices in a realm.
   Existing realms are not affected by this change.
 - [astarte_realm_management_api] Allow to read realm's device registration limit

--- a/doc/pages/architecture/060-triggers.md
+++ b/doc/pages/architecture/060-triggers.md
@@ -241,6 +241,7 @@ a JSON document with this format:
 {
   "timestamp": "<timestamp>",
   "device_id": "<device_id>",
+  "trigger_name": "<trigger_name>",
   "event": <event>
 }
 ```
@@ -249,6 +250,8 @@ a JSON document with this format:
 `"2019-10-16T08:56:08.534377Z"`) representing when the event happened.
 
 `device_id` identifies the device that triggered the event.
+
+`trigger_name` identifies the trigger that fired the event.
 
 `event` is a JSON object that has a specific structure depending on the type of the `simple_trigger`
 that generated it. Event objects are detailed below.
@@ -431,6 +434,7 @@ The basic keys that can be use to populate the template are:
 
 - `{{ realm }}`: the realm the trigger belongs to.
 - `{{ device_id }}`: the device that originated the trigger.
+- `{{ trigger_name }}`: the trigger name.
 - `{{ event_type }}`: the type of the received event.
 
 The `ignore_ssl_errors` key is optional and defaults to `false`. If set to `true`, any SSL error


### PR DESCRIPTION
## astarte_trigger_engine: add `trigger_name` to http event

Relative to https://github.com/astarte-platform/astarte/issues/692

Currently, when a Trigger delivers an Event, the Event does not contain any information about the Trigger that generated it. This means that to distinguish between two triggers on the same interface, users have to use some out of band mechanism (e.g. using a different URL or adding a fixed query parameter).

- Added `trigger_name` both in mustache template and event payload
- Updated doc

No tests in this PR (there aren't tests for event data validation)