### PR TITLE
Run docker-compose-initializer on dev tool up command

### DIFF
--- a/tools/astarte_dev_tool/lib/commands/system/up.ex
+++ b/tools/astarte_dev_tool/lib/commands/system/up.ex
@@ -21,12 +21,20 @@ defmodule AstarteDevTool.Commands.System.Up do
   alias AstarteDevTool.Constants.System, as: Constants
 
   def exec(path) do
-    case System.cmd(
-           Constants.command(),
-           Constants.command_up_args(),
-           Constants.base_opts() ++ [cd: path]
-         ) do
-      {_result, 0} -> :ok
+    with {_result, 0} <-
+           System.cmd(
+             Constants.command(),
+             Constants.command_initialize_keys(),
+             Constants.base_opts() ++ [cd: path]
+           ),
+         {_result, 0} <-
+           System.cmd(
+             Constants.command(),
+             Constants.command_up_args(),
+             Constants.base_opts() ++ [cd: path]
+           ) do
+      :ok
+    else
       {:process, _} -> {:error, "The system is already running"}
       {result, exit_code} -> {:error, "Cannot exec system.up: #{result}, #{exit_code}"}
     end

--- a/tools/astarte_dev_tool/lib/constants/system.ex
+++ b/tools/astarte_dev_tool/lib/constants/system.ex
@@ -30,5 +30,8 @@ defmodule AstarteDevTool.Constants.System do
   def command_version_args,
     do: ~w(version --format '{{.Client.Version}}')
 
+  def command_initialize_keys,
+    do: ~w(run -v ./compose:/compose astarte/docker-compose-initializer:snapshot)
+
   def base_opts, do: [stderr_to_stdout: true, into: IO.stream(:stdio, :line)]
 end


### PR DESCRIPTION

* [X ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [X ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [X ] I have added or ran the appropriate tests

#### What this PR does / why we need it:
Enable astarte keys and certificates creation (if needed) on dev tool up command

#### Which issue(s) this PR fixes:
Without this, if there are no keys and certificates generated by 
```
docker run -v $(pwd)/compose:/compose astarte/docker-compose-initializer:snapshot
```
Astarte refuses to start

ref
https://docs.astarte-platform.org/astarte/1.2/010-astarte_in_5_minutes.html
