### PR TITLE
[Doc] Astarte 1.1 is stable. Remove the "unstable" warning.

### DIFF
--- a/doc/pages/user/001-intro_user.md
+++ b/doc/pages/user/001-intro_user.md
@@ -2,8 +2,6 @@
 
 <img align="right" src="assets/mascot_developer.svg" style="border:20px solid transparent" alt="Join Puppy Lion and have some fun with Astarte!" width="40%" />
 
-**This documentation page describes a development version, for production systems please use the [stable version](https://docs.astarte-platform.org/latest) instead.**
-
 Astarte is an Open Source IoT platform focused on Data management. It takes care of everything from collecting data from devices to delivering data to end-user applications. To achieve such a thing, it uses a mixture of mechanisms and paradigm to store organized data, perform live queries.
 
 This guide focuses on daily operations for Astarte users and integrators. It goes through fundamental operations such as setting up triggers, querying APIs, integrating 3rd party applications and more.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
  Nothing added to the changelog.
* [x] I have added or ran the appropriate tests
  The documentation was succsessfully built with `mix docs` in the dev env.
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
The documentation of Astarte 1.1 was showing a warning stating that it was an unstable version. That was both wrong and misleading. Remove that statement.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
