### PR TITLE
Forward-port changes from release 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 - Forward-port changes from release-1.0 (gracefully handle malformed
-  purge properties messages).
+  purge properties messages, fix message count metrics, fix typing issues
+  in payloads).
 - [astarte_data_updater_plant] do not leak consumer channels in corner cases.
 - [astarte_data_updater_plant] do not leak producer channels in corner cases.
 
-## [1.1.1.] - 2023-11-15
+## [1.1.1] - 2023-11-15
 ### Fixed
 - [astarte_data_updater_plant] Don't crash when retrieving the interface version
   in a device whose introspection is empty, allowing data in `astarte-data_`
@@ -70,10 +71,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_appengine_api] Return empty data instead of error when querying `properties` interfaces 
   which are not fully populated. Fix [531](astarte-platform#531).
 
-## [1.0.6] - Unreleased
+## [1.0.6] - 2024-04-23
 ### Fixed
 - [astarte_appengine_api] Allow to send binaryblobarrays over server owned interfaces.
+- [astarte_appengine_api] Doubles and DoubleArrays without decimal part are no longer saved as 
+  integer, but a trailing zero is added.
 - [astarte_data_updater_plant] Do not crash when receiving a malformed purge properties message.
+- [astarte_pairing_api] Gracefully handle HTTP requests with malformed payload.
+- [astarte_housekeeping_api] Gracefully handle HTTP requests with malformed payload.
+- [astarte_realm_management_api] Gracefully handle HTTP requests with malformed payload.
+- [astarte_appengine_api] Expose exchanged_bytes metrics as `sum` (instead of `counter`).
+- [astarte_pairing] Do not reset total sent messages/bytes when re-registering a device.
+  Fix [#776](https://github.com/astarte-platform/astarte/issues/776).
 
 ## [1.0.5] - 2023-09-26
 ### Fixed

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -750,6 +750,22 @@ defmodule Astarte.AppEngine.API.Device do
     end
   end
 
+  # conversion adding 0.0 is required because anyvalue comes from a json value,
+  # that does not distinguish from double or int and automatically strip out trailing decimal zeroes
+  defp cast_value(:double, anyvalue) do
+    {:ok, anyvalue + 0.0}
+  end
+
+  defp cast_value(:doublearray, values) do
+    case map_while_ok(values, &cast_value(:double, &1)) do
+      {:ok, mapped_values} ->
+        {:ok, mapped_values}
+
+      _ ->
+        {:error, :unexpected_value_type, expected: :doublearray}
+    end
+  end
+
   defp cast_value(_anytype, anyvalue) do
     {:ok, anyvalue}
   end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
@@ -97,7 +97,7 @@ defmodule Astarte.AppEngine.APIWeb.Telemetry do
         tags: [:realm],
         description: "AppEngine sent messages count."
       ),
-      counter("astarte.appengine.device.message_sent.exchanged_bytes",
+      sum("astarte.appengine.device.message_sent.exchanged_bytes",
         tags: [:realm],
         description: "AppEngine exchanged bytes count."
       ),

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/error_view.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/views/error_view.ex
@@ -19,6 +19,10 @@
 defmodule Astarte.Housekeeping.APIWeb.ErrorView do
   use Astarte.Housekeeping.APIWeb, :view
 
+  def render("400.json", _assigns) do
+    %{errors: %{detail: "Bad request"}}
+  end
+
   def render("404.json", _assigns) do
     %{errors: %{detail: "Page not found"}}
   end

--- a/apps/astarte_pairing/test/astarte_pairing/engine_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/engine_test.exs
@@ -159,6 +159,29 @@ defmodule Astarte.Pairing.EngineTest do
       assert Enum.member?(introspection, {"org.astarteplatform.OtherValues", 1})
       assert Enum.member?(introspection_minor, {"org.astarteplatform.OtherValues", 2})
     end
+
+    test "does not reset received message count with registered and not confirmed device" do
+      total_received_msgs = System.unique_integer([:positive])
+      total_received_bytes = System.unique_integer([:positive])
+      hw_id = DatabaseTestHelper.registered_not_confirmed_hw_id()
+
+      assert DatabaseTestHelper.get_first_registration(hw_id) != nil
+
+      DatabaseTestHelper.set_received_message_count_for_device(
+        hw_id,
+        total_received_msgs,
+        total_received_bytes
+      )
+
+      assert {:ok, _new_credentials_secret} = Engine.register_device(@test_realm, hw_id)
+
+      assert [
+               %{
+                 "total_received_msgs" => ^total_received_msgs,
+                 "total_received_bytes" => ^total_received_bytes
+               }
+             ] = DatabaseTestHelper.get_message_count_for_device(hw_id)
+    end
   end
 
   describe "unregister device" do

--- a/apps/astarte_pairing/test/support/database_test_helper.ex
+++ b/apps/astarte_pairing/test/support/database_test_helper.ex
@@ -333,6 +333,51 @@ defmodule Astarte.Pairing.DatabaseTestHelper do
     :ok
   end
 
+  def get_message_count_for_device(device_id) do
+    {:ok, device_id} = Device.decode_device_id(device_id, allow_extended_id: true)
+
+    statement = """
+    SELECT total_received_msgs, total_received_bytes
+    FROM #{@test_realm}.devices
+    WHERE device_id=:device_id
+    """
+
+    %Xandra.Page{} =
+      page =
+      Xandra.Cluster.run(:xandra, fn conn ->
+        %Xandra.Prepared{} = prepared = Xandra.prepare!(conn, statement)
+        Xandra.execute!(conn, prepared, %{"device_id" => device_id}, uuid_format: :binary)
+      end)
+
+    Enum.to_list(page)
+  end
+
+  def set_received_message_count_for_device(device_id, total_received_msgs, total_received_bytes) do
+    {:ok, device_id} = Device.decode_device_id(device_id, allow_extended_id: true)
+
+    statement = """
+    UPDATE #{@test_realm}.devices
+    SET total_received_msgs = :total_received_msgs,
+        total_received_bytes = :total_received_bytes
+    WHERE device_id=:device_id
+    """
+
+    %Xandra.Void{} =
+      Xandra.Cluster.run(:xandra, fn conn ->
+        %Xandra.Prepared{} = prepared = Xandra.prepare!(conn, statement)
+
+        params = %{
+          "device_id" => device_id,
+          "total_received_msgs" => total_received_msgs,
+          "total_received_bytes" => total_received_bytes
+        }
+
+        Xandra.execute!(conn, prepared, params, uuid_format: :binary)
+      end)
+
+    :ok
+  end
+
   def drop_db do
     client =
       Config.cassandra_node!()

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/views/error_view.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/views/error_view.ex
@@ -19,6 +19,10 @@
 defmodule Astarte.Pairing.APIWeb.ErrorView do
   use Astarte.Pairing.APIWeb, :view
 
+  def render("400.json", _assigns) do
+    %{errors: %{detail: "Bad request"}}
+  end
+
   def render("401.json", _assigns) do
     %{errors: %{detail: "Unauthorized"}}
   end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/error_view.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/error_view.ex
@@ -19,6 +19,10 @@
 defmodule Astarte.RealmManagement.APIWeb.ErrorView do
   use Astarte.RealmManagement.APIWeb, :view
 
+  def render("400.json", _assigns) do
+    %{errors: %{detail: "Bad request"}}
+  end
+
   def render("404.json", _assigns) do
     %{errors: %{detail: "Not found"}}
   end


### PR DESCRIPTION
Forward-port a number of changes from release 1.0, most notably fixes when handling malformed payloads and server-side data, plus moving to a coherent semantics regarding device message count stats.
