### PR TITLE
Docs: point Swagger URLs to master

### DIFF
--- a/doc/swagger-ui-index.html
+++ b/doc/swagger-ui-index.html
@@ -42,19 +42,19 @@
         urls: [
           {
             name: "AppEngine API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/v1.2.0/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/master/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml"
           },
           {
             name: "Realm Management API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/v1.2.0/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/master/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml"
           },
           {
             name: "Pairing API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/v1.2.0/apps/astarte_pairing_api/priv/static/astarte_pairing_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/master/apps/astarte_pairing_api/priv/static/astarte_pairing_api.yaml"
           },
           {
             name: "Housekeeping API", 
-            url: "https://raw.githubusercontent.com/astarte-platform/astarte/v1.2.0/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml"
+            url: "https://raw.githubusercontent.com/astarte-platform/astarte/master/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml"
         }],
         dom_id: '#swagger-ui',
         deepLinking: true,


### PR DESCRIPTION
v1.2.0 is the stable release, we're on master and docs should reflect that.
