### PR TITLE
Workflows: add build and push to Dockerhub workflow 

### DIFF
--- a/.github/workflows/publish-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-release-to-dockerhub-workflow.yaml
@@ -1,0 +1,61 @@
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker images
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_release_to_registry:
+    name: Push Docker images to Docker Hub
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: true
+      matrix:
+        app:
+        - astarte_appengine_api
+        - astarte_data_updater_plant
+        - astarte_housekeeping
+        - astarte_housekeeping_api
+        - astarte_pairing
+        - astarte_pairing_api
+        - astarte_realm_management
+        - astarte_realm_management_api
+        - astarte_trigger_engine
+    needs: [test-coverage, end-to-end-test]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            astarte/${{ matrix.app }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push tagged Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: apps/${{ matrix.app }}
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
@@ -1,0 +1,74 @@
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish snapshot Docker images
+
+on:
+  push:
+    paths:
+    - 'apps/**'
+    - '.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml'
+    - 'Dockerfile'
+    branches:
+    - 'master'
+    - 'release-*'
+
+jobs:
+  push_snapshot_to_registry:
+    name: Push Docker images to Docker Hub
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: true
+      matrix:
+        app:
+        - astarte_appengine_api
+        - astarte_data_updater_plant
+        - astarte_housekeeping
+        - astarte_housekeeping_api
+        - astarte_pairing
+        - astarte_pairing_api
+        - astarte_realm_management
+        - astarte_realm_management_api
+        - astarte_trigger_engine
+    needs: [test-coverage, end-to-end-test]
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Compute tag name for snapshot images
+        id: compute-tag
+        run: |
+          export TAG="$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-\(.*\)/\1-snapshot/g' )"
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            astarte/${{ matrix.app }}
+          tags: |
+            # TODO we probably want something smarter, but the 'pattern' type runs only on tags at the moment
+            type=raw,value=${{ steps.compute-tag.outputs.TAG }}
+
+      - name: Build and push tagged Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: apps/${{ matrix.app }}
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-tool-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-tool-release-to-dockerhub-workflow.yaml
@@ -1,0 +1,55 @@
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker images of Astarte tools
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_tool_release_to_registry:
+    name: Push Docker images of Astarte tools to Docker Hub 
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: true
+      matrix:
+        app:
+        - astarte_device_fleet_simulator
+        - astarte_e2e
+        - astarte_export
+        - astarte_import
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) of Astarte tools for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            astarte/${{ matrix.app }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push tagged Docker image of Astarte tools
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: tools/${{ matrix.app }}
+          file: tools/${{ matrix.app }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-tool-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-tool-snapshot-to-dockerhub-workflow.yaml
@@ -1,0 +1,67 @@
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish snapshot Docker images of Astarte tools
+
+on:
+  push:
+    paths:
+    - 'tools/**'
+    - '.github/workflows/publish-tool-snapshot-to-dockerhub-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+
+jobs:
+  push_tool_snapshot_to_registry:
+    name: Push Docker images of Astarte tools to Docker Hub
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: true
+      matrix:
+        app:
+        - astarte_device_fleet_simulator
+        - astarte_e2e
+        - astarte_export
+        - astarte_import
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Compute tag name for snapshot images of Astarte tools
+        id: compute-tag
+        run: |
+          export TAG="$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-\(.*\)/\1-snapshot/g' )"
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Extract metadata (tags, labels) of Astarte tools for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            astarte/${{ matrix.app }}
+          tags: |
+            # TODO we probably want something smarter, but the 'pattern' type runs only on tags at the moment
+            type=raw,value=${{ steps.compute-tag.outputs.TAG }}
+
+      - name: Build and push tagged Docker image of Astarte tools
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: tools/${{ matrix.app }}
+          file: tools/${{ matrix.app }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Since now we are using the new docker build infra, the old image building and publishing workflow, based on dockerhub runners, is broken.
Replace it with a new one, this time fully based on Github, to standardize the image publishing process.
`DOCKER_USERNAME` and `DOCKER_PASSWORD` of the registry must be added to repo secrets for this to work.

In order to separate the flow of tagged and untagged builds, workflows are splitted: one works only on tags, the other on everyday push events. Examples:
- When a change is merged into a release branch, say `release-1.2`, new images with `1.2-snapshot` tag are built and pushed to astarte's dockerhub;
- When a change is merged into the `master` branch, new images with `snapshot` tag are built and pushed to astarte's dockerhub;
- When a new Github release, say `v1.2.0`, is made, new images with `1.2.0` tag are build and pushed to astarte's dockerhub 
- When a new Github pre-release, say `v1.2.0-rc.1`, is made, new images with `1.2.0-rc.1` tag are build and pushed to astarte's dockerhub 

(also, a small astartectl version bump)

This PR is based, based on #956.

Since this is not a small change, discussion on how/where/why to publish images is welcome.