### PR TITLE
Trigger Engine: do not crash when trigger policy has a ttl

### DIFF
--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_message_consumer.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_message_consumer.ex
@@ -200,9 +200,9 @@ defmodule Astarte.TriggerEngine.AMQPConsumer.AMQPMessageConsumer do
          event_ttl: event_ttl
        }) do
     []
-    |> put_x_arg_if(max_capacity != nil, fn _ -> {"x-max-length", :signedint, max_capacity} end)
+    |> put_x_arg_if(max_capacity != nil, fn -> {"x-max-length", :signedint, max_capacity} end)
     # AMQP message TTLs are in milliseconds!
-    |> put_x_arg_if(event_ttl != nil, fn _ -> {"x-message-ttl", :signedint, event_ttl * 1_000} end)
+    |> put_x_arg_if(event_ttl != nil, fn -> {"x-message-ttl", :signedint, event_ttl * 1_000} end)
   end
 
   defp put_x_arg_if(list, true, x_arg_fun), do: [x_arg_fun.() | list]


### PR DESCRIPTION
Fix a bug introduced in #952 where the TTL x-arg is not correctly generated leading to a crash.
