### PR TITLE
Workflows: allow to publish images to Dockerhub again

### DIFF
--- a/.github/workflows/publish-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-release-to-dockerhub-workflow.yaml
@@ -11,6 +11,7 @@ on:
 jobs:
   container_tests:
     uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    secrets: inherit
 
   e2e_tests:
     uses: ./.github/workflows/astarte-end-to-end-test-workflow.yaml

--- a/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
@@ -17,6 +17,7 @@ on:
 jobs:
   container_tests:
     uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    secrets: inherit
 
   e2e_tests:
     uses: ./.github/workflows/astarte-end-to-end-test-workflow.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [X] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [X] I have added or ran the appropriate tests

#### What this PR does / why we need it:
Workflows publishing images to Dockerhub did not run up to the publishing step because they depended on the apps test workflow, which did always fail because it could not access the codecov token secret when called via another workflow. Allow the apps test workflow to inherit secrets from the calling workflow (see [here](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow)), so that it can successfully run again and unlock the publisher workflow.

#### Which issue(s) this PR fixes:
Allow the CI to build&push images to Dockerhub again

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
