### PR TITLE
DUP: move UPDATE queries from CQEx to Ecto

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -1395,8 +1395,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
         Map.put(acc, {iface, prev_major}, prev_minor)
       end)
 
-    :ok = Queries.add_old_interfaces(db_client, new_state.device_id, old_introspection)
-    :ok = Queries.remove_old_interfaces(db_client, new_state.device_id, readded_introspection)
+    :ok = Queries.add_old_interfaces(realm, new_state.device_id, old_introspection)
+    :ok = Queries.remove_old_interfaces(realm, new_state.device_id, readded_introspection)
 
     # Deliver interface_minor_updated triggers if needed
     for {interface_name, old_minor} <- old_minors,
@@ -1435,7 +1435,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     new_state = forget_interfaces(new_state, interfaces_to_drop_list)
 
     Queries.update_device_introspection!(
-      db_client,
+      realm,
       new_state.device_id,
       db_introspection_map,
       db_introspection_minor_map

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -109,9 +109,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   def handle_connection(state, ip_address_string, message_id, timestamp) do
-    {:ok, db_client} = Database.connect(realm: state.realm)
-
-    new_state = execute_time_based_actions(state, timestamp, db_client)
+    new_state = execute_time_based_actions(state, timestamp)
 
     timestamp_ms = div(timestamp, 10_000)
 
@@ -131,9 +129,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       end
 
     Queries.set_device_connected!(
-      db_client,
+      new_state.realm,
       new_state.device_id,
-      timestamp_ms,
+      DateTime.from_unix!(timestamp_ms, :microsecond),
       ip_address
     )
 
@@ -170,11 +168,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
   # TODO make this private when all heartbeats will be moved to internal
   def handle_heartbeat(state, message_id, timestamp) do
-    {:ok, db_client} = Database.connect(realm: state.realm)
+    new_state = execute_time_based_actions(state, timestamp)
 
-    new_state = execute_time_based_actions(state, timestamp, db_client)
-
-    Queries.maybe_refresh_device_connected!(db_client, new_state.realm, new_state.device_id)
+    Queries.maybe_refresh_device_connected!(new_state.realm, new_state.device_id)
 
     MessageTracker.ack_delivery(new_state.message_tracker, message_id)
     Logger.info("Device heartbeat.", tag: "device_heartbeat")
@@ -230,21 +226,17 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   def start_device_deletion(state, timestamp) do
-    {:ok, db_client} = Database.connect(realm: state.realm)
-
     # Device deletion is among time-based actions
-    new_state = execute_time_based_actions(state, timestamp, db_client)
+    new_state = execute_time_based_actions(state, timestamp)
 
     {:ok, new_state}
   end
 
   def handle_disconnection(state, message_id, timestamp) do
-    {:ok, db_client} = Database.connect(realm: state.realm)
-
     new_state =
       state
-      |> execute_time_based_actions(timestamp, db_client)
-      |> set_device_disconnected(db_client, timestamp)
+      |> execute_time_based_actions(timestamp)
+      |> set_device_disconnected(timestamp)
 
     MessageTracker.ack_delivery(new_state.message_tracker, message_id)
     Logger.info("Device disconnected.", tag: "device_disconnected")
@@ -499,7 +491,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   def handle_data(state, interface, path, payload, message_id, timestamp) do
     {:ok, db_client} = Database.connect(realm: state.realm)
 
-    new_state = execute_time_based_actions(state, timestamp, db_client)
+    new_state = execute_time_based_actions(state, timestamp)
 
     with :ok <- validate_interface(interface),
          :ok <- validate_path(path),
@@ -1241,7 +1233,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   def process_introspection(state, new_introspection_list, payload, message_id, timestamp) do
     {:ok, db_client} = Database.connect(realm: state.realm)
 
-    new_state = execute_time_based_actions(state, timestamp, db_client)
+    new_state = execute_time_based_actions(state, timestamp)
 
     timestamp_ms = div(timestamp, 10_000)
 
@@ -1472,9 +1464,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   def handle_control(state, "/producer/properties", <<0, 0, 0, 0>>, message_id, timestamp) do
-    {:ok, db_client} = Database.connect(realm: state.realm)
-
-    new_state = execute_time_based_actions(state, timestamp, db_client)
+    new_state = execute_time_based_actions(state, timestamp)
 
     timestamp_ms = div(timestamp, 10_000)
 
@@ -1492,9 +1482,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   def handle_control(state, "/producer/properties", payload, message_id, timestamp) do
-    {:ok, db_client} = Database.connect(realm: state.realm)
-
-    new_state = execute_time_based_actions(state, timestamp, db_client)
+    new_state = execute_time_based_actions(state, timestamp)
 
     timestamp_ms = div(timestamp, 10_000)
 
@@ -1532,13 +1520,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   def handle_control(state, "/emptyCache", _payload, message_id, timestamp) do
-    {:ok, db_client} = Database.connect(realm: state.realm)
-
-    new_state = execute_time_based_actions(state, timestamp, db_client)
+    new_state = execute_time_based_actions(state, timestamp)
 
     with :ok <- send_control_consumer_properties(state),
          {:ok, new_state} <- resend_all_properties(state),
-         :ok <- Queries.set_pending_empty_cache(db_client, new_state.device_id, false) do
+         :ok <- Queries.set_pending_empty_cache(new_state.realm, new_state.device_id, false) do
       MessageTracker.ack_delivery(state.message_tracker, message_id)
 
       :telemetry.execute(
@@ -1909,7 +1895,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     )
   end
 
-  defp execute_time_based_actions(state, timestamp, db_client) do
+  defp execute_time_based_actions(state, timestamp) do
     if state.connected && state.last_seen_message > 0 do
       # timestamps are handled as microseconds*10, so we need to divide by 10 when saving as a metric for a coherent data
       :telemetry.execute(
@@ -1924,14 +1910,14 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     |> reload_groups_on_expiry(timestamp)
     |> purge_expired_interfaces(timestamp)
     |> reload_device_triggers_on_expiry(timestamp)
-    |> reload_device_deletion_status_on_expiry(timestamp, db_client)
+    |> reload_device_deletion_status_on_expiry(timestamp)
     |> reload_datastream_maximum_storage_retention_on_expiry(timestamp)
   end
 
-  defp reload_device_deletion_status_on_expiry(state, timestamp, db_client) do
+  defp reload_device_deletion_status_on_expiry(state, timestamp) do
     if state.last_deletion_in_progress_refresh + @deletion_refresh_lifespan_decimicroseconds <=
          timestamp do
-      new_state = maybe_start_device_deletion(db_client, state, timestamp)
+      new_state = maybe_start_device_deletion(state, timestamp)
       %State{new_state | last_deletion_in_progress_refresh: timestamp}
     else
       state
@@ -1965,21 +1951,23 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     end
   end
 
-  defp maybe_start_device_deletion(db_client, state, timestamp) do
-    if should_start_device_deletion?(state.realm, state.device_id) do
-      encoded_device_id = Device.encode_device_id(state.device_id)
+  defp maybe_start_device_deletion(state, timestamp) do
+    %State{realm: realm, device_id: device_id} = state
 
-      :ok = force_device_deletion_from_broker(state.realm, encoded_device_id)
-      new_state = set_device_disconnected(state, db_client, timestamp)
+    if should_start_device_deletion?(realm, device_id) do
+      encoded_device_id = Device.encode_device_id(device_id)
+
+      :ok = force_device_deletion_from_broker(realm, encoded_device_id)
+      new_state = set_device_disconnected(state, timestamp)
 
       _ =
         Logger.info("Stop handling data from device in deletion, device_id #{encoded_device_id}")
 
       # It's ok to repeat that, as we always write ⊤
       keyspace_name =
-        CQLUtils.realm_name_to_keyspace_name(state.realm, Config.astarte_instance_id!())
+        CQLUtils.realm_name_to_keyspace_name(realm, Config.astarte_instance_id!())
 
-      Queries.ack_start_device_deletion(keyspace_name, state.device_id)
+      Queries.ack_start_device_deletion(keyspace_name, device_id)
 
       %State{new_state | discard_messages: true}
     else
@@ -2252,13 +2240,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     end)
   end
 
-  defp set_device_disconnected(state, db_client, timestamp) do
+  defp set_device_disconnected(state, timestamp) do
     timestamp_ms = div(timestamp, 10_000)
 
     Queries.set_device_disconnected!(
-      db_client,
+      state.realm,
       state.device_id,
-      timestamp_ms,
+      DateTime.from_unix!(timestamp_ms, :microsecond),
       state.total_received_msgs,
       state.total_received_bytes,
       state.interface_exchanged_msgs,
@@ -2297,19 +2285,15 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     )
   end
 
-  defp ask_clean_session(
-         %State{realm: realm, device_id: device_id} = state,
-         timestamp
-       ) do
+  defp ask_clean_session(state, timestamp) do
     Logger.warning("Disconnecting client and asking clean session.")
+    %State{realm: realm, device_id: device_id} = state
 
     encoded_device_id = Device.encode_device_id(device_id)
 
-    {:ok, db_client} = Database.connect(realm: state.realm)
-
-    with :ok <- Queries.set_pending_empty_cache(db_client, device_id, true),
+    with :ok <- Queries.set_pending_empty_cache(realm, device_id, true),
          :ok <- force_disconnection(realm, encoded_device_id) do
-      new_state = set_device_disconnected(state, db_client, timestamp)
+      new_state = set_device_disconnected(realm, timestamp)
 
       Logger.info("Successfully forced device disconnection.", tag: "forced_device_disconnection")
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -63,30 +63,28 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     Repo.all(q)
   end
 
-  def set_pending_empty_cache(db_client, device_id, pending_empty_cache) do
-    pending_empty_cache_statement = """
-    UPDATE devices
-    SET pending_empty_cache = :pending_empty_cache
-    WHERE device_id = :device_id
-    """
+  def set_pending_empty_cache(realm, device_id, pending_empty_cache) do
+    keyspace_name = Realm.keyspace_name(realm)
 
-    update_pending =
-      DatabaseQuery.new()
-      |> DatabaseQuery.statement(pending_empty_cache_statement)
-      |> DatabaseQuery.put(:device_id, device_id)
-      |> DatabaseQuery.put(:pending_empty_cache, pending_empty_cache)
+    device =
+      from d in Device,
+        prefix: ^keyspace_name,
+        where: [device_id: ^device_id],
+        update: [set: [pending_empty_cache: ^pending_empty_cache]]
 
-    with {:ok, _result} <- DatabaseQuery.call(db_client, update_pending) do
-      :ok
-    else
-      %{acc: _, msg: error_message} ->
-        Logger.warning("Database error: #{error_message}.")
-        {:error, :database_error}
+    case Repo.safe_update_all(device, []) do
+      {1, _} ->
+        :ok
 
       {:error, reason} ->
-        # DB Error
-        Logger.warning("Failed with reason #{inspect(reason)}.")
-        {:error, :database_error}
+        _ =
+          Logger.warning(
+            "Cannot set pending empty cache for device #{CoreDevice.encode_device_id(device_id)}: #{inspect(reason)}",
+            realm: realm,
+            tag: "set_pending_empty_cache_fail"
+          )
+
+        {:error, reason}
     end
   end
 
@@ -436,19 +434,19 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     }
   end
 
