### PR TITLE
DUP: refactor to catch Xandra exceptions on (new) Ecto queries

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -88,7 +88,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     Logger.info("Created device process.", tag: "device_process_created")
 
     stats_and_introspection =
-      Queries.retrieve_device_stats_and_introspection(new_state.realm, device_id)
+      Queries.retrieve_device_stats_and_introspection!(new_state.realm, device_id)
 
     # TODO this could be a bang!
     {:ok, ttl} = Queries.fetch_datastream_maximum_storage_retention(new_state.realm)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/repo.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/repo.ex
@@ -30,6 +30,15 @@ defmodule Astarte.DataUpdaterPlant.Repo do
     {:ok, config}
   end
 
+  def fetch_all(queryable, opts \\ []) do
+    try do
+      all(queryable, opts)
+    catch
+      error ->
+        handle_xandra_error(error)
+    end
+  end
+
   def fetch_one(queryable, opts \\ []) do
     try do
       one(queryable, opts)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Refactor to let the `Repo` handle raised exceptions rather than crashing on queries changed in #1084.

#### Special notes for your reviewer:

Only queries where the function API was changed in #1084 were touched.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No


