### PR TITLE
Trigger policy TTL in seconds, also in release-1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   in payloads).
 - [astarte_data_updater_plant] do not leak consumer channels in corner cases.
 - [astarte_data_updater_plant] do not leak producer channels in corner cases.
+- [astarte_trigger_engine] Always treat event TTL for trigger policies in seconds,
+  not milliseconds.
 
 ## [1.1.1] - 2023-11-15
 ### Fixed

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_message_consumer.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_message_consumer.ex
@@ -201,7 +201,8 @@ defmodule Astarte.TriggerEngine.AMQPConsumer.AMQPMessageConsumer do
        }) do
     []
     |> put_x_arg_if(maximum_capacity != nil, {"x-max-length", :signedint, maximum_capacity})
-    |> put_x_arg_if(event_ttl != nil, {"x-message-ttl", :signedint, event_ttl})
+    # AMQP message TTLs are in milliseconds!
+    |> put_x_arg_if(event_ttl != nil, {"x-message-ttl", :signedint, event_ttl * 1_000})
   end
 
   defp put_x_arg_if(list, true, x_arg), do: [x_arg | list]

--- a/doc/pages/architecture/062-trigger_delivery_policies.md
+++ b/doc/pages/architecture/062-trigger_delivery_policies.md
@@ -48,7 +48,7 @@ A Trigger Delivery Policy is composed of:
   This is optional, but required if the policy specifies at least one handler with retry strategy.
 
 - Event TTL: in order to further lower the space requirement of the event queue, events may be equipped with a TTL which specifies the amount of
-  milliseconds an event is retained in the event queue. When an event expires, it is discarded from the event queue, even if it has not been
+  seconds an event is retained in the event queue. When an event expires, it is discarded from the event queue, even if it has not been
   delivered. This is optional.
 
 


### PR DESCRIPTION
Backport #950 into release-1.1.