### PR TITLE
feature: docker-compose.dev improvement

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,8 @@
 services:
   astarte-housekeeping:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_housekeeping
       target: builder
       args:
         BUILD_ENV: dev
@@ -16,6 +18,8 @@ services:
           action: rebuild
   astarte-housekeeping-api:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_housekeeping_api
       target: builder
       args:
         BUILD_ENV: dev
@@ -29,6 +33,8 @@ services:
           target: /src/lib
   astarte-realm-management:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_realm_management
       target: builder
       args:
         BUILD_ENV: dev
@@ -41,6 +47,8 @@ services:
           action: rebuild
   astarte-realm-management-api:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_realm_management_api
       target: builder
       args:
         BUILD_ENV: dev
@@ -54,6 +62,8 @@ services:
           target: /src/lib
   astarte-pairing:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_pairing
       target: builder
       args:
         BUILD_ENV: dev
@@ -66,6 +76,8 @@ services:
           action: rebuild
   astarte-pairing-api:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_pairing_api
       target: builder
       args:
         BUILD_ENV: dev
@@ -79,6 +91,8 @@ services:
           target: /src/lib
   astarte-appengine-api:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_appengine_api
       target: builder
       args:
         BUILD_ENV: dev
@@ -92,6 +106,8 @@ services:
           target: /src/lib
   astarte-data-updater-plant:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_data_updater_plant
       target: builder
       args:
         BUILD_ENV: dev
@@ -104,6 +120,8 @@ services:
           action: rebuild
   astarte-trigger-engine:
     build:
+      dockerfile: ../../Dockerfile
+      context: apps/astarte_trigger_engine
       target: builder
       args:
         BUILD_ENV: dev
@@ -114,3 +132,7 @@ services:
       watch:
         - path: apps/astarte_trigger_engine/lib
           action: rebuild
+  scylla:
+    command: --smp 1 --memory 750M
+    ports:
+      - 9042:9042

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
   astarte-housekeeping:
     image: astarte/astarte_housekeeping:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_housekeeping
     env_file:
       - ./.env
     restart: on-failure
@@ -13,9 +10,6 @@ services:
 
   astarte-housekeeping-api:
     image: astarte/astarte_housekeeping_api:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_housekeeping_api
     env_file:
       - ./.env
     environment:
@@ -41,9 +35,6 @@ services:
 
   astarte-realm-management:
     image: astarte/astarte_realm_management:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_realm_management
     env_file:
       - ./.env
     restart: on-failure
@@ -53,9 +44,6 @@ services:
 
   astarte-realm-management-api:
     image: astarte/astarte_realm_management_api:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_realm_management_api
     env_file:
       - ./.env
     restart: on-failure
@@ -75,9 +63,6 @@ services:
 
   astarte-pairing:
     image: astarte/astarte_pairing:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_pairing
     env_file:
       - ./.env
     environment:
@@ -89,9 +74,6 @@ services:
 
   astarte-pairing-api:
     image: astarte/astarte_pairing_api:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_pairing_api
     env_file:
       - ./.env
     restart: on-failure
@@ -111,9 +93,6 @@ services:
 
   astarte-appengine-api:
     image: astarte/astarte_appengine_api:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_appengine_api
     env_file:
       - ./.env
     environment:
@@ -136,9 +115,6 @@ services:
 
   astarte-data-updater-plant:
     image: astarte/astarte_data_updater_plant:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_data_updater_plant
     env_file:
       - ./.env
     environment:
@@ -155,9 +131,6 @@ services:
 
   astarte-trigger-engine:
     image: astarte/astarte_trigger_engine:snapshot
-    build:
-      dockerfile: ../../Dockerfile
-      context: apps/astarte_trigger_engine
     env_file:
       - ./.env
     environment:


### PR DESCRIPTION
#### What this PR does / why we need it:
The change improves the development experience via `docker-compose.dev`. 
- The image build has been moved inside the `docker-compose.dev` file. 
- The ports of `scylladb` have been opened to allow connection from the host
- Development instances of `scylladb` have been reduced to one, as per the official site

#### Which issue(s) this PR fixes:
`astarte-dev-tool` can now connect to the db locally

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No