### PR TITLE
test(appengine): consistently define endpoint types

### DIFF
--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
@@ -1464,12 +1464,12 @@ defmodule Astarte.AppEngine.API.DeviceTest do
                 data: %{
                   "my_new_path" => %{
                     "enable" => false,
-                    "samplingPeriod" => 100.0,
+                    "samplingPeriod" => 100,
                     "timestamp" => time1
                   },
                   "my_path" => %{
                     "enable" => true,
-                    "samplingPeriod" => 10.0,
+                    "samplingPeriod" => 10,
                     "timestamp" => time2
                   }
                 },
@@ -1618,12 +1618,12 @@ defmodule Astarte.AppEngine.API.DeviceTest do
                 data: %{
                   "my_new_path" => %{
                     "enable" => false,
-                    "samplingPeriod" => 100.0,
+                    "samplingPeriod" => 100,
                     "timestamp" => time1
                   },
                   "my_path" => %{
                     "enable" => true,
-                    "samplingPeriod" => 10.0,
+                    "samplingPeriod" => 10,
                     "timestamp" => time2
                   }
                 },

--- a/apps/astarte_appengine_api/test/support/database_test_helper.exs
+++ b/apps/astarte_appengine_api/test/support/database_test_helper.exs
@@ -857,7 +857,7 @@ defmodule Astarte.AppEngine.API.DatabaseTestHelper do
     reception_timestamp timestamp,
     reception_timestamp_submillis smallint,
     v_enable boolean,
-    v_samplingPeriod double,
+    v_samplingPeriod int,
     v_binaryblobarray list<blob>,
     PRIMARY KEY ((device_id, path), reception_timestamp, reception_timestamp_submillis));
     """


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [X] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

`samplingPeriod` is declared as a double in `create_server_owned_aggregated_object_table/1`, but the endpoint is declared as an integer

the endpoint type is changed to match the database type

This is a needed fix for using (e)xandra, as otherwise the tests would fail because [xandra requires float values when the database type is a double](https://github.com/whatyouhide/xandra/blob/42e8b26cf6f2e55de9b087cb2fa9f9388e9f5f50/lib/xandra/protocol/v4.ex#L305)

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [X] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
