### PR TITLE
chore(workflows): update cache version to v4

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -42,19 +42,19 @@ jobs:
       MIX_ENV: ci
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: apps/${{ matrix.app }}/deps
         key: ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
         restore-keys: |
           ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: apps/${{ matrix.app }}/_build
         key: ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       id: plt_cache
       with:
         path: apps/${{ matrix.app }}/dialyzer_cache
@@ -121,7 +121,7 @@ jobs:
       RABBITMQ_HOST: localhost
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: apps/${{ matrix.app }}/deps
         key: ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}

--- a/.github/workflows/astarte-end-to-end-test-workflow.yaml
+++ b/.github/workflows/astarte-end-to-end-test-workflow.yaml
@@ -68,11 +68,11 @@ jobs:
       run: |
         JWT=$(./astartectl utils gen-jwt appengine channels -k test_private.pem)
         echo "E2E_JWT=$JWT" >> $GITHUB_ENV
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: tools/astarte_e2e/deps
         key: deps-${{ env.otp_version }}-${{ env.elixir_version }}-${{ hashFiles(format('{0}{1}{2}', github.workspace, '/tools/astarte_e2e', '/mix.lock')) }}
-    - uses: actions/cache@v1
+    - uses: actions/cache@v4
       with:
         path: tools/astarte_e2e/_build
         key: build-${{ env.otp_version }}-${{ env.elixir_version }}


### PR DESCRIPTION
CI for new PRs fails due to unmaintained `actions/cache@v1`, this pr bumps up the cache version to v4.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
