### PR TITLE
docs: empty parameter is not allowed

### DIFF
--- a/doc/pages/architecture/030-interface.md
+++ b/doc/pages/architecture/030-interface.md
@@ -225,9 +225,9 @@ of a valid aggregated interface mapping:
 Additional limitations (which stem from the MQTT protocol specification) can be outlined. When using
 parametric endpoints, the actual values used in place of parameter placeholders must fulfill the
 following requirements:
-* endpoint parameters must be UTF-8 encoded strings;
-* endpoint parameters must not contain the following characters: `+` and `#`. In particular, those
-  characters are treated as wildcards for MQTT topics and therefore must be avoided;
+* endpoint parameters must be non-empty UTF-8 encoded strings;
+* endpoint parameters must not contain the following characters: `+` and `#`. Those characters are
+  treated as wildcards for MQTT topics and therefore must be avoided;
 * endpoint parameters must not contain the `/` character.
 
 ## Aggregation

--- a/doc/pages/architecture/040-interface_schema.md
+++ b/doc/pages/architecture/040-interface_schema.md
@@ -154,7 +154,8 @@ Additional properties are allowed.
 The template of the path. This is a UNIX-like path (e.g. /my/path) and can be parametrized.
 Parameters are in the %{name} form, and can be used to create interfaces which represent
 dictionaries of mappings. When the interface aggregation is object, an object is composed by all the
-mappings for one specific parameter combination.
+mappings for one specific parameter combination. Refer to the mapping section of the
+[interface](030-interface.html) page for further details on allowed parameter substitution values.
 
 * **Type**: `string`
 * **Required**: Yes


### PR DESCRIPTION
Document that empty parameters are not allowed in a mapping.
Closes #983 
