### PR TITLE
added cassandra port binding

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -114,3 +114,6 @@ services:
       watch:
         - path: apps/astarte_trigger_engine/lib
           action: rebuild
+  scylla:
+    ports:
+      - "9042:9042"


### PR DESCRIPTION
#### What this PR does / why we need it:
In order to local develop astarte via `dev mode`, cassandra/scylla needs to expose the port used to connection 
