### PR TITLE
feat(exandra): move realm management select queries to exandra

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/endpoint.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/endpoint.ex
@@ -1,0 +1,48 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagement.Realms.Endpoint do
+  use TypedEctoSchema
+
+  alias Astarte.Core.Interface.Type, as: InterfaceType
+  alias Astarte.Core.Mapping.DatabaseRetentionPolicy
+  alias Astarte.Core.Mapping.Reliability
+  alias Astarte.Core.Mapping.Retention
+  alias Astarte.Core.Mapping.ValueType
+
+  @primary_key false
+  typed_schema "endpoints" do
+    field :interface_id, Astarte.DataAccess.UUID, primary_key: true
+    field :endpoint_id, Astarte.DataAccess.UUID, primary_key: true
+    field :allow_unset, :boolean
+    field :database_retention_policy, DatabaseRetentionPolicy
+    field :database_retention_ttl, :integer
+    field :description, :string
+    field :doc, :string
+    field :endpoint, :string
+    field :expiry, :integer
+    field :explicit_timestamp, :boolean
+    field :interface_major_version, :integer
+    field :interface_minor_version, :integer
+    field :interface_name, :string
+    field :interface_type, InterfaceType
+    field :reliability, Reliability
+    field :retention, Retention
+    field :value_type, ValueType
+  end
+end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/simple_trigger.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/simple_trigger.ex
@@ -1,0 +1,34 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+defmodule Astarte.RealmManagement.Realms.SimpleTrigger do
+  use TypedEctoSchema
+
+  alias Astarte.DataAccess.UUID
+
+  @primary_key false
+  typed_schema "simple_triggers" do
+    field :object_id, UUID, primary_key: true
+    field :object_type, :integer, primary_key: true
+    field :parent_trigger_id, UUID, primary_key: true
+    field :simple_trigger_id, UUID, primary_key: true
+    field :trigger_data, :binary
+    field :trigger_target, :binary
+  end
+end

--- a/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
@@ -260,7 +260,8 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
   test "object interface install" do
     {:ok, _} = DatabaseTestHelper.connect_to_test_database()
-    client = connect_to_test_realm("autotestrealm")
+    realm_name = "autotestrealm"
+    client = connect_to_test_realm(realm_name)
 
     json_obj = Jason.decode!(@object_datastream_interface_json)
     interface_changeset = InterfaceDocument.changeset(%InterfaceDocument{}, json_obj)
@@ -274,26 +275,26 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
     {:ok, automaton} = Astarte.Core.Mapping.EndpointsAutomaton.build(intdoc.mappings)
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, false}
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version - 1) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version - 1) ==
              {:ok, false}
 
-    assert Queries.interface_available_versions(client, interface_name) ==
+    assert Queries.interface_available_versions(realm_name, interface_name) ==
              {:error, :interface_not_found}
 
-    assert Queries.get_interfaces_list(client) == {:ok, []}
+    assert Queries.get_interfaces_list(realm_name) == {:ok, []}
 
     Queries.install_new_interface(client, intdoc, automaton)
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, true}
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version - 1) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version - 1) ==
              {:ok, false}
 
-    assert Queries.interface_available_versions(client, interface_name) ==
+    assert Queries.interface_available_versions(realm_name, interface_name) ==
              {:ok,
               [
                 [
@@ -302,7 +303,7 @@ defmodule Astarte.RealmManagement.QueriesTest do
                 ]
               ]}
 
-    assert Queries.get_interfaces_list(client) == {:ok, ["com.ispirata.Hemera.DeviceLog"]}
+    assert Queries.get_interfaces_list(realm_name) == {:ok, ["com.ispirata.Hemera.DeviceLog"]}
 
     DatabaseQuery.call!(client, @insert_log_line0_device_a)
     DatabaseQuery.call!(client, @insert_log_line1_device_a)
@@ -371,7 +372,8 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
   test "individual interface install" do
     {:ok, _} = DatabaseTestHelper.connect_to_test_database()
-    client = connect_to_test_realm("autotestrealm")
+    realm_name = "autotestrealm"
+    client = connect_to_test_realm(realm_name)
 
     json_obj = Jason.decode!(@individual_property_device_owned_interface)
     interface_changeset = InterfaceDocument.changeset(%InterfaceDocument{}, json_obj)
@@ -385,26 +387,26 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
     {:ok, automaton} = Astarte.Core.Mapping.EndpointsAutomaton.build(intdoc.mappings)
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, false}
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version - 1) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version - 1) ==
              {:ok, false}
 
-    assert Queries.interface_available_versions(client, interface_name) ==
+    assert Queries.interface_available_versions(realm_name, interface_name) ==
              {:error, :interface_not_found}
 
-    assert Queries.get_interfaces_list(client) == {:ok, []}
+    assert Queries.get_interfaces_list(realm_name) == {:ok, []}
 
     Queries.install_new_interface(client, intdoc, automaton)
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, true}
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version - 1) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version - 1) ==
              {:ok, false}
 
-    assert Queries.interface_available_versions(client, interface_name) ==
+    assert Queries.interface_available_versions(realm_name, interface_name) ==
              {:ok,
               [
                 [
@@ -413,7 +415,8 @@ defmodule Astarte.RealmManagement.QueriesTest do
                 ]
               ]}
 
-    assert Queries.get_interfaces_list(client) == {:ok, ["com.ispirata.Hemera.DeviceLog.Status"]}
+    assert Queries.get_interfaces_list(realm_name) ==
+             {:ok, ["com.ispirata.Hemera.DeviceLog.Status"]}
 
     endpoint =
       find_endpoint(


### PR DESCRIPTION
Based on #1078, see there for context.
Moves the `SELECT` queries to exandra, modifiying the functions signatures where needed, while trying not to change the return types.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No