### PR TITLE
AppEngine: access again `Config` in `rooms/room.ex`

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/room.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/room.ex
@@ -25,6 +25,7 @@ defmodule Astarte.AppEngine.API.Rooms.Room do
   alias Astarte.AppEngine.API.RPC.DataUpdaterPlant
   alias Astarte.AppEngine.API.RPC.DataUpdaterPlant.VolatileTrigger
   alias Astarte.AppEngine.API.Utils
+  alias Astarte.AppEngine.API.Config
   alias Astarte.AppEngine.APIWeb.Endpoint
   alias Astarte.Core.Triggers.SimpleTriggerConfig
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.AMQPTriggerTarget


### PR DESCRIPTION
The `Astarte.AppEngine.API.Config` module was removed from the alias list by chance, resulting in an `undefined` error when calling `Config.rooms_events_routing_key!/0`. Add it back.

