### PR TITLE
chore(doc): add the websocket url for channels

### DIFF
--- a/doc/mix.exs
+++ b/doc/mix.exs
@@ -41,7 +41,7 @@ defmodule Doc.MixProject do
         "User Guide": ~r"/user/",
         "Administrator Guide": ~r"/administrator/",
         Tutorials: ~r"/tutorials/",
-        "REST API Reference": ~r"/api/"
+        "API Reference": ~r"/api/"
       ],
       groups_for_modules: [
         "App Engine": ~r"Astarte.AppEngine",

--- a/doc/pages/api/001-intro_api.md
+++ b/doc/pages/api/001-intro_api.md
@@ -1,7 +1,18 @@
 # Introduction
 
+## REST API
+
 <img align="right" src="assets/mascot_developer.svg" style="border:20px solid transparent" alt="Join Puppy Lion and have some fun with Astarte!" width="40%" />
 
-Astarte's APIs are documented through [Swagger](https://swagger.io/). Your Astarte installation probably already has Swagger UI support, which serves as the reference for your installed APIs.
+Astarte's APIs are documented through [Swagger](https://swagger.io/). Your Astarte installation
+probably already has Swagger UI support, which serves as the reference for your installed APIs.
 
 To browse API documentation online, [follow this link](api/index.html).
+
+## WebSocket Astarte Channels
+
+The AppEngine API for Astarte Channels is located at the URL:
+`ws://<astarte-base-url>/appengine/v1/socket/websocket`.
+
+To learn how to use the Channels API, you can read the documentation at:
+[Using Astarte Channels (WebSockets)](user/052-using_channels.md)

--- a/doc/pages/user/052-using_channels.md
+++ b/doc/pages/user/052-using_channels.md
@@ -6,6 +6,9 @@ provide such a thing over [WebSockets](https://en.wikipedia.org/wiki/WebSocket) 
 WebSockets can be used natively from a Web Browser and follow the same authentication pattern as a
 standard HTTP call.
 
+The AppEngine API for Astarte Channels is located at the URL:
+`ws://<astarte-base-url>/appengine/v1/socket/websocket`.
+
 Astarte Channels define a semantic on top of Phoenix Channels which allows read-only monitoring of
 `device` Interfaces. Authentication and Authorization over Channels happens in the very same way as
 `AppEngine`, and the `a_ch` claim in the token is respected when joining rooms and installing


### PR DESCRIPTION
Specify in the Astarte Channels documentation page the AppEngine URL for the WebSocket channel.