-  def set_device_connected!(db_client, device_id, timestamp_ms, ip_address) do
-    set_connection_info!(db_client, device_id, timestamp_ms, ip_address)
+  def set_device_connected!(realm, device_id, timestamp, ip_address) do
+    set_connection_info!(realm, device_id, timestamp, ip_address)
 
     ttl = heartbeat_interval_seconds() * 8
-    refresh_device_connected!(db_client, device_id, ttl)
+    refresh_device_connected!(realm, device_id, ttl)
   end
 
-  def maybe_refresh_device_connected!(db_client, realm, device_id) do
+  def maybe_refresh_device_connected!(realm, device_id) do
     with {:ok, remaining_ttl} <- get_connected_remaining_ttl(realm, device_id) do
       if remaining_ttl < heartbeat_interval_seconds() * 2 do
         Logger.debug("Refreshing connected status", tag: "refresh_device_connected")
         write_ttl = heartbeat_interval_seconds() * 8
-        refresh_device_connected!(db_client, device_id, write_ttl)
+        refresh_device_connected!(realm, device_id, write_ttl)
       else
         :ok
       end
@@ -459,39 +457,26 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     Config.device_heartbeat_interval_ms!() |> div(1000)
   end
 
-  defp set_connection_info!(db_client, device_id, timestamp_ms, ip_address) do
-    device_update_statement = """
-    UPDATE devices
-    SET last_connection=:last_connection, last_seen_ip=:last_seen_ip
-    WHERE device_id=:device_id
-    """
+  defp set_connection_info!(realm, device_id, timestamp, ip_address) do
+    keyspace_name = Realm.keyspace_name(realm)
 
