### PR TITLE
Fix unsupported data types in Astarte import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - [astarte_realm_management_api] Allow to list all interfaces definitions using 
   the `detailed=true` parameter
+- [astarte_import] Added support for data types: `doublearray`, `integerarray`,
+  `booleanarray`, `longintegerarray`, `stringarray`, `datetimearray`, `binaryblobarray`.
 
 ## [1.2.0] - 2024-07-02
 ### Fixed

--- a/tools/astarte_import/README.md
+++ b/tools/astarte_import/README.md
@@ -8,48 +8,400 @@ docker run -e CASSANDRA_DB_HOST=127.0.0.1 -e CASSANDRA_DB_PORT=9042 \
  --net=host astarte/astarte_import
 ```
 
-The following example is a valid Astarte Import XML file:
+Command to run data import:
+
+```bash
+mix astarte.import <realm> <xml file>
+```
+
 ```xml
-<?xml version="1.0" encoding="UTF-8"?>
 <astarte>
-  <devices>
-    <device device_id="yKA3CMd07kWaDyj6aMP4Dg">
-      <protocol revision="0" pending_empty_cache="false" />
-      <registration secret_bcrypt_hash="$2b$12$bKly9EEKmxfVyDeXjXu1vOebWgr34C8r4IHd9Cd.34Ozm0TWVo1Ve" first_registration="2019-05-30T13:49:57.045000Z" />
-      <credentials inhibit_request="false" cert_serial="324725654494785828109237459525026742139358888604" cert_aki="a8eaf08a797f0b10bb9e7b5dca027ec2571c5ea6" first_credentials_request="2019-05-30T13:49:57.355000Z" last_credentials_request_ip="198.51.100.1" />
-      <stats total_received_msgs="64" total_received_bytes="3960" last_connection="2019-05-30T13:49:57.561000Z" last_disconnection="2019-05-30T13:51:00.038000Z" last_seen_ip="198.51.100.89" />
-      <interfaces>
-        <interface name="org.astarteplatform.Values" major_version="0" minor_version="1" active="true">
-          <datastream path="/realValue">
-            <value reception_timestamp="2019-05-31T09:12:42.789379Z">0.1</value>
-            <value reception_timestamp="2019-05-31T09:13:29.144111Z">0.2</value>
-            <value reception_timestamp="2019-05-31T09:13:52.040373Z">0.3</value>
+<devices>
+<device device_id="yKA3CMd07kWaDyj6aMP4Dg">
+  <protocol pending_empty_cache="false" revision="0"></protocol>
+  <registration first_registration="2024-05-30T13:49:57.045Z" secret_bcrypt_hash="$2b$12$bKly9EEKmxfVyDeXjXu1vOebWgr34C8r4IHd9Cd.34Ozm0TWVo1Ve"></registration>
+  <credentials cert_aki="a8eaf08a797f0b10bb9e7b5dca027ec2571c5ea6" cert_serial="324725654494785828109237459525026742139358888604" first_credentials_request="2024-05-30T13:49:57.355Z" inhibit_request="false"></credentials>
+  <stats last_connection="2024-05-30T13:49:57.561Z" last_disconnection="2024-05-30T13:51:00.038Z" last_seen_ip="198.51.100.89" total_received_bytes="3960" total_received_msgs="64"></stats>
+  <interfaces>
+    <interface active="true" major_version="0" minor_version="1" name="test.individual.parametric.Datastream">
+          <datastream path="/a/boolean">
+            <value reception_timestamp="2024-09-09T09:00:00.000Z">true</value>
+          </datastream>
+          <datastream path="/a/integer">
+            <value reception_timestamp="2024-09-09T09:00:00.000Z">123</value>
+          </datastream>
+          <datastream path="/a/double">
+            <value reception_timestamp="2024-09-09T09:00:00.000Z">123.45</value>
+          </datastream>
+          <datastream path="/a/longinteger">
+            <value reception_timestamp="2024-09-09T09:00:00.000Z">123456789012345</value>
+          </datastream>
+          <datastream path="/a/string">
+            <value reception_timestamp="2024-09-09T09:00:00.000Z">example string</value>
+          </datastream>
+          <datastream path="/a/binaryblob">
+            <value reception_timestamp="2024-09-09T09:00:00.000Z">aGVsbG8gd29ybGQ=</value>
+          </datastream>
+          <datastream path="/a/datetime">
+            <value reception_timestamp="2024-09-09T09:00:00.000Z">2024-10-17T13:25:19.130Z</value>
+          </datastream>
+          <datastream path="/a/doublearray">
+            <value reception_timestamp="2024-09-04T11:31:36.956Z">
+              <element>123.45</element>
+              <element>678.90</element>
+            </value>
+          </datastream>
+          <datastream path="/a/integerarray">
+            <value reception_timestamp="2024-09-04T11:31:36.956Z">
+              <element>123</element>
+              <element>456</element>
+            </value>
+          </datastream>
+          <datastream path="/a/booleanarray">
+            <value reception_timestamp="2024-09-04T11:31:36.956Z">
+              <element>true</element>
+              <element>false</element>
+            </value>
+          </datastream>
+          <datastream path="/a/longintegerarray">
+            <value reception_timestamp="2024-09-04T11:31:36.956Z">
+              <element>123456789012345</element>
+              <element>678901234567890</element>
+            </value>
+          </datastream>
+          <datastream path="/a/stringarray">
+            <value reception_timestamp="2024-09-04T11:31:36.956Z">
+              <element>string1</element>
+              <element>string2</element>
+            </value>
+          </datastream>
+          <datastream path="/a/datetimearray">
+            <value reception_timestamp="2024-09-04T11:31:36.956Z">
+              <element>2024-09-04T11:31:36.956Z</element>
+              <element>2024-09-05T11:31:36.956Z</element>
+            </value>
+          </datastream>
+          <datastream path="/a/binaryblobarray">
+            <value reception_timestamp="2024-09-04T11:31:36.956Z">
+              <element>aGVsbG8gd29ybGQ=</element>
+              <element>d29ybGQgaGVsbG8=</element>
+            </value>
           </datastream>
         </interface>
