### PR TITLE
AstarteExport: Rename interface attribute key

### DIFF
--- a/tools/astarte_export/lib/astarte/fetchdata/fetchdata.ex
+++ b/tools/astarte_export/lib/astarte/fetchdata/fetchdata.ex
@@ -169,7 +169,7 @@ defmodule Astarte.Export.FetchData do
         mappings = Enum.sort_by(mappings, fn mapping -> mapping.endpoint end)
 
         interface_attributes = [
-          interface_name: interface_name,
+          name: interface_name,
           major_version: to_string(major_version),
           minor_version: to_string(minor_version),
           active: "true"

--- a/tools/astarte_export/test/astarte_export_test.exs
+++ b/tools/astarte_export/test/astarte_export_test.exs
@@ -16,11 +16,11 @@ defmodule Astarte.ExportTest do
   <credentials inhibit_request="false" cert_serial="324725654494785828109237459525026742139358888604" cert_aki="a8eaf08a797f0b10bb9e7b5dca027ec2571c5ea6" first_credentials_request="2019-05-30T13:49:57.355Z" last_credentials_request_ip="198.51.100.1"/>
   <stats total_received_msgs="64" total_received_bytes="3960" last_connection="2019-05-30T13:49:57.561Z" last_disconnection="2019-05-30T13:51:00.038Z" last_seen_ip="198.51.100.89"/>
   <interfaces>
-  <interface interface_name="properties.org" major_version="0" minor_version="1" active="true">
+  <interface name="properties.org" major_version="0" minor_version="1" active="true">
   <property reception_timestamp="2020-01-30T03:26:23.184Z" path="/properties1">42.0</property>
   <property reception_timestamp="2020-01-30T03:26:23.185Z" path="/properties2">This is property string</property>
   </interface>
-  <interface interface_name="org.individualdatastreams.values" major_version="0" minor_version="1" active="true">
+  <interface name="org.individualdatastreams.values" major_version="0" minor_version="1" active="true">
   <datastream path="/testinstall1">
   <value reception_timestamp="2019-05-31T09:12:42.789Z">0.1</value>
   <value reception_timestamp="2019-05-31T09:13:29.144Z">0.2</value>
@@ -45,7 +45,7 @@ defmodule Astarte.ExportTest do
   <value reception_timestamp="2019-05-31T09:13:29.144Z">4885959589</value>
   </datastream>
   </interface>
-  <interface interface_name="objectdatastreams.org" major_version="0" minor_version="1" active="true">
+  <interface name="objectdatastreams.org" major_version="0" minor_version="1" active="true">
   <datastream path="/objectendpoint1">
   <object reception_timestamp="2019-06-11T13:24:03.200Z">
   <item name="/y">2</item>
@@ -104,7 +104,6 @@ defmodule Astarte.ExportTest do
 
     {:ok, state} = XMLGenerate.xml_write_start_tag(:standard_error, {"device", attributes}, state)
     assert ["device", "devices", "astarte"] == state
-    IO.inspect(state)
 
     {:ok, state} = Export.construct_device_xml_tags(mapped_device_data, :standard_error, state)
     assert ["device", "devices", "astarte"] == state


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
- [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
To ensure consistency between the export and import processes. Renames the key of the interface attribute from `"interface_name"` to `"name"`. Standardizes the output of `astarte_export` to match the import file format used by `astarte_import`.

#### Which issue(s) this PR fixes:
Closes: #1026
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
- [x] Yes
- [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
