### PR TITLE
fix: vernemq command changed to start_vernemq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -275,7 +275,7 @@ services:
       - "rabbitmq"
       - "traefik"
     # Ensure we wait for rabbit and cfssl
-    command: wait-for rabbitmq:5672 -t 90 -- wait-for cfssl:8080 -t 90 -- /opt/vernemq/bin/vernemq.sh
+    command: start_vernemq
     # Restart if we fail
     restart: on-failure
     labels:


### PR DESCRIPTION
#### What this PR does / why we need it:
New version of `vernemq` container needs `start_vernemq` command
#### Which issue(s) this PR fixes:
Does the job

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No