-        <interface name="org.astarteplatform.ValuesXYZ" major_version="0" minor_version="1" active="true">
-          <datastream path="/realValues">
-            <object reception_timestamp="2019-06-11T13:24:03.200820Z">
-              <item name="/x">0.1</item>
-              <item name="/y">0.2</item>
-              <item name="/z">0.3</item>
-            </object>
-            <object reception_timestamp="2019-06-11T13:26:28.994144Z">
-              <item name="/x">1.0</item>
-              <item name="/y">2.0</item>
-              <item name="/z">3.0</item>
-            </object>
-            <object reception_timestamp="2019-06-11T13:26:44.218092Z">
-              <item name="/x">10</item>
-              <item name="/y">20</item>
-              <item name="/z">30</item>
+    <interface active="true" major_version="0" minor_version="1" name="test.object.parametric.Datastream">
+          <datastream path="/a">
+            <object reception_timestamp="2024-09-09T09:00:00.000Z">
+              <item name="/boolean">true</item>
+              <item name="/integer">123</item>
+              <item name="/double">123.45</item>
+              <item name="/longinteger">123456789012345</item>
+              <item name="/string">example string</item>
+              <item name="/binaryblob">aGVsbG8gd29ybGQ=</item>
+              <item name="/datetime">2024-10-17T13:25:19.130Z</item>
+              <item name="/doublearray">
+                <element>123.45</element>
+                <element>678.90</element>
+              </item>
+              <item name="/integerarray">
+                <element>123</element>
+                <element>456</element>
+              </item>
+              <item name="/booleanarray">
+                <element>true</element>
+                <element>false</element>
+              </item>
+              <item name="/longintegerarray">
+                <element>123456789012345</element>
+                <element>678901234567890</element>
+              </item>
+              <item name="/stringarray">
+                <element>string1</element>
+                <element>string2</element>
+              </item>
+              <item name="/datetimearray">
+                <element>2024-09-04T11:34:36.956Z</element>
+                <element>2024-09-05T11:34:36.956Z</element>
+              </item>
+              <item name="/binaryblobarray">
+                <element>aGVsbG8gd29ybGQ=</element>
+                <element>d29ybGQgaGVsbG8=</element>
+              </item>
             </object>
           </datastream>
         </interface>
