### PR TITLE
FIX: errors from previous PRs #978 #982

### DIFF
--- a/tools/astarte_dev_tool/README.md
+++ b/tools/astarte_dev_tool/README.md
@@ -25,6 +25,10 @@ To start `docker compose` in development mode, use:
 mix astarte_dev_tool.system.up --path <astarte-path>
 ```
 
+where the following options are:
+
+* `-p` `--path` - (required) working Astarte project directory
+
 ### Stopping the System
 
 To stop `docker compose` in development mode, use:
@@ -32,6 +36,10 @@ To stop `docker compose` in development mode, use:
 ```bash
 mix astarte_dev_tool.system.down --path <astarte-path>
 ```
+
+where the following options are:
+
+* `-p` `--path` - (required) working Astarte project directory 
 
 ### Watching for Changes
 
@@ -41,6 +49,10 @@ To enable watch mode for hot-code-reloading, use:
 mix astarte_dev_tool.system.watch --path <astarte-path>
 ```
 
+where the following options are:
+
+* `-p` `--path` - (required) working Astarte project directory
+
 This command will start the system in watch mode and keep running in the foreground, allowing for real-time code reloading during development.
 
 ### Accessing the Dashboard
@@ -48,14 +60,17 @@ This command will start the system in watch mode and keep running in the foregro
 To open an authenticated Dashboard session on your web browser:
 
 ```bash
-mix astarte_dev_tool.dashboard.open
+mix astarte_dev_tool.dashboard.open --path 
 ```
 
-where the following options can be specified:
-- `--realm-name`, or `-r`, for the name of the Astarte realm. It defaults to `test`.
-- `--realm-private-key`, or `-k`, for the path of the private key for the Astarte realm. It defaults to `../../test_private.pem`, which assumes the user has followed the [Astarte in 5 minutes guide](https://docs.astarte-platform.org/astarte/latest/010-astarte_in_5_minutes.html).
-- `--auth-token`, or `-t`, for the auth token to use. If specified, it takes precedence over the `--realm-private-key` option.
-- `--dashboard-url`, or `-u`, for the URL of the Astarte Dashboard. It defaults to `http://dashboard.astarte.localhost`.
+where the following options are:
+
+* `-r` `--realm-name` - (required) The name of the Astarte realm.
+* `-u` `--dashboard-url` - (required) The URL of the Astarte Dashboard
+* `-k` `--realm-private-key` - (required if --auth-token is not provided) The path of the private key for the Astarte
+  realm.
+* `-t` `--auth-token` - (required if --realm-private-key is not provided) The auth token to use. If specified, it takes
+  precedence over the --realm-private-key option.
 
 ---
 
@@ -63,8 +78,8 @@ where the following options can be specified:
 
 1. Start the system: `mix astarte_dev_tool.system.up --path ../../../astarte`
 2. Enable watch mode: `mix astarte_dev_tool.system.watch --path ../../../astarte`
-3. Open the Astarte Dashboard: `mix astarte_dev_tool.dashboard.open --realm-name test --realm-private-key ../../../astarte/test_private.pem`
-3. Stop the system: `mix astarte_dev_tool.system.down --path ../../../astarte`
+3. Open the Astarte Dashboard: `mix astarte_dev_tool.dashboard.open --realm-name test --dashboard-url http://dashboard.astarte.localhost --realm-private-key ../../../astarte/test_private.pem`
+4. Stop the system: `mix astarte_dev_tool.system.down --path ../../../astarte`
 
 These commands will help you manage the development environment for Astarte efficiently.
 

--- a/tools/astarte_dev_tool/lib/mix/tasks/astarte_dev_tool/system/down.ex
+++ b/tools/astarte_dev_tool/lib/mix/tasks/astarte_dev_tool/system/down.ex
@@ -39,8 +39,8 @@ defmodule Mix.Tasks.AstarteDevTool.System.Down do
 
   ## Examples
 
-      $ mix system.down -p /absolute/path/astarte
-      $ mix system.down -p ../../relative/to/astarte -v
+      $ mix astarte_dev_tool.system.down -p /absolute/path/astarte
+      $ mix astarte_dev_tool.system.down -p ../../relative/to/astarte -v
 
   ## Command line options
     * `-p` `--path` - (required) working Astarte project directory

--- a/tools/astarte_dev_tool/lib/mix/tasks/astarte_dev_tool/system/up.ex
+++ b/tools/astarte_dev_tool/lib/mix/tasks/astarte_dev_tool/system/up.ex
@@ -37,8 +37,8 @@ defmodule Mix.Tasks.AstarteDevTool.System.Up do
 
   ## Examples
 
-      $ mix system.up -p /absolute/path/astarte
-      $ mix system.up -p ../../relative/to/astarte
+      $ mix astarte_dev_tool.system.up -p /absolute/path/astarte
+      $ mix astarte_dev_tool.system.up -p ../../relative/to/astarte
 
   ## Command line options
     * `-p` `--path` - (required) working Astarte project directory

--- a/tools/astarte_dev_tool/lib/mix/tasks/astarte_dev_tool/system/watch.ex
+++ b/tools/astarte_dev_tool/lib/mix/tasks/astarte_dev_tool/system/watch.ex
@@ -37,8 +37,8 @@ defmodule Mix.Tasks.AstarteDevTool.System.Watch do
 
   ## Examples
 
-      $ mix system.watch -p /absolute/path/astarte
-      $ mix system.watch -p ../../relative/to/astarte
+      $ mix astarte_dev_tool.system.watch -p /absolute/path/astarte
+      $ mix astarte_dev_tool.system.watch -p ../../relative/to/astarte
 
   ## Command line options
     * `-p` `--path` - (required) working Astarte project directory

--- a/tools/astarte_dev_tool/lib/utilities/auth.ex
+++ b/tools/astarte_dev_tool/lib/utilities/auth.ex
@@ -16,20 +16,10 @@
 # limitations under the License.
 #
 
-defmodule AstarteDevTool.Utilities.Path do
-  @moduledoc false
-  def path_from(path) when is_bitstring(path) do
-    abs_path = Path.expand(path)
-    if File.exists?(abs_path), do: {:ok, abs_path}, else: {:error, "Invalid path: #{path}"}
-  end
+defmodule AstarteDevTool.Utilities.Auth do
+  alias Astarte.Client.Credentials
 
-  def directory_path_from(path) when is_bitstring(path) do
-    case path_from(path) do
-      {:ok, abs_path} ->
-        if File.dir?(abs_path), do: {:ok, abs_path}, else: {:error, "#{path} is not a directory"}
-
-      error ->
-        error
-    end
+  def gen_auth_token(private_key) when is_bitstring(private_key) do
+    Credentials.dashboard_credentials() |> Credentials.to_jwt(private_key)
   end
 end


### PR DESCRIPTION
#### What this PR does / why we need it:

Previous PRs contained documentation errors and could be improved at code level

* added existence check of `_private.pem` file
* checked the parameters of `mix astarte_dev_tool.dashboard.start`.
* various documentation fixes
