### PR TITLE
Add connection_error handler

### DIFF
--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/policy/policy.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/policy/policy.ex
@@ -79,6 +79,9 @@ defmodule Astarte.TriggerEngine.Policy do
       {:http_error, status_code} ->
         maybe_requeue_message(chan, meta, status_code, policy, retry_map)
 
+      {:error, :connection_error} ->
+        maybe_requeue_message(chan, meta, 503, policy, retry_map)
+
       {:error, :trigger_not_found} ->
         discard_message(chan, meta, policy, retry_map)
     end


### PR DESCRIPTION
Add :connection_error exception handler when executing a trigger policy, then try to re-enqueue as 408 (timeout) error

resolves https://github.com/astarte-platform/astarte/issues/936
