### PR TITLE
AstarteExport:  XML generation and type handling

### DIFF
--- a/tools/astarte_export/lib/astarte/xml_generate.ex
+++ b/tools/astarte_export/lib/astarte/xml_generate.ex
@@ -13,12 +13,28 @@ defmodule Astarte.Export.XMLGenerate do
   end
 
   def xml_write_full_element(fd, {tag, attributes, value}, state) do
-    {:ok, start_tag, state} = XMLStreamWriter.start_element(state, tag, attributes)
-    {:ok, data, state} = XMLStreamWriter.characters(state, value)
-    {:ok, end_tag, state} = XMLStreamWriter.end_element(state)
-    xml_data = [start_tag, data, end_tag]
-    IO.puts(fd, xml_data)
-    {:ok, state}
+    if is_list(value) do
+      {:ok, start_tag, state} = XMLStreamWriter.start_element(state, tag, attributes)
+      IO.puts(fd, start_tag)
+
+      Enum.each(value, fn element ->
+        {:ok, element_start, state} = XMLStreamWriter.start_element(state, "element", [])
+        {:ok, element_data, state} = XMLStreamWriter.characters(state, to_string(element))
+        {:ok, element_end, state} = XMLStreamWriter.end_element(state)
+        IO.puts(fd, [element_start, element_data, element_end])
+      end)
+
+      {:ok, end_tag, state} = XMLStreamWriter.end_element(state)
+      IO.puts(fd, end_tag)
+      {:ok, state}
+    else
+      {:ok, start_tag, state} = XMLStreamWriter.start_element(state, tag, attributes)
+      {:ok, data, state} = XMLStreamWriter.characters(state, to_string(value))
+      {:ok, end_tag, state} = XMLStreamWriter.end_element(state)
+      xml_data = [start_tag, data, end_tag]
+      IO.puts(fd, xml_data)
+      {:ok, state}
+    end
   end
 
   def xml_write_start_tag(fd, {tag, attributes}, state) do


### PR DESCRIPTION
Enhancements to XML and data type handling in astarte/tools/astarte_export

Improvements to XML generation:

astarte/tools/astarte_export/lib/xml_generate.ex:

- Enhanced xml_write_full_element function to handle lists and simple values.
- Added iteration through list elements to generate sub-elements dynamically.
- Simplified handling for non-list values by encoding them directly.

Improvements to data type conversion:

astarte/tools/astarte_export/lib/fetchdata/fetchdata.ex:

- Refactored from_native_type function for :binaryblob to use pattern matching, improving robustness and handling invalid binary values gracefully.
- Added support for array types like :binaryblobarray, :booleanarray, :datetimearray, and others, leveraging Enum.map for efficient conversion.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
The primary goal of these changes is to improve the flexibility and robustness of the XML generation and data conversion processes in the Astarte Export tool. This ensures seamless handling of various data types and structures, improving overall data export functionality.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
Please review the changes in both xml_generate.ex and fetchdata.ex for alignment with existing coding standards.
##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
