### PR TITLE
Pairing: do not reset device stats on re-registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_housekeeping_api] Gracefully handle HTTP requests with malformed payload.
 - [astarte_realm_management_api] Gracefully handle HTTP requests with malformed payload.
 - [astarte_appengine_api] Expose exchanged_bytes metrics as `sum` (instead of `counter`).
+- [astarte_pairing] Do not reset total sent messages/bytes when re-registering a device.
+  Fix [#776](https://github.com/astarte-platform/astarte/issues/776).
 
 ## [1.0.5] - 2023-09-26
 ### Fixed

--- a/apps/astarte_pairing/test/astarte_pairing/engine_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/engine_test.exs
@@ -159,6 +159,29 @@ defmodule Astarte.Pairing.EngineTest do
       assert Enum.member?(introspection, {"org.astarteplatform.OtherValues", 1})
       assert Enum.member?(introspection_minor, {"org.astarteplatform.OtherValues", 2})
     end
+
+    test "does not reset received message count with registered and not confirmed device" do
+      total_received_msgs = System.unique_integer([:positive])
+      total_received_bytes = System.unique_integer([:positive])
+      hw_id = DatabaseTestHelper.registered_not_confirmed_hw_id()
+
+      assert DatabaseTestHelper.get_first_registration(hw_id) != nil
+
+      DatabaseTestHelper.set_received_message_count_for_device(
+        hw_id,
+        total_received_msgs,
+        total_received_bytes
+      )
+
+      assert {:ok, _new_credentials_secret} = Engine.register_device(@test_realm, hw_id)
+
+      assert [
+               %{
+                 "total_received_msgs" => ^total_received_msgs,
+                 "total_received_bytes" => ^total_received_bytes
+               }
+             ] = DatabaseTestHelper.get_message_count_for_device(hw_id)
+    end
   end
 
   describe "unregister device" do

--- a/apps/astarte_pairing/test/support/database_test_helper.ex
+++ b/apps/astarte_pairing/test/support/database_test_helper.ex
@@ -333,6 +333,51 @@ defmodule Astarte.Pairing.DatabaseTestHelper do
     :ok
   end
 
+  def get_message_count_for_device(device_id) do
+    {:ok, device_id} = Device.decode_device_id(device_id, allow_extended_id: true)
+
+    statement = """
+    SELECT total_received_msgs, total_received_bytes
+    FROM #{@test_realm}.devices
+    WHERE device_id=:device_id
+    """
+
+    %Xandra.Page{} =
+      page =
+      Xandra.Cluster.run(:xandra, fn conn ->
+        %Xandra.Prepared{} = prepared = Xandra.prepare!(conn, statement)
+        Xandra.execute!(conn, prepared, %{"device_id" => device_id}, uuid_format: :binary)
+      end)
+
+    Enum.to_list(page)
+  end
+
+  def set_received_message_count_for_device(device_id, total_received_msgs, total_received_bytes) do
+    {:ok, device_id} = Device.decode_device_id(device_id, allow_extended_id: true)
+
+    statement = """
+    UPDATE #{@test_realm}.devices
+    SET total_received_msgs = :total_received_msgs,
+        total_received_bytes = :total_received_bytes
+    WHERE device_id=:device_id
+    """
+
+    %Xandra.Void{} =
+      Xandra.Cluster.run(:xandra, fn conn ->
+        %Xandra.Prepared{} = prepared = Xandra.prepare!(conn, statement)
+
+        params = %{
+          "device_id" => device_id,
+          "total_received_msgs" => total_received_msgs,
+          "total_received_bytes" => total_received_bytes
+        }
+
+        Xandra.execute!(conn, prepared, params, uuid_format: :binary)
+      end)
+
+    :ok
+  end
+
   def drop_db do
     client =
       Config.cassandra_node!()


### PR DESCRIPTION
When a device is unregistered and re-registered, the total sent bytes/messages counters are set to 0. This causes an inconsistency with bytes sent on interfaces. Fix this by not resetting counters. Fix #776.

Code is duplicated in `queries.ex` because string-based querying does not allow for much extensibility.
