### PR TITLE
refactor(exandra): insert and update interface

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -86,11 +86,11 @@ defmodule Astarte.RealmManagement.Engine do
 
       if opts[:async] do
         # TODO: add _ = Logger.metadata(realm: realm_name)
-        Task.start(Queries, :install_new_interface, [client, interface_doc, automaton])
+        Task.start(Queries, :install_new_interface, [client, realm_name, interface_doc, automaton])
 
         {:ok, :started}
       else
-        Queries.install_new_interface(client, interface_doc, automaton)
+        Queries.install_new_interface(client, realm_name, interface_doc, automaton)
       end
     else
       {:error, {:invalid, _invalid_str, _invalid_pos}} ->
@@ -167,6 +167,7 @@ defmodule Astarte.RealmManagement.Engine do
       else
         execute_interface_update(
           client,
+          realm_name,
           interface_update,
           mapping_updates,
           automaton,
@@ -222,6 +223,7 @@ defmodule Astarte.RealmManagement.Engine do
 
   def execute_interface_update(
         client,
+        realm_name,
         interface_descriptor,
         %MappingUpdates{} = mapping_updates,
         automaton,
@@ -243,7 +245,7 @@ defmodule Astarte.RealmManagement.Engine do
 
     with :ok <- Queries.update_interface_storage(client, interface_descriptor, new_mappings) do
       Queries.update_interface(
-        client,
+        realm_name,
         interface_descriptor,
         all_changed_mappings,
         automaton,

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/endpoint.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/endpoint.ex
@@ -25,6 +25,27 @@ defmodule Astarte.RealmManagement.Realms.Endpoint do
   alias Astarte.Core.Mapping.Retention
   alias Astarte.Core.Mapping.ValueType
 
+  import Ecto.Changeset
+
+  @required_fields [:interface_id, :endpoint_id]
+  @permitted_fields [
+                      :allow_unset,
+                      :database_retention_policy,
+                      :database_retention_ttl,
+                      :description,
+                      :doc,
+                      :endpoint,
+                      :expiry,
+                      :explicit_timestamp,
+                      :interface_major_version,
+                      :interface_minor_version,
+                      :interface_name,
+                      :interface_type,
+                      :reliability,
+                      :retention,
+                      :value_type
+                    ] ++ @required_fields
+
   @primary_key false
   typed_schema "endpoints" do
     field :interface_id, Astarte.DataAccess.UUID, primary_key: true
@@ -44,5 +65,12 @@ defmodule Astarte.RealmManagement.Realms.Endpoint do
     field :reliability, Reliability
     field :retention, Retention
     field :value_type, ValueType
+  end
+
+  def changeset(endpoint, params \\ %{}) do
+    endpoint
+    |> cast(params, @permitted_fields)
+    |> validate_required(@required_fields)
+    |> unique_constraint([:interface_id, :endpoint_id])
   end
 end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/interface.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/interface.ex
@@ -26,6 +26,25 @@ defmodule Astarte.RealmManagement.Realms.Interface do
   alias Astarte.Core.Interface.Type
   alias Astarte.Core.StorageType
 
+  import Ecto.Changeset
+
+  @required_fields [:name, :major_version]
+
+  @permitted_fields @required_fields ++
+                      [
+                        :aggregation,
+                        :automaton_accepting_states,
+                        :automaton_transitions,
+                        :description,
+                        :doc,
+                        :interface_id,
+                        :minor_version,
+                        :ownership,
+                        :storage,
+                        :storage_type,
+                        :type
+                      ]
+
   @primary_key false
   typed_schema "interfaces" do
     field :name, :string, primary_key: true
@@ -41,5 +60,11 @@ defmodule Astarte.RealmManagement.Realms.Interface do
     field :storage, :string
     field :storage_type, StorageType
     field :type, Type
+  end
+
+  def changeset(interface, params) do
+    interface
+    |> cast(params, @permitted_fields)
+    |> validate_required(@required_fields)
   end
 end

--- a/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
@@ -1194,7 +1194,7 @@ defmodule Astarte.RealmManagement.EngineTest do
   end
 
   test "get JWT public key PEM with unexisting realm" do
-    assert Engine.get_jwt_public_key_pem("notexisting") == {:error, :realm_not_found}
+    assert_raise Xandra.Error, fn -> Engine.get_jwt_public_key_pem("notexisting") end
   end
 
   test "update JWT public key PEM" do
@@ -1210,10 +1210,6 @@ defmodule Astarte.RealmManagement.EngineTest do
 
     assert Engine.get_jwt_public_key_pem("autotestrealm") ==
              {:ok, DatabaseTestHelper.jwt_public_key_pem_fixture()}
-  end
-
-  test "update JWT public key PEM with unexisting realm" do
-    assert Engine.get_jwt_public_key_pem("notexisting") == {:error, :realm_not_found}
   end
 
   test "install HTTP trigger" do

--- a/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
@@ -286,7 +286,7 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
     assert Queries.get_interfaces_list(realm_name) == {:ok, []}
 
-    Queries.install_new_interface(client, intdoc, automaton)
+    Queries.install_new_interface(client, realm_name, intdoc, automaton)
 
     assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, true}
@@ -398,7 +398,7 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
     assert Queries.get_interfaces_list(realm_name) == {:ok, []}
 
-    Queries.install_new_interface(client, intdoc, automaton)
+    Queries.install_new_interface(client, realm_name, intdoc, automaton)
 
     assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, true}
@@ -491,14 +491,15 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
   test "timestamp handling" do
     {:ok, _} = DatabaseTestHelper.connect_to_test_database()
-    client = connect_to_test_realm("autotestrealm")
+    realm_name = "autotestrealm"
+    client = connect_to_test_realm(realm_name)
 
     json_obj = Jason.decode!(@individual_datastream_with_explicit_timestamp_interface_json)
     interface_changeset = InterfaceDocument.changeset(%InterfaceDocument{}, json_obj)
     {:ok, doc} = Ecto.Changeset.apply_action(interface_changeset, :insert)
 
     {:ok, automaton} = Astarte.Core.Mapping.EndpointsAutomaton.build(doc.mappings)
-    Queries.install_new_interface(client, doc, automaton)
+    Queries.install_new_interface(client, realm_name, doc, automaton)
 
     endpoint_id = retrieve_endpoint_id(client, "com.timestamp.Test", 1, "/test/0/v")
 


### PR DESCRIPTION
Based on #1089 to have a unified `fetch_*` interface.

- Moves `insert_mapping_query` in realm management to exandra
- `install_new_interface` interaction with the database moved to
  `exandra`
- `update_interface` interaction with the database moved to `exandra`
- removed custom batch, using `Exandra.execute_batch`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No