### PR TITLE
Pairing API: Enforce authentication for realm API endpoints

### DIFF
--- a/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api_web/router.ex
@@ -18,10 +18,12 @@
 
 defmodule Astarte.Pairing.APIWeb.Router do
   use Astarte.Pairing.APIWeb, :router
+  alias Astarte.Pairing.APIWeb.Plug.LogRealm
 
   pipeline :realm_api do
     plug :accepts, ["json"]
-    plug Astarte.Pairing.APIWeb.Plug.LogRealm
+    plug LogRealm
+    plug Astarte.Pairing.APIWeb.Plug.AuthorizePath
   end
 
   pipeline :agent_api do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
- Includes Astarte.Pairing.APIWeb.Plug.AuthorizePath in the :realm_api pipeline for the Pairing microservice.
- Ensures authentication is consistently applied to requests under /v1/:realm_name.
- Allows users to access /version even with an invalid or missing token.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
- When logged in with invalid JWT token (astartectl utils gen-jwt all-realm-apis -k test_private.pem) :
Before fix:
![Screenshot from 2025-02-05 16-05-12](https://github.com/user-attachments/assets/9401c276-2a1d-4777-a83b-59f95a90c2dd)

After fix:
![Screenshot from 2025-02-05 16-04-00](https://github.com/user-attachments/assets/4ec7a3a8-ae73-4e15-9fbd-d8f714379472)



