### PR TITLE
fix(test): new keyspace not found behavior

### DIFF
--- a/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/engine_test.exs
@@ -1569,8 +1569,9 @@ defmodule Astarte.RealmManagement.EngineTest do
   test "fail to retrieve datastream_maximum_storage_retention if realm does not exist" do
     realm_name = "realm#{System.unique_integer([:positive])}"
 
-    assert {:error, _} =
-             Engine.get_datastream_maximum_storage_retention(realm_name)
+    assert_raise Xandra.Error, fn ->
+      Engine.get_datastream_maximum_storage_retention(realm_name)
+    end
   end
 
   defp unpack_source({:ok, source}) when is_binary(source) do

--- a/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
@@ -875,7 +875,8 @@ defmodule Astarte.RealmManagement.QueriesTest do
   test "fail to retrieve datastream_maximum_storage_retention if realm does not exist" do
     realm_name = "realm#{System.unique_integer([:positive])}"
 
-    assert {:error, _} =
-             Queries.get_datastream_maximum_storage_retention(realm_name)
+    assert_raise Xandra.Error, fn ->
+      Queries.get_datastream_maximum_storage_retention(realm_name)
+    end
   end
 end


### PR DESCRIPTION
integrates the new behavior for when the keyspace is not found in tests: raise instead of returning an `{:error, _}` tuple.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
