### PR TITLE
TE: handle failure to connect to trigger target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_data_updater_plant] do not leak producer channels in corner cases.
 - [astarte_trigger_engine] Always treat event TTL for trigger policies in seconds,
   not milliseconds.
+- [astarte_trigger_engine] ack messages even with unreachable target (see https://github.com/astarte-platform/astarte/issues/936)
 
 ## [1.1.1] - 2023-11-15
 ### Fixed

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/policy/policy.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/policy/policy.ex
@@ -79,6 +79,9 @@ defmodule Astarte.TriggerEngine.Policy do
       {:http_error, status_code} ->
         maybe_requeue_message(chan, meta, status_code, policy, retry_map)
 
+      {:error, :connection_error} ->
+        maybe_requeue_message(chan, meta, 503, policy, retry_map)
+
       {:error, :trigger_not_found} ->
         discard_message(chan, meta, policy, retry_map)
     end


### PR DESCRIPTION
Add :connection_error exception when handling a trigger policy response, then try to re-enqueue as 503 error

resolves https://github.com/astarte-platform/astarte/issues/936