### PR TITLE
Astarte export: astarte export by device_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the `detailed=true` parameter
 - [astarte_import] Added support for data types: `doublearray`, `integerarray`,
   `booleanarray`, `longintegerarray`, `stringarray`, `datetimearray`, `binaryblobarray`.
+- [astarte_export] Added a new command for exporting by device_id. 
+  `mix astarte.export $REALM $FILE_XML $DEVICE_ID`
 
 ## [1.2.1] - Unreleased
 ### Changed

--- a/tools/astarte_export/README.md
+++ b/tools/astarte_export/README.md
@@ -1,9 +1,5 @@
 # astarte_export
 
-## ⚠ Warning
-
-This tool is still in alpha phase, don't rely on it for critical migrations.
-
 Astarte Export is an easy to use tool that allows to exporting all the devices and data from an existing Astarte realm to XML format.
 
 ```iex
@@ -15,6 +11,55 @@ level=info ts=2020-02-03T03:57:21.437+00:00 msg="Export Completed." module=Astar
 {:ok, :export_completed}
 iex(astarte_export@127.0.0.1)7>
 ```
+
+## Environment variables
+
+``` bash
+  export export CASSANDRA_DB_HOST="127.0.0.1"
+  export CASSANDRA_DB_PORT=9042
+  export CASSANDRA_NODES="localhost:9042"
+```
+## Exporting Data with Astarte
+
+You can export data from an Astarte realm using the following commands.
+
+Export Data for All Devices in a Realm
+To export data for all devices in a realm:
+
+```bash
+mix astarte.export <REALM> <FILE_XML>
+```
+- `<REALM>`: The name of the Astarte realm.
+- `<FILE_XML>`: The output file path where the exported data will be saved.
+
+Export Data for All Devices in a Realm
+To export data for all devices in a realm:
+
+## Export Data for a Specific Device
+
+To export data for a single device in a realm:
+
+```bash
+mix astarte.export <REALM> <FILE_XML> <DEVICE_ID>
+```
+
+- `<REALM>`: The name of the Astarte realm.
+- `<FILE_XML>`: The output file path where the exported data will be saved.
+- `<DEVICE_ID>`: The unique identifier of the device (e.g., "ogmcilZpRDeDWwuNfJr0yA").
+
+## Example Commands
+
+Export all devices in the realm example_realm:
+
+``` bash
+mix astarte.export example_realm devices_data.xml
+```
+Export data for a specific device yKA3CMd07kWaDyj6aMP4Dg in the realm example_realm:
+
+``` bash
+mix astarte.export example_realm device_data.xml yKA3CMd07kWaDyj6aMP4Dg
+```
+
 The exported realm data is captured in xml_format as below.
 
 ```xml

--- a/tools/astarte_export/lib/astarte/export.ex
+++ b/tools/astarte_export/lib/astarte/export.ex
@@ -34,27 +34,28 @@ defmodule Astarte.Export do
     the arguments are
     - realm-name -> This is a string format of input
     - file      -> file where to export the realm data.
+    - options   -> options to export the realm data.
   """
 
-  @spec export_realm_data(String.t(), String.t()) ::
+  @spec export_realm_data(String.t(), String.t(), keyword()) ::
           :ok | {:error, :invalid_parameters} | {:error, any()}
 
-  def export_realm_data(realm, file) do
+  def export_realm_data(realm, file, opts \\ []) do
     file = Path.expand(file) |> Path.absname()
 
     with {:ok, fd} <- File.open(file, [:write]) do
-      generate_xml(realm, fd)
+      generate_xml(realm, fd, opts)
     end
   end
 
-  defp generate_xml(realm, fd) do
+  defp generate_xml(realm, fd, opts \\ []) do
     Logger.info("Export started.", realm: realm, tag: "export_started")
 
     with {:ok, state} <- XMLGenerate.xml_write_default_header(fd),
          {:ok, state} <- XMLGenerate.xml_write_start_tag(fd, {"astarte", []}, state),
          {:ok, state} <- XMLGenerate.xml_write_start_tag(fd, {"devices", []}, state),
          {:ok, conn} <- FetchData.db_connection_identifier(),
-         {:ok, state} <- process_devices(conn, realm, fd, state),
+         {:ok, state} <- process_devices(conn, realm, fd, state, opts),
          {:ok, state} <- XMLGenerate.xml_write_end_tag(fd, state),
          {:ok, _state} <- XMLGenerate.xml_write_end_tag(fd, state),
          :ok <- File.close(fd) do
@@ -67,20 +68,20 @@ defmodule Astarte.Export do
     end
   end
 
-  defp process_devices(conn, realm, fd, state) do
+  defp process_devices(conn, realm, fd, state, opts \\ []) do
     tables_page_configs = Application.get_env(:xandra, :cassandra_table_page_sizes, [])
     page_size = Keyword.get(tables_page_configs, :device_table_page_size, 100)
     options = [page_size: page_size]
-    process_devices(conn, realm, fd, state, options)
+    process_devices(conn, realm, fd, state, options, opts)
   end
 
-  defp process_devices(conn, realm, fd, state, options) do
+  defp process_devices(conn, realm, fd, state, options, opts) do
     with {:more_data, device_list, updated_options} <-
-           FetchData.fetch_device_data(conn, realm, options),
+           FetchData.fetch_device_data(conn, realm, options, opts),
          {:ok, state} <- process_device_list(conn, realm, device_list, fd, state),
          {:ok, paging_state} when paging_state != nil <-
            Keyword.fetch(updated_options, :paging_state) do
-      process_devices(conn, realm, fd, state, updated_options)
+      process_devices(conn, realm, fd, state, updated_options, opts)
     else
       {:ok, nil} -> {:ok, state}
       {:ok, :completed} -> {:ok, state}

--- a/tools/astarte_export/lib/astarte/fetchdata/fetchdata.ex
+++ b/tools/astarte_export/lib/astarte/fetchdata/fetchdata.ex
@@ -21,15 +21,15 @@ defmodule Astarte.Export.FetchData do
     end
   end
 
-  def fetch_device_data(conn, realm, opts) do
-    case Queries.stream_devices(conn, realm, opts) do
+  def fetch_device_data(conn, realm, options, device_options \\ []) do
+    case Queries.stream_devices(conn, realm, options, device_options) do
       {:ok, result} ->
         result_list = Enum.to_list(result)
 
         if result_list == [] do
           {:ok, :completed}
         else
-          updated_options = Keyword.put(opts, :paging_state, result.paging_state)
+          updated_options = Keyword.put(options, :paging_state, result.paging_state)
           {:more_data, result_list, updated_options}
         end
 

--- a/tools/astarte_export/lib/mix/tasks/astarte_export.ex
+++ b/tools/astarte_export/lib/mix/tasks/astarte_export.ex
@@ -6,13 +6,33 @@ defmodule Mix.Tasks.Astarte.Export do
 
   @impl Mix.Task
   @shortdoc "export data from an existing Astarte realm"
-  def run([realm, filename]) do
-    case Application.ensure_all_started(:astarte_export) do
-      {:ok, _} ->
-        Export.export_realm_data(realm, filename)
+  def run(args) do
+    case args do
+      [realm, file_name] ->
+        Logger.info("Exporting data from realm #{realm} to file #{file_name}")
 
-      {:error, reason} ->
-        Logger.error("Cannot start applications: #{inspect(reason)}")
+        case Application.ensure_all_started(:astarte_export) do
+          {:ok, _} ->
+            Export.export_realm_data(realm, file_name)
+
+          {:error, reason} ->
+            Logger.error("Cannot start applications: #{inspect(reason)}")
+        end
+
+      [realm, file_name, device_id] ->
+        Logger.info(
+          "Exporting data for device #{device_id} from realm #{realm} to file #{file_name}"
+        )
+
+        options = [device_id: device_id]
+
+        case Application.ensure_all_started(:astarte_export) do
+          {:ok, _} ->
+            Export.export_realm_data(realm, file_name, options)
+
+          {:error, reason} ->
+            Logger.error("Cannot start applications: #{inspect(reason)}")
+        end
     end
   end
 end


### PR DESCRIPTION
### New Export Functionality:
* [`tools/astarte_export/lib/astarte/export.ex`](diffhunk://#diff-02207ec611cfd12f45fc5ef9ba78740251937cc34b75dd5260940ede37f765d1R50-R57): Added `export_realm_data_by_device_id/3` to export data for a specific device ID and corresponding helper functions (`generate_xml_by_device_id/3`, `process_devices_by_device_id/5`, `process_devices_by_device_id/6`). [[1]](diffhunk://#diff-02207ec611cfd12f45fc5ef9ba78740251937cc34b75dd5260940ede37f765d1R50-R57) [[2]](diffhunk://#diff-02207ec611cfd12f45fc5ef9ba78740251937cc34b75dd5260940ede37f765d1R78-R125)

### Data Fetching:
* [`tools/astarte_export/lib/astarte/fetchdata/fetchdata.ex`](diffhunk://#diff-83c27e89ef06e3b054c9193e03f133222f2c7a863d2db8a33600eb1691095465R41-R59): Added `fetch_device_data_by_device_id/4` to fetch data for a specific device ID.

### Database Queries:
* [`tools/astarte_export/lib/astarte/fetchdata/queries/queries.ex`](diffhunk://#diff-4e7cb76986095e54601c715a2df91824d49ca4b99b3d37eefded191374bb3046R85-R109): Added `stream_devices_by_device_id/4` to execute database queries based on device ID.

### Mix Task:
* [`tools/astarte_export/lib/mix/tasks/astarte_export_by_device_id.ex`](diffhunk://#diff-705f820e5d7339fb94e763e6248f12d40c09427d90bff1e9d5d211c864ceeebbR1-R21): Created a new Mix task `Mix.Tasks.Astarte.Export.DeviceId` to facilitate exporting data by device ID via command line.

### Command Update:
* [`tools/astarte_export/rel/commands/export`](diffhunk://#diff-bc45b3370753ca61b3856f3f95ae4a401f646aa10b858136eea2977329a44401R4): Updated the export command script to include the new Mix task for exporting by device ID.
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
- [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
In scenarios where an Astarte realm contains multiple devices, there might be a need to export the data or configuration of a specific device without affecting others. This command enables precise and efficient device-level data management.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
- [x] Yes
- [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
