### PR TITLE
DUP: do not generate redundant disconnection triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update the docker-compose configuration to allow both physical and virtual devices
   to connect to Astarte, provided that the devices and the host are on the same LAN.
 
+### Fixed
+- [astarte_data_updater_plant] Do not generate redundant disconnection
+  triggers in corner cases when a device is already disconnected.
+  Fix [#1014](https://github.com/astarte-platform/astarte/issues/1014).
+
 ## [1.2.0] - 2024-07-02
 ### Fixed
 - Forward port changes from release-1.1 (connection failure when delivering

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -2263,6 +2263,16 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       state.interface_exchanged_bytes
     )
 
+    maybe_execute_device_disconnected_trigger(state, timestamp_ms)
+
+    %{state | connected: false}
+  end
+
+  defp maybe_execute_device_disconnected_trigger(%State{connected: false}, _) do
+    :ok
+  end
+
+  defp maybe_execute_device_disconnected_trigger(state, timestamp_ms) do
     trigger_target_with_policy_list =
       Map.get(state.device_triggers, :on_device_disconnection, [])
       |> Enum.map(fn target ->
@@ -2283,8 +2293,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       %{},
       %{realm: state.realm}
     )
-
-    %{state | connected: false}
   end
 
   defp ask_clean_session(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
In some corner cases, e.g. deletion of a disconnected device, Astarte would generate a disconnection trigger even if
the device is already disconnected.
Avoid doing so by checking the device connection state before generating a trigger.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #1014

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [x] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
