### PR TITLE
DUP: use all connection options for AMQP

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/application.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/application.ex
@@ -63,7 +63,7 @@ defmodule Astarte.DataUpdaterPlant.Application do
 
   defp mississippi_consumer_opts!() do
     [
-      amqp_consumer_options: [host: Config.amqp_consumer_host!()],
+      amqp_consumer_options: Config.amqp_consumer_options!(),
       mississippi_config: [
         queues: [
           events_exchange_name: Config.events_exchange_name!(),


### PR DESCRIPTION
Do not use just the `host` option to let the consumer connect to AMQP, use the full opts set.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
Allow to connect to any AMQP broker.

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
