### PR TITLE
feat(RM): let it crash!

### DIFF
--- a/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
@@ -1194,7 +1194,7 @@ defmodule Astarte.RealmManagement.EngineTest do
   end
 
   test "get JWT public key PEM with unexisting realm" do
-    assert Engine.get_jwt_public_key_pem("notexisting") == {:error, :realm_not_found}
+    assert_raise Xandra.Error, fn -> Engine.get_jwt_public_key_pem("notexisting") end
   end
 
   test "update JWT public key PEM" do
@@ -1210,10 +1210,6 @@ defmodule Astarte.RealmManagement.EngineTest do
 
     assert Engine.get_jwt_public_key_pem("autotestrealm") ==
              {:ok, DatabaseTestHelper.jwt_public_key_pem_fixture()}
-  end
-
-  test "update JWT public key PEM with unexisting realm" do
-    assert Engine.get_jwt_public_key_pem("notexisting") == {:error, :realm_not_found}
   end
 
   test "install HTTP trigger" do


### PR DESCRIPTION
- Realm Management :: does not handle Xandra errors anymore in the repo itself, it will be the rpc caller to do so.

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No