### PR TITLE
Remove --watch with --detach options in docker compose up

### DIFF
--- a/tools/astarte_dev_tool/lib/constants/system.ex
+++ b/tools/astarte_dev_tool/lib/constants/system.ex
@@ -20,12 +20,15 @@ defmodule AstarteDevTool.Constants.System do
   def command, do: "docker"
 
   def command_up_args,
-    do: ~w(compose -f docker-compose.yml -f docker-compose.dev.yml up --build --watch -d)
+    do: ~w(compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d)
 
   def command_down_args, do: ~w(compose -f docker-compose.yml -f docker-compose.dev.yml down)
 
   def command_watch_args,
     do: ~w(compose -f docker-compose.yml -f docker-compose.dev.yml watch --no-up)
+
+  def command_version_args,
+    do: ~w(version --format '{{.Client.Version}}')
 
   def base_opts, do: [stderr_to_stdout: true, into: IO.stream(:stdio, :line)]
 end

--- a/tools/astarte_dev_tool/lib/mix/tasks/astarte_dev_tool/system/up.ex
+++ b/tools/astarte_dev_tool/lib/mix/tasks/astarte_dev_tool/system/up.ex
@@ -20,6 +20,7 @@ defmodule Mix.Tasks.AstarteDevTool.System.Up do
   use Mix.Task
   alias AstarteDevTool.Commands.System.Up
   alias AstarteDevTool.Utilities.Path
+  alias AstarteDevTool.Utilities.Process
 
   @shortdoc "Up the local Astarte system"
 
@@ -53,6 +54,10 @@ defmodule Mix.Tasks.AstarteDevTool.System.Up do
   @impl true
   def run(args) do
     {opts, _} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
+    {:ok, is_valid} = Process.check_valid_version()
+
+    unless is_valid,
+      do: Mix.raise("Docker v#{Process.version_ref()} at least is required")
 
     unless Keyword.has_key?(opts, :path), do: Mix.raise("The --path argument is required")
 

--- a/tools/astarte_dev_tool/lib/utilities/process.ex
+++ b/tools/astarte_dev_tool/lib/utilities/process.ex
@@ -17,6 +17,31 @@
 #
 
 defmodule AstarteDevTool.Utilities.Process do
+  alias AstarteDevTool.Constants.System, as: SystemConstants
+
+  def version_ref,
+    do: %Version{
+      major: 27,
+      minor: 2,
+      patch: 2
+    }
+
+  def check_valid_version() do
+    with {version, 0} <-
+           System.cmd(SystemConstants.command(), SystemConstants.command_version_args()),
+         {:ok, version} <- clean_version(version),
+         {:ok, version} <- Version.parse(version) do
+      result =
+        case Version.compare(version, version_ref()) do
+          :lt -> false
+          _ -> true
+        end
+
+      {:ok, result}
+  end
+
+  defp clean_version(version), do: {:ok, version |> String.trim() |> String.trim("'")}
+
   def check_process(command, args, path) when is_list(args) do
     command = "#{command} #{Enum.join(args, "")}"
     check_process(command, path)

--- a/tools/astarte_dev_tool/test/astarte_dev_tool_test.exs
+++ b/tools/astarte_dev_tool/test/astarte_dev_tool_test.exs
@@ -1,6 +1,6 @@
 defmodule AstarteDevToolTest do
   use ExUnit.Case
-  doctest AstarteDevTool
+  # doctest false
 
   test "greets the world" do
     assert AstarteDevTool.hello() == :world

--- a/tools/astarte_dev_tool/test/system_test.exs
+++ b/tools/astarte_dev_tool/test/system_test.exs
@@ -1,0 +1,29 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2024 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule AstarteDevToolTest.System do
+  use ExUnit.Case
+  alias AstarteDevTool.Utilities.Process
+  # doctest AstarteDevToolTest
+
+  @moduletag :system
+  test "check_version/0" do
+    {:ok, result} = Process.check_valid_version()
+    assert is_boolean(result)
+  end
+end


### PR DESCRIPTION


* [ X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [X ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ X] I have added or ran the appropriate tests

#### What this PR does / why we need it:
--watch with a --detach flag is deprecated since  2.27.2,  docker compose refuses to "up" with  those flags

This PR fixes this behavior 


