### PR TITLE
Setup CI for multi-arch builds

### DIFF
--- a/.github/workflows/publish-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-release-to-dockerhub-workflow.yaml
@@ -50,6 +50,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
@@ -68,3 +71,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
@@ -62,6 +62,9 @@ jobs:
           export TAG="$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-\(.*\)/\1-snapshot/g' )"
           echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
@@ -81,3 +84,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as base
+FROM --platform=${BUILDPLATFORM} hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as base
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -61,7 +61,7 @@ RUN if [ -f "./entrypoint.sh" ]; then \
 
 # Note: it is important to keep Debian versions in sync, 
 # or incompatibilities between libcrypto will happen
-FROM debian:bookworm-slim
+FROM --platform=${BUILDPLATFORM} debian:bookworm-slim
 
 # Set the locale
 ENV LANG C.UTF-8


### PR DESCRIPTION
This change adds support for building Astarte services targeting specific architectures.

The CI workflows are updated to setup buildx, a Docker CLI plugin for extended build capabilities with BuildKit, and to build multi-arch Docker images.
The targeted platforms are: linux/amd64 and linux/arm64.
