### PR TITLE
Resolve test flakiness

### DIFF
--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/trigger_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/trigger_controller_test.exs
@@ -19,12 +19,16 @@
 defmodule Astarte.RealmManagement.APIWeb.TriggerControllerTest do
   use Astarte.RealmManagement.APIWeb.ConnCase
 
+  alias Astarte.RealmManagement.API.JWTTestHelper
+  alias Astarte.RealmManagement.Mock
+
   @create_attrs %{}
   @invalid_attrs %{}
 
   @test_realm "test"
 
   setup %{conn: conn} do
+    Mock.DB.put_jwt_public_key_pem(@test_realm, JWTTestHelper.public_key_pem())
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 

--- a/apps/astarte_trigger_engine/test/amqp_consumer/amqp_consumer_tracker_test.exs
+++ b/apps/astarte_trigger_engine/test/amqp_consumer/amqp_consumer_tracker_test.exs
@@ -83,6 +83,7 @@ defmodule Astarte.TriggerEngine.AMQPConsumer.AMQPConsumerTrackerTest do
 
     # make sure we update the consumer list without waiting for the update timeout
     AMQPConsumerTracker.handle_info(:update_consumers, [])
+    Process.sleep(3000)
 
     assert Enum.member?(
              Registry.select(Registry.AMQPConsumerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}]),
@@ -93,6 +94,7 @@ defmodule Astarte.TriggerEngine.AMQPConsumer.AMQPConsumerTrackerTest do
 
     # make sure we update the consumer list without waiting for the update timeout
     AMQPConsumerTracker.handle_info(:update_consumers, [])
+    Process.sleep(3000)
 
     assert not Enum.member?(
              Registry.select(Registry.AMQPConsumerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}]),


### PR DESCRIPTION
This PR aims to resolve flakiness for trigger_engine tests (due to a delay in data synchronization) and realm_management_api test (due to a flaw in tests setup)