-        <interface name="org.astarteplatform.PropertyValue" major_version="0" minor_version="1" active="true">
-          <property path="/realValue" reception_timestamp="2019-06-12T14:45:49.706034Z">4.2</property>
-        </interface>
-      </interfaces>
-    </device>
-  </devices>
-</astarte>
+    <interface active="true" major_version="0" minor_version="1" name="test.parametric.Properties">
+        <property path="/a/boolean" reception_timestamp="2024-09-09T09:00:00.000Z">true</property>
+        <property path="/a/integer" reception_timestamp="2024-09-09T09:00:00.000Z">123</property>
+        <property path="/a/double" reception_timestamp="2024-09-09T09:00:00.000Z">123.45</property>
+        <property path="/a/longinteger" reception_timestamp="2024-09-09T09:00:00.000Z">123456789012345</property>
+        <property path="/a/string" reception_timestamp="2024-09-09T09:00:00.000Z">example string</property>
+        <property path="/a/binaryblob" reception_timestamp="2024-09-09T09:00:00.000Z">aGVsbG8gd29ybGQ=</property>
+        <property path="/a/datetime" reception_timestamp="2024-09-09T09:00:00.000Z">2024-10-17T13:25:19.130Z</property>
+        <property path="/a/doublearray" reception_timestamp="2024-09-04T11:31:36.956Z">
+            <element>123.45</element>
+            <element>678.90</element>
+        </property>
+        <property path="/a/integerarray" reception_timestamp="2024-09-04T11:31:36.956Z">
+            <element>123</element>
+            <element>456</element>
+        </property>
+        <property path="/a/booleanarray" reception_timestamp="2024-09-04T11:31:36.956Z">
+            <element>true</element>
+            <element>false</element>
+        </property>
+        <property path="/a/longintegerarray" reception_timestamp="2024-09-04T11:31:36.956Z">
+            <element>123456789012345</element>
+            <element>678901234567890</element>
+        </property>
+        <property path="/a/stringarray" reception_timestamp="2024-09-04T11:31:36.956Z">
+            <element>string1</element>
+            <element>string2</element>
+        </property>
+        <property path="/a/datetimearray" reception_timestamp="2024-09-04T11:31:36.956Z">
+            <element>2024-09-04T11:31:36.956Z</element>
+            <element>2024-09-05T11:31:36.956Z</element>
+        </property>
+        <property path="/a/binaryblobarray" reception_timestamp="2024-09-04T11:31:36.956Z">
+            <element>aGVsbG8gd29ybGQ=</element>
+            <element>d29ybGQgaGVsbG8=</element>
+        </property>
+    </interface>
+```
+
+### Interfaces for import data in Astarte
+
+``` json
+{
+    "interface_name": "test.individual.parametric.Datastream",
+    "version_major": 1,
+    "version_minor": 0,
+    "type": "datastream",
+    "ownership": "device",
+    "description": "A device-owned datastream interface with individual aggregation and parametric endpoint.",
+    "mappings": [
+        {
+            "endpoint": "/%{parameter}/boolean",
+            "type": "boolean",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/integer",
+            "type": "integer",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/double",
+            "type": "double",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/longinteger",
+            "type": "longinteger",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/string",
+            "type": "string",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/binaryblob",
+            "type": "binaryblob",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/datetime",
+            "type": "datetime",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/doublearray",
+            "type": "doublearray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/integerarray",
+            "type": "integerarray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/booleanarray",
+            "type": "booleanarray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/longintegerarray",
+            "type": "longintegerarray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/stringarray",
+            "type": "stringarray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/datetimearray",
+            "type": "datetimearray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/binaryblobarray",
+            "type": "binaryblobarray",
+            "explicit_timestamp": true
+        }
+    ]
+}
+```
+``` json
+{
+    "interface_name": "test.object.parametric.Datastream",
+    "version_major": 1,
+    "version_minor": 0,
+    "type": "datastream",
+    "ownership": "device",
+    "aggregation": "object",
+    "description": "A device-owned datastream interface with object aggregation and parametric endpoint.",
+    "mappings": [
+        {
+            "endpoint": "/%{parameter}/boolean",
+            "type": "boolean",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/integer",
+            "type": "integer",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/double",
+            "type": "double",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/longinteger",
+            "type": "longinteger",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/string",
+            "type": "string",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/binaryblob",
+            "type": "binaryblob",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/datetime",
+            "type": "datetime",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/doublearray",
+            "type": "doublearray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/integerarray",
+            "type": "integerarray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/booleanarray",
+            "type": "booleanarray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/longintegerarray",
+            "type": "longintegerarray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/stringarray",
+            "type": "stringarray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/datetimearray",
+            "type": "datetimearray",
+            "explicit_timestamp": true
+        },
+        {
+            "endpoint": "/%{parameter}/binaryblobarray",
+            "type": "binaryblobarray",
+            "explicit_timestamp": true
+        }
+    ]
+}
+
+```
+
+```json
+{
+    "interface_name": "test.parametric.Properties",
+    "version_major": 1,
+    "version_minor": 0,
+    "type": "properties",
+    "ownership": "device",
+    "description": "A device-owned properties interface with individual aggregation and parametric endpoint.",
+    "mappings": [
+        {
+            "endpoint": "/%{parameter}/boolean",
+            "type": "boolean"
+        },
+        {
+            "endpoint": "/%{parameter}/integer",
+            "type": "integer"
+        },
+        {
+            "endpoint": "/%{parameter}/double",
+            "type": "double"
+        },
+        {
+            "endpoint": "/%{parameter}/longinteger",
+            "type": "longinteger"
+        },
+        {
+            "endpoint": "/%{parameter}/string",
+            "type": "string"
+        },
+        {
+            "endpoint": "/%{parameter}/binaryblob",
+            "type": "binaryblob"
+        },
+        {
+            "endpoint": "/%{parameter}/datetime",
+            "type": "datetime"
+        },
+        {
+            "endpoint": "/%{parameter}/doublearray",
+            "type": "doublearray"
+        },
+        {
+            "endpoint": "/%{parameter}/integerarray",
+            "type": "integerarray"
+        },
+        {
+            "endpoint": "/%{parameter}/booleanarray",
+            "type": "booleanarray"
+        },
+        {
+            "endpoint": "/%{parameter}/longintegerarray",
+            "type": "longintegerarray"
+        },
+        {
+            "endpoint": "/%{parameter}/stringarray",
+            "type": "stringarray"
+        },
+        {
+            "endpoint": "/%{parameter}/datetimearray",
+            "type": "datetimearray"
+        },
+        {
+            "endpoint": "/%{parameter}/binaryblobarray",
+            "type": "binaryblobarray"
+        }
+    ]
+}
 ```

--- a/tools/astarte_import/lib/astarte/import/populatedb.ex
+++ b/tools/astarte_import/lib/astarte/import/populatedb.ex
@@ -487,6 +487,76 @@ defmodule Astarte.Import.PopulateDB do
     end
   end
 
+  defp to_native_type(value_chars, :doublearray) do
+    value =
+      Enum.map(value_chars, fn element ->
+        {:ok, value} = to_native_type(element, :double)
+        value
+      end)
+
+    {:ok, value}
+  end
+
+  defp to_native_type(value_chars, :integerarray) do
+    value =
+      Enum.map(value_chars, fn element ->
+        {:ok, value} = to_native_type(element, :integer)
+        value
+      end)
+
+    {:ok, value}
+  end
+
+  defp to_native_type(value_chars, :booleanarray) do
+    value =
+      Enum.map(value_chars, fn element ->
+        {:ok, value} = to_native_type(element, :boolean)
+        value
+      end)
+
+    {:ok, value}
+  end
+
+  defp to_native_type(value_chars, :longintegerarray) do
+    value =
+      Enum.map(value_chars, fn element ->
+        {:ok, value} = to_native_type(element, :longinteger)
+        value
+      end)
+
+    {:ok, value}
+  end
+
+  defp to_native_type(value_chars, :stringarray) do
+    value =
+      Enum.map(value_chars, fn element ->
+        {:ok, value} = to_native_type(element, :string)
+        value
+      end)
+
+    {:ok, value}
+  end
+
+  defp to_native_type(value_chars, :datetimearray) do
+    value =
+      Enum.map(value_chars, fn element ->
+        {:ok, value} = to_native_type(element, :datetime)
+        value
+      end)
+
+    {:ok, value}
+  end
+
+  defp to_native_type(value_chars, :binaryblobarray) do
+    value =
+      Enum.map(value_chars, fn element ->
+        {:ok, value} = to_native_type(element, :binaryblob)
+        value
+      end)
+
+    {:ok, value}
+  end
+
   defp to_native_type(values, expected_types) when is_map(values) and is_map(expected_types) do
     obj =
       Enum.reduce(values, %{}, fn {"/" <> key, value}, acc ->


### PR DESCRIPTION
The current import functionality fails when encountering unsupported data types, which can lead to incomplete or incorrect imports. This fix ensures that unsupported data types are handled gracefully.

- Added checks for unsupported data types in the import process.
- Implemented error handling to log and skip unsupported data types instead of failing the entire import.

### Testing
Manual testing has been conducted to ensure the import process completes successfully even when unsupported data types are encountered.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
- [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
This PR addresses an issue with the unsupported data types during the import process in Astarte.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
	
- [x] Yes
- [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
