### PR TITLE
refactor(realm_management): move remaining `SELECT` queries to `exandra` and `ecto`

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -1780,18 +1780,9 @@ defmodule Astarte.RealmManagement.Queries do
   end
 
   def retrieve_realms!() do
-    statement = """
-    SELECT *
-    FROM #{CQLUtils.realm_name_to_keyspace_name("astarte", Config.astarte_instance_id!())}.realms
-    """
+    keyspace = Realm.keyspace_name("astarte")
 
-    realms =
-      Xandra.Cluster.run(
-        :xandra,
-        &Xandra.execute!(&1, statement, %{}, consistency: :local_quorum)
-      )
-
-    Enum.to_list(realms)
+    Repo.all(Realm, prefix: keyspace, consistency: :local_quorum)
   end
 
   def retrieve_devices_to_delete!(realm_name) do

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/deletion_in_progress.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/deletion_in_progress.ex
@@ -1,0 +1,41 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.RealmManagement.Realms.DeletionInProgress do
+  @moduledoc false
+
+  use TypedEctoSchema
+
+  alias __MODULE__, as: Data
+
+  @primary_key false
+  schema "deletion_in_progress" do
+    field :device_id, Astarte.DataAccess.UUID, primary_key: true
+    field :vmq_ack, :boolean
+    field :dup_start_ack, :boolean
+    field :dup_end_ack, :boolean
+  end
+
+  def all_ack?(%Data{} = deletion) do
+    %Data{vmq_ack: vmq, dup_start_ack: dup_start, dup_end_ack: dup_end} = deletion
+
+    vmq and dup_start and dup_end
+  end
+end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/device.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/device.ex
@@ -1,0 +1,64 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagement.Realms.Device do
+  use TypedEctoSchema
+
+  @primary_key {:device_id, Astarte.DataAccess.UUID, autogenerate: false}
+  typed_schema "devices" do
+    field :aliases, Exandra.Map, key: :string, value: :string
+    field :attributes, Exandra.Map, key: :string, value: :string
+    field :cert_aki, :string
+    field :cert_serial, :string
+    field :connected, :boolean
+    field :credentials_secret, :string
+
+    field :exchanged_bytes_by_interface, Exandra.Map,
+      key: Exandra.Tuple,
+      types: [:string, :integer],
+      value: :integer
+
+    field :exchanged_msgs_by_interface, Exandra.Map,
+      key: Exandra.Tuple,
+      types: [:string, :integer],
+      value: :integer
+
+    field :first_credentials_request, :utc_datetime_usec
+    field :first_registration, :utc_datetime_usec
+    field :groups, Exandra.Map, key: :string, value: Astarte.DataAccess.UUID
+    field :inhibit_credentials_request, :boolean
+    field :introspection, Exandra.Map, key: :string, value: :integer
+    field :introspection_minor, Exandra.Map, key: :string, value: :integer
+    field :last_connection, :utc_datetime_usec
+    field :last_credentials_request_ip, Exandra.Inet
+
+    field :last_disconnection, :utc_datetime_usec
+    field :last_seen_ip, Exandra.Inet
+
+    field :old_introspection,
+          Exandra.Map,
+          key: Exandra.Tuple,
+          types: [:string, :integer],
+          value: :integer
+
+    field :pending_empty_cache, :boolean
+    field :protocol_revision, :integer
+    field :total_received_bytes, :integer
+    field :total_received_msgs, :integer
+  end
+end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/grouped_device.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/grouped_device.ex
@@ -1,0 +1,31 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+
+defmodule Astarte.RealmManagement.Realms.GroupedDevice do
+  use TypedEctoSchema
+
+  alias Astarte.DataAccess.UUID
+
+  @primary_key false
+  typed_schema "grouped_devices" do
+    field :group_name, :string, primary_key: true
+    field :insertion_uuid, UUID, primary_key: true
+    field :device_id, UUID, primary_key: true
+  end
+end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/name.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/name.ex
@@ -1,0 +1,28 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagement.Realms.Name do
+  use TypedEctoSchema
+
+  @primary_key false
+  typed_schema "names" do
+    field :object_name, :string, primary_key: true
+    field :object_type, :integer, primary_key: true
+    field :object_uuid, Astarte.DataAccess.UUID
+  end
+end


### PR DESCRIPTION
Moves the remaining `SELECT` queries to `exandra` and `ecto`
