### PR TITLE
Prepare 1.3.0 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - Unreleased
 ### Added
 - [astarte_realm_management_api] Allow to list all interfaces definitions using 
   the `detailed=true` parameter

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ and [Cassandra](http://cassandra.apache.org/)/[ScyllaDB](https://www.scylladb.co
 
 **This is the master branch, which is not guaranteed to always be in a usable state.**
 
-**For production purposes we recommend using the latest stable release (currently [v1.1](https://github.com/astarte-platform/astarte/tree/release-1.1)), this branch should be used only for v1.2 development activities.**
+**For production purposes we recommend using the latest stable release (currently [v1.2](https://github.com/astarte-platform/astarte/tree/release-1.2)), this branch should be used only for v1.3 development activities.**
 
 Can't be easier. Pick your favorite machine with at least 4GB of free RAM, make sure it has
 [Docker](https://www.docker.com/), and simply:

--- a/apps/astarte_appengine_api/mix.exs
+++ b/apps/astarte_appengine_api/mix.exs
@@ -22,7 +22,7 @@ defmodule Astarte.AppEngine.API.Mixfile do
     [
       app: :astarte_appengine_api,
       elixir: "~> 1.15",
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml
+++ b/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml
@@ -35,7 +35,7 @@ info:
     an impact on devices and their data. Most Astarte applications would want to
     use this API to interact with devices, stream and receive data, and oversee
     their fleet.
-  version: 1.2.0-dev
+  version: 1.3.0-dev
   title: Astarte App Engine API
   contact:
     email: info@ispirata.com

--- a/apps/astarte_data_updater_plant/mix.exs
+++ b/apps/astarte_data_updater_plant/mix.exs
@@ -23,7 +23,7 @@ defmodule Astarte.DataUpdaterPlant.Mixfile do
     [
       app: :astarte_data_updater_plant,
       elixir: "~> 1.15",
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/apps/astarte_housekeeping/mix.exs
+++ b/apps/astarte_housekeeping/mix.exs
@@ -22,7 +22,7 @@ defmodule Astarte.Housekeeping.Mixfile do
   def project do
     [
       app: :astarte_housekeeping,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       build_path: "_build",
       config_path: "config/config.exs",
       deps_path: "deps",

--- a/apps/astarte_housekeeping_api/mix.exs
+++ b/apps/astarte_housekeeping_api/mix.exs
@@ -22,7 +22,7 @@ defmodule Astarte.Housekeeping.API.Mixfile do
   def project do
     [
       app: :astarte_housekeeping_api,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
+++ b/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml
@@ -16,7 +16,7 @@ info:
     configuration. This API is usually accessible only to system administrators,
     and is not meant for the average user of Astarte, which should refer to
     Realm Management API instead.
-  version: 1.2.0-dev
+  version: 1.3.0-dev
   title: Astarte Housekeeping API
   contact:
     email: info@ispirata.com

--- a/apps/astarte_pairing/mix.exs
+++ b/apps/astarte_pairing/mix.exs
@@ -22,7 +22,7 @@ defmodule Astarte.Pairing.Mixfile do
   def project do
     [
       app: :astarte_pairing,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/apps/astarte_pairing_api/mix.exs
+++ b/apps/astarte_pairing_api/mix.exs
@@ -23,7 +23,7 @@ defmodule Astarte.Pairing.API.Mixfile do
     [
       app: :astarte_pairing_api,
       elixir: "~> 1.15",
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/apps/astarte_pairing_api/priv/static/astarte_pairing_api.yaml
+++ b/apps/astarte_pairing_api/priv/static/astarte_pairing_api.yaml
@@ -11,7 +11,7 @@ servers:
           standard Astarte installation, it is most likely `https://<your host>/pairing`.
 info:
   description: 'Control device registration, authentication an authorization'
-  version: 1.2.0-dev
+  version: 1.3.0-dev
   title: Astarte Pairing API
   contact:
     email: info@ispirata.com

--- a/apps/astarte_realm_management/mix.exs
+++ b/apps/astarte_realm_management/mix.exs
@@ -23,7 +23,7 @@ defmodule Astarte.RealmManagement.Mixfile do
     [
       app: :astarte_realm_management,
       elixir: "~> 1.15",
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/apps/astarte_realm_management_api/mix.exs
+++ b/apps/astarte_realm_management_api/mix.exs
@@ -22,7 +22,7 @@ defmodule Astarte.RealmManagement.API.Mixfile do
   def project do
     [
       app: :astarte_realm_management_api,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       build_path: "_build",
       config_path: "config/config.exs",
       deps_path: "deps",

--- a/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
+++ b/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml
@@ -15,7 +15,7 @@ info:
     Astarte's Realm Management API is the main mechanism to configure a Realm.
     It allows installing and managing Interfaces, Triggers and any configuration
     of the Realm itself.
-  version: 1.2.0-dev
+  version: 1.3.0-dev
   title: Astarte Realm Management API
   contact:
     email: info@ispirata.com

--- a/apps/astarte_trigger_engine/mix.exs
+++ b/apps/astarte_trigger_engine/mix.exs
@@ -23,7 +23,7 @@ defmodule Astarte.TriggerEngine.Mixfile do
     [
       app: :astarte_trigger_engine,
       elixir: "~> 1.15",
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/doc/mix.exs
+++ b/doc/mix.exs
@@ -10,7 +10,7 @@ defmodule Doc.MixProject do
 
     [
       app: :doc,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixir: "~> 1.14",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/tools/astarte_device_fleet_simulator/mix.exs
+++ b/tools/astarte_device_fleet_simulator/mix.exs
@@ -22,7 +22,7 @@ defmodule AstarteDeviceFleetSimulator.MixProject do
   def project do
     [
       app: :astarte_device_fleet_simulator,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps()

--- a/tools/astarte_e2e/mix.exs
+++ b/tools/astarte_e2e/mix.exs
@@ -22,7 +22,7 @@ defmodule AstarteE2E.MixProject do
   def project do
     [
       app: :astarte_e2e,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       dialyzer_cache_directory: dialyzer_cache_directory(Mix.env()),

--- a/tools/astarte_export/mix.exs
+++ b/tools/astarte_export/mix.exs
@@ -4,7 +4,7 @@ defmodule AstarteExport.MixProject do
   def project do
     [
       app: :astarte_export,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/tools/astarte_import/mix.exs
+++ b/tools/astarte_import/mix.exs
@@ -4,7 +4,7 @@ defmodule Astarte.Import.MixProject do
   def project do
     [
       app: :astarte_import,
-      version: "1.2.0-dev",
+      version: "1.3.0-dev",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps()


### PR DESCRIPTION
Update the readme, mix.exs and OpenAPI files to refer to the new Astarte dev version 1.3.0-dev.