### PR TITLE
AppEngine: handle type casting for `longinteger` inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [astarte_trigger_engine] Always treat event TTL for trigger policies in seconds,
   not milliseconds.
 - [astarte_trigger_engine] ack messages even with unreachable target (see https://github.com/astarte-platform/astarte/issues/936)
+- [astarte_appengine_api] Handle type casting for `longinteger` inputs
 
 ## [1.1.1] - 2023-11-15
 ### Fixed

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -766,6 +766,34 @@ defmodule Astarte.AppEngine.API.Device do
     end
   end
 
+  defp cast_value(:longinteger, string_value) when is_binary(string_value) do
+    case Integer.parse(string_value) do
+      {int_value, ""} ->
+        {:ok, int_value}
+
+      _ ->
+        {:error, :unexpected_value_type, expected: :longinteger}
+    end
+  end
+
+  defp cast_value(:longinteger, int_value) when is_integer(int_value) do
+    {:ok, int_value}
+  end
+
+  defp cast_value(:longinteger, _value) do
+    {:error, :unexpected_value_type, expected: :longinteger}
+  end
+
+  defp cast_value(:longintegerarray, values) do
+    case map_while_ok(values, &cast_value(:longinteger, &1)) do
+      {:ok, mapped_values} ->
+        {:ok, mapped_values}
+
+      _ ->
+        {:error, :unexpected_value_type, expected: :longintegerarray}
+    end
+  end
+
   defp cast_value(_anytype, anyvalue) do
     {:ok, anyvalue}
   end


### PR DESCRIPTION
Implemented `cast_value/2` functions to support string input parsing for `longinteger` values and arrays in server-owned interfaces. This implementation enables parsing of string inputs into integers where necessary.

Fixes #967 