### PR TITLE
chore(exandra): move remaining `SELECT` queries in `realm_management` from `CQEx` to `Exandra`

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -715,8 +715,7 @@ defmodule Astarte.RealmManagement.Engine do
   def get_trigger(realm_name, trigger_name) do
     _ = Logger.debug("Get trigger.", trigger_name: trigger_name)
 
-    with {:ok, client} <- get_database_client(realm_name),
-         {:ok, %Trigger{} = trigger} <- Queries.retrieve_trigger(realm_name, trigger_name) do
+    with {:ok, %Trigger{} = trigger} <- Queries.retrieve_trigger(realm_name, trigger_name) do
       %Trigger{
         trigger_uuid: parent_uuid,
         simple_triggers_uuids: simple_triggers_uuids
@@ -730,7 +729,7 @@ defmodule Astarte.RealmManagement.Engine do
             {false, []}
 
           uuid, {true, acc} ->
-            case Queries.retrieve_tagged_simple_trigger(client, parent_uuid, uuid) do
+            case Queries.retrieve_tagged_simple_trigger(realm_name, parent_uuid, uuid) do
               {:ok, %TaggedSimpleTrigger{} = result} ->
                 {true, [TaggedSimpleTrigger.encode(result) | acc]}
 

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -716,7 +716,7 @@ defmodule Astarte.RealmManagement.Engine do
     _ = Logger.debug("Get trigger.", trigger_name: trigger_name)
 
     with {:ok, client} <- get_database_client(realm_name),
-         {:ok, %Trigger{} = trigger} <- Queries.retrieve_trigger(client, trigger_name, realm_name) do
+         {:ok, %Trigger{} = trigger} <- Queries.retrieve_trigger(realm_name, trigger_name) do
       %Trigger{
         trigger_uuid: parent_uuid,
         simple_triggers_uuids: simple_triggers_uuids
@@ -768,7 +768,7 @@ defmodule Astarte.RealmManagement.Engine do
     _ = Logger.info("Going to delete trigger.", trigger_name: trigger_name, tag: "delete_trigger")
 
     with {:ok, client} <- get_database_client(realm_name),
-         {:ok, trigger} <- Queries.retrieve_trigger(client, trigger_name, realm_name) do
+         {:ok, trigger} <- Queries.retrieve_trigger(realm_name, trigger_name) do
       _ =
         Logger.info("Deleting trigger.",
           trigger_name: trigger_name,

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -879,8 +879,7 @@ defmodule Astarte.RealmManagement.Engine do
         policy_name: policy_name
       )
 
-    with {:ok, client} <- connect_to_db_with_realm(realm_name),
-         {:ok, policy_proto} <- fetch_trigger_policy(client, policy_name) do
+    with {:ok, policy_proto} <- fetch_trigger_policy(realm_name, policy_name) do
       policy_proto
       |> PolicyProto.decode()
       |> Policy.from_policy_proto!()
@@ -888,8 +887,8 @@ defmodule Astarte.RealmManagement.Engine do
     end
   end
 
-  defp fetch_trigger_policy(client, policy_name) do
-    with {:error, :policy_not_found} <- Queries.fetch_trigger_policy(client, policy_name) do
+  defp fetch_trigger_policy(realm_name, policy_name) do
+    with {:error, :policy_not_found} <- Queries.fetch_trigger_policy(realm_name, policy_name) do
       Logger.warning("Trigger policy not found",
         tag: "trigger_policy_not_found",
         policy_name: policy_name

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -907,7 +907,7 @@ defmodule Astarte.RealmManagement.Engine do
 
     with {:ok, client} <- connect_to_db_with_realm(realm_name),
          :ok <- verify_trigger_policy_exists(client, policy_name),
-         {:ok, false} <- check_trigger_policy_has_triggers(client, policy_name) do
+         {:ok, false} <- check_trigger_policy_has_triggers(realm_name, policy_name) do
       if opts[:async] do
         Task.start_link(Engine, :execute_trigger_policy_deletion, [client, policy_name])
 
@@ -964,8 +964,8 @@ defmodule Astarte.RealmManagement.Engine do
     end
   end
 
-  defp check_trigger_policy_has_triggers(client, policy_name) do
-    with {:ok, true} <- Queries.check_policy_has_triggers(client, policy_name) do
+  defp check_trigger_policy_has_triggers(realm_name, policy_name) do
+    with {:ok, true} <- Queries.check_policy_has_triggers(realm_name, policy_name) do
       Logger.warning("Trigger policy #{policy_name} is currently being used by triggers",
         tag: "cannot_delete_currently_used_trigger_policy"
       )

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -869,9 +869,7 @@ defmodule Astarte.RealmManagement.Engine do
   def get_trigger_policies_list(realm_name) do
     _ = Logger.debug("Get trigger policy list", tag: "get_trigger_policies_list")
 
-    with {:ok, client} <- connect_to_db_with_realm(realm_name) do
-      Queries.get_trigger_policies_list(client)
-    end
+    Queries.get_trigger_policies_list(realm_name)
   end
 
   def trigger_policy_source(realm_name, policy_name) do

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -776,7 +776,12 @@ defmodule Astarte.RealmManagement.Engine do
 
       delete_all_simple_triggers_succeeded =
         Enum.all?(trigger.simple_triggers_uuids, fn simple_trigger_uuid ->
-          Queries.delete_simple_trigger(client, trigger.trigger_uuid, simple_trigger_uuid) == :ok
+          Queries.delete_simple_trigger(
+            client,
+            trigger.trigger_uuid,
+            simple_trigger_uuid,
+            realm_name
+          ) == :ok
         end)
 
       delete_policy_link_succeeded =

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/endpoint.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/endpoint.ex
@@ -1,0 +1,48 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagement.Realms.Endpoint do
+  use TypedEctoSchema
+
+  alias Astarte.Core.Interface.Type, as: InterfaceType
+  alias Astarte.Core.Mapping.DatabaseRetentionPolicy
+  alias Astarte.Core.Mapping.Reliability
+  alias Astarte.Core.Mapping.Retention
+  alias Astarte.Core.Mapping.ValueType
+
+  @primary_key false
+  typed_schema "endpoints" do
+    field :interface_id, Astarte.DataAccess.UUID, primary_key: true
+    field :endpoint_id, Astarte.DataAccess.UUID, primary_key: true
+    field :allow_unset, :boolean
+    field :database_retention_policy, DatabaseRetentionPolicy
+    field :database_retention_ttl, :integer
+    field :description, :string
+    field :doc, :string
+    field :endpoint, :string
+    field :expiry, :integer
+    field :explicit_timestamp, :boolean
+    field :interface_major_version, :integer
+    field :interface_minor_version, :integer
+    field :interface_name, :string
+    field :interface_type, InterfaceType
+    field :reliability, Reliability
+    field :retention, Retention
+    field :value_type, ValueType
+  end
+end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/simple_trigger.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/simple_trigger.ex
@@ -1,0 +1,34 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+defmodule Astarte.RealmManagement.Realms.SimpleTrigger do
+  use TypedEctoSchema
+
+  alias Astarte.DataAccess.UUID
+
+  @primary_key false
+  typed_schema "simple_triggers" do
+    field :object_id, UUID, primary_key: true
+    field :object_type, :integer, primary_key: true
+    field :parent_trigger_id, UUID, primary_key: true
+    field :simple_trigger_id, UUID, primary_key: true
+    field :trigger_data, :binary
+    field :trigger_target, :binary
+  end
+end

--- a/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
@@ -260,7 +260,8 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
   test "object interface install" do
     {:ok, _} = DatabaseTestHelper.connect_to_test_database()
-    client = connect_to_test_realm("autotestrealm")
+    realm_name = "autotestrealm"
+    client = connect_to_test_realm(realm_name)
 
     json_obj = Jason.decode!(@object_datastream_interface_json)
     interface_changeset = InterfaceDocument.changeset(%InterfaceDocument{}, json_obj)
@@ -274,26 +275,26 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
     {:ok, automaton} = Astarte.Core.Mapping.EndpointsAutomaton.build(intdoc.mappings)
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, false}
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version - 1) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version - 1) ==
              {:ok, false}
 