-    device_update_query =
-      DatabaseQuery.new()
-      |> DatabaseQuery.statement(device_update_statement)
-      |> DatabaseQuery.put(:device_id, device_id)
-      |> DatabaseQuery.put(:last_connection, timestamp_ms)
-      |> DatabaseQuery.put(:last_seen_ip, ip_address)
-      |> DatabaseQuery.consistency(:local_quorum)
-
-    DatabaseQuery.call!(db_client, device_update_query)
+    %Device{device_id: device_id}
+    |> Ecto.Changeset.change(
+      last_connection: timestamp,
+      last_seen_ip: ip_address
+    )
+    |> Repo.update!(prefix: keyspace_name, consistency: :local_quorum)
   end
 
-  defp refresh_device_connected!(db_client, device_id, ttl) do
-    refresh_connected_statement = """
-    UPDATE devices
-    USING TTL #{ttl}
-    SET connected=true
-    WHERE device_id=:device_id
-    """
+  defp refresh_device_connected!(realm, device_id, ttl) do
+    keyspace_name = Realm.keyspace_name(realm)
 
-    refresh_connected_query =
-      DatabaseQuery.new()
-      |> DatabaseQuery.statement(refresh_connected_statement)
-      |> DatabaseQuery.put(:device_id, device_id)
-      |> DatabaseQuery.consistency(:local_quorum)
+    changeset =
+      %Device{device_id: device_id}
+      |> Ecto.Changeset.change(connected: true)
 
-    DatabaseQuery.call!(db_client, refresh_connected_query)
+    # We use `insert` here becuase Exandra does not support ttl on updates. However, this is an upsert in Scylla.
+    Repo.insert!(changeset, prefix: keyspace_name, ttl: ttl, consistency: :local_quorum)
   end
 
   defp get_connected_remaining_ttl(realm, device_id) do
@@ -523,7 +508,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
   end
 
   def set_device_disconnected!(
-        db_client,
+        realm,
         device_id,
         timestamp_ms,
         total_received_msgs,
@@ -531,29 +516,18 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
         interface_exchanged_msgs,
         interface_exchanged_bytes
       ) do
-    device_update_statement = """
-    UPDATE devices
-    SET connected=false,
-        last_disconnection=:last_disconnection,
-        total_received_msgs=:total_received_msgs,
-        total_received_bytes=:total_received_bytes,
-        exchanged_bytes_by_interface=exchanged_bytes_by_interface + :exchanged_bytes_by_interface,
-        exchanged_msgs_by_interface=exchanged_msgs_by_interface + :exchanged_msgs_by_interface
-    WHERE device_id=:device_id
-    """
+    keyspace_name = Realm.keyspace_name(realm)
 
-    device_update_query =
-      DatabaseQuery.new()
-      |> DatabaseQuery.statement(device_update_statement)
-      |> DatabaseQuery.put(:device_id, device_id)
-      |> DatabaseQuery.put(:last_disconnection, timestamp_ms)
-      |> DatabaseQuery.put(:total_received_msgs, total_received_msgs)
-      |> DatabaseQuery.put(:total_received_bytes, total_received_bytes)
-      |> DatabaseQuery.put(:exchanged_bytes_by_interface, interface_exchanged_bytes)
-      |> DatabaseQuery.put(:exchanged_msgs_by_interface, interface_exchanged_msgs)
-      |> DatabaseQuery.consistency(:local_quorum)
-
-    DatabaseQuery.call!(db_client, device_update_query)
+    %Device{device_id: device_id}
+    |> Ecto.Changeset.change(
+      connected: false,
+      last_disconnection: timestamp_ms,
+      total_received_msgs: total_received_msgs,
+      total_received_bytes: total_received_bytes,
+      exchanged_bytes_by_interface: interface_exchanged_bytes,
+      exchanged_msgs_by_interface: interface_exchanged_msgs
+    )
+    |> Repo.update!(prefix: keyspace_name, consistency: :local_quorum)
   end
 
   def fetch_device_introspection_minors(realm, device_id) do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/repo.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/repo.ex
@@ -48,6 +48,15 @@ defmodule Astarte.DataUpdaterPlant.Repo do
     end
   end
 
+  def safe_update_all(queryable, updates, opts \\ []) do
+    try do
+      update_all(queryable, updates, opts)
+    catch
+      error ->
+        handle_xandra_error(error)
+    end
+  end
+
   defp handle_xandra_error(%Xandra.ConnectionError{} = error) do
     _ =
       Logger.warning("Database connection error #{Exception.message(error)}.",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
Same old, same old: replace the unsupported CQEx driver with Ecto (specifically, to use the Exandra adapter).
This also implies some refactor, as we don't need to pass around the CQEx client anymore. 

#### Special notes for your reviewer:
The API of existing query functions is kept as it was.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No