-    assert Queries.interface_available_versions(client, interface_name) ==
+    assert Queries.interface_available_versions(realm_name, interface_name) ==
              {:error, :interface_not_found}
 
-    assert Queries.get_interfaces_list(client) == {:ok, []}
+    assert Queries.get_interfaces_list(realm_name) == {:ok, []}
 
     Queries.install_new_interface(client, intdoc, automaton)
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, true}
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version - 1) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version - 1) ==
              {:ok, false}
 
-    assert Queries.interface_available_versions(client, interface_name) ==
+    assert Queries.interface_available_versions(realm_name, interface_name) ==
              {:ok,
               [
                 [
@@ -302,7 +303,7 @@ defmodule Astarte.RealmManagement.QueriesTest do
                 ]
               ]}
 
-    assert Queries.get_interfaces_list(client) == {:ok, ["com.ispirata.Hemera.DeviceLog"]}
+    assert Queries.get_interfaces_list(realm_name) == {:ok, ["com.ispirata.Hemera.DeviceLog"]}
 
     DatabaseQuery.call!(client, @insert_log_line0_device_a)
     DatabaseQuery.call!(client, @insert_log_line1_device_a)
@@ -371,7 +372,8 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
   test "individual interface install" do
     {:ok, _} = DatabaseTestHelper.connect_to_test_database()
-    client = connect_to_test_realm("autotestrealm")
+    realm_name = "autotestrealm"
+    client = connect_to_test_realm(realm_name)
 
     json_obj = Jason.decode!(@individual_property_device_owned_interface)
     interface_changeset = InterfaceDocument.changeset(%InterfaceDocument{}, json_obj)
@@ -385,26 +387,26 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
     {:ok, automaton} = Astarte.Core.Mapping.EndpointsAutomaton.build(intdoc.mappings)
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, false}
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version - 1) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version - 1) ==
              {:ok, false}
 
-    assert Queries.interface_available_versions(client, interface_name) ==
+    assert Queries.interface_available_versions(realm_name, interface_name) ==
              {:error, :interface_not_found}
 
-    assert Queries.get_interfaces_list(client) == {:ok, []}
+    assert Queries.get_interfaces_list(realm_name) == {:ok, []}
 
     Queries.install_new_interface(client, intdoc, automaton)
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, true}
 
-    assert Queries.is_interface_major_available?(client, interface_name, major_version - 1) ==
+    assert Queries.is_interface_major_available?(realm_name, interface_name, major_version - 1) ==
              {:ok, false}
 
-    assert Queries.interface_available_versions(client, interface_name) ==
+    assert Queries.interface_available_versions(realm_name, interface_name) ==
              {:ok,
               [
                 [
@@ -413,7 +415,8 @@ defmodule Astarte.RealmManagement.QueriesTest do
                 ]
               ]}
 
-    assert Queries.get_interfaces_list(client) == {:ok, ["com.ispirata.Hemera.DeviceLog.Status"]}
+    assert Queries.get_interfaces_list(realm_name) ==
+             {:ok, ["com.ispirata.Hemera.DeviceLog.Status"]}
 
     endpoint =
       find_endpoint(


### PR DESCRIPTION
Moving the remaining `SELECT` queries from `CQEx` to  `Exandra`, based on #1080 (see there for context).

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

