### PR TITLE
Pairing: port remaining CQEx queries to Ecto

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/engine.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/engine.ex
@@ -27,7 +27,6 @@ defmodule Astarte.Pairing.Engine do
   alias Astarte.Pairing.Config
   alias Astarte.Pairing.CredentialsSecret
   alias Astarte.Pairing.Queries
-  alias CQEx.Client
   alias Astarte.Core.CQLUtils
 
   require Logger
@@ -156,7 +155,8 @@ defmodule Astarte.Pairing.Engine do
          :ok <- verify_can_register_device(realm, device_id),
          credentials_secret <- CredentialsSecret.generate(),
          secret_hash <- CredentialsSecret.hash(credentials_secret),
-         :ok <- Queries.register_device(realm, device_id, hardware_id, secret_hash, opts) do
+         {:ok, _device} <-
+           Queries.register_device(realm, device_id, hardware_id, secret_hash, opts) do
       {:ok, credentials_secret}
     else
       {:error, :shutdown} ->

--- a/apps/astarte_pairing/lib/astarte_pairing/engine.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/engine.ex
@@ -71,19 +71,9 @@ defmodule Astarte.Pairing.Engine do
     )
 
     :telemetry.execute([:astarte, :pairing, :get_credentials], %{}, %{realm: realm})
-    keyspace_name = CQLUtils.realm_name_to_keyspace_name(realm, Config.astarte_instance_id!())
-
-    cqex_options =
-      Config.cqex_options!()
-      |> Keyword.put(:keyspace, keyspace_name)
 
     with {:ok, device_id} <- Device.decode_device_id(hardware_id, allow_extended_id: true),
          {:ok, ip_tuple} <- parse_ip(device_ip),
-         {:ok, client} <-
-           Client.new(
-             Config.cassandra_node!(),
-             cqex_options
-           ),
          {:ok, device} <- Queries.fetch_device(realm, device_id),
          {:authorized?, true} <-
            {:authorized?, CredentialsSecret.verify(credentials_secret, device.credentials_secret)},
@@ -93,10 +83,10 @@ defmodule Astarte.Pairing.Engine do
          encoded_device_id <- Device.encode_device_id(device_id),
          {:ok, %{cert: cert, aki: _aki, serial: _serial} = cert_data} <-
            CFSSLCredentials.get_certificate(csr, realm, encoded_device_id),
-         :ok <-
+         {:ok, _device} <-
            Queries.update_device_after_credentials_request(
-             client,
-             device_id,
+             realm,
+             device,
              cert_data,
              ip_tuple,
              device.first_credentials_request
@@ -108,9 +98,6 @@ defmodule Astarte.Pairing.Engine do
 
       {:credentials_inhibited?, true} ->
         {:error, :credentials_request_inhibited}
-
-      {:error, :shutdown} ->
-        {:error, :realm_not_found}
 
       {:error, reason} ->
         {:error, reason}

--- a/apps/astarte_pairing/lib/astarte_pairing/queries.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/queries.ex
@@ -21,8 +21,6 @@ defmodule Astarte.Pairing.Queries do
   This module is responsible for the interaction with the database.
   """
 
-  alias CQEx.Client
-  alias CQEx.Query
   alias Astarte.Core.CQLUtils
   alias Astarte.Pairing.Config
   alias Astarte.Pairing.Astarte.Realm
@@ -104,9 +102,8 @@ defmodule Astarte.Pairing.Queries do
 
           do_register_unconfirmed_device(
             realm_name,
-            device_id,
+            device,
             credentials_secret,
-            device.first_registration,
             opts
           )
         else
@@ -250,113 +247,52 @@ defmodule Astarte.Pairing.Queries do
          %DateTime{} = registration_timestamp,
          opts
        ) do
-    statement = """
-    INSERT INTO devices
-    (device_id, first_registration, credentials_secret, inhibit_credentials_request,
-    protocol_revision, total_received_bytes, total_received_msgs, introspection,
-    introspection_minor)
-    VALUES
-    (:device_id, :first_registration, :credentials_secret, :inhibit_credentials_request,
-    :protocol_revision, :total_received_bytes, :total_received_msgs, :introspection,
-    :introspection_minor)
-    """
-
     {introspection, introspection_minor} =
       opts
       |> Keyword.get(:initial_introspection, [])
       |> build_initial_introspection_maps()
 
-    query =
-      Query.new()
-      |> Query.statement(statement)
-      |> Query.put(:device_id, device_id)
-      |> Query.put(:first_registration, registration_timestamp |> DateTime.to_unix(:millisecond))
-      |> Query.put(:credentials_secret, credentials_secret)
-      |> Query.put(:inhibit_credentials_request, false)
-      |> Query.put(:protocol_revision, 0)
-      |> Query.put(:total_received_bytes, 0)
-      |> Query.put(:total_received_msgs, 0)
-      |> Query.put(:introspection, introspection)
-      |> Query.put(:introspection_minor, introspection_minor)
-      |> Query.consistency(:quorum)
-
     keyspace_name =
       CQLUtils.realm_name_to_keyspace_name(realm_name, Config.astarte_instance_id!())
 
-    cqex_options =
-      Config.cqex_options!()
-      |> Keyword.put(:keyspace, keyspace_name)
-
-    with {:ok, client} <-
-           Client.new(
-             Config.cassandra_node!(),
-             cqex_options
-           ),
-         {:ok, _res} <- Query.call(client, query) do
-      :ok
-    else
-      error ->
-        Logger.warning("DB error: #{inspect(error)}")
-        {:error, :database_error}
-    end
+    %Device{}
+    |> Ecto.Changeset.change(%{
+      device_id: device_id,
+      first_registration: registration_timestamp,
+      credentials_secret: credentials_secret,
+      inhibit_credentials_request: false,
+      protocol_revision: 0,
+      total_received_bytes: 0,
+      total_received_msgs: 0,
+      introspection: introspection,
+      introspection_minor: introspection_minor
+    })
+    |> Repo.insert(prefix: keyspace_name, consistency: :quorum)
   end
 
   defp do_register_unconfirmed_device(
          realm_name,
-         device_id,
+         %Device{} = device,
          credentials_secret,
-         %DateTime{} = registration_timestamp,
          opts
        ) do
-    statement = """
-    UPDATE devices
-    SET
-      first_registration = :first_registration,
-      credentials_secret = :credentials_secret,
-      inhibit_credentials_request = :inhibit_credentials_request,
-      protocol_revision = :protocol_revision,
-      introspection = :introspection,
-      introspection_minor = :introspection_minor
-
-    WHERE device_id = :device_id
-    """
-
     {introspection, introspection_minor} =
       opts
       |> Keyword.get(:initial_introspection, [])
       |> build_initial_introspection_maps()
 
-    query =
-      Query.new()
-      |> Query.statement(statement)
-      |> Query.put(:device_id, device_id)
-      |> Query.put(:first_registration, registration_timestamp |> DateTime.to_unix(:millisecond))
-      |> Query.put(:credentials_secret, credentials_secret)
-      |> Query.put(:inhibit_credentials_request, false)
-      |> Query.put(:protocol_revision, 0)
-      |> Query.put(:introspection, introspection)
-      |> Query.put(:introspection_minor, introspection_minor)
-      |> Query.consistency(:quorum)
-
     keyspace_name =
       CQLUtils.realm_name_to_keyspace_name(realm_name, Config.astarte_instance_id!())
 
-    cqex_options =
-      Config.cqex_options!()
-      |> Keyword.put(:keyspace, keyspace_name)
-
-    with {:ok, client} <-
-           Client.new(
-             Config.cassandra_node!(),
-             cqex_options
-           ),
-         {:ok, _res} <- Query.call(client, query) do
-      :ok
-    else
-      error ->
-        Logger.warning("DB error: #{inspect(error)}")
-        {:error, :database_error}
-    end
+    device
+    |> Ecto.Changeset.change(%{
+      credentials_secret: credentials_secret,
+      inhibit_credentials_request: false,
+      protocol_revision: 0,
+      introspection: introspection,
+      introspection_minor: introspection_minor
+    })
+    |> Repo.update(prefix: keyspace_name, consistency: :quorum)
   end
 
   defp build_initial_introspection_maps(initial_introspection) do

--- a/apps/astarte_pairing/lib/astarte_pairing/queries.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/queries.ex
@@ -170,12 +170,12 @@ defmodule Astarte.Pairing.Queries do
     end
   end
 
-  def update_device_after_credentials_request(client, device_id, cert_data, device_ip, nil) do
+  def update_device_after_credentials_request(realm_name, device, cert_data, device_ip, nil) do
     first_credentials_request_timestamp = DateTime.utc_now()
 
     update_device_after_credentials_request(
-      client,
-      device_id,
+      realm_name,
+      device,
       cert_data,
       device_ip,
       first_credentials_request_timestamp
@@ -183,41 +183,23 @@ defmodule Astarte.Pairing.Queries do
   end
 
   def update_device_after_credentials_request(
-        client,
-        device_id,
+        realm_name,
+        %Device{} = device,
         %{serial: serial, aki: aki} = _cert_data,
         device_ip,
         %DateTime{} = first_credentials_request_timestamp
       ) do
-    statement = """
-    UPDATE devices
-    SET cert_aki=:cert_aki, cert_serial=:cert_serial, last_credentials_request_ip=:last_credentials_request_ip,
-    first_credentials_request=:first_credentials_request
-    WHERE device_id=:device_id
-    """
+    keyspace_name =
+      CQLUtils.realm_name_to_keyspace_name(realm_name, Config.astarte_instance_id!())
 
-    query =
-      Query.new()
-      |> Query.statement(statement)
-      |> Query.put(:device_id, device_id)
-      |> Query.put(:cert_aki, aki)
-      |> Query.put(:cert_serial, serial)
-      |> Query.put(:last_credentials_request_ip, device_ip)
-      |> Query.put(
-        :first_credentials_request,
-        first_credentials_request_timestamp |> DateTime.to_unix(:millisecond)
-      )
-      |> Query.put(:protocol_revision, @protocol_revision)
-      |> Query.consistency(:quorum)
-
-    case Query.call(client, query) do
-      {:ok, _res} ->
-        :ok
-
-      error ->
-        Logger.warning("DB error: #{inspect(error)}")
-        {:error, :database_error}
-    end
+    device
+    |> Ecto.Changeset.change(%{
+      cert_aki: aki,
+      cert_serial: serial,
+      last_credentials_request_ip: device_ip,
+      first_credentials_request: first_credentials_request_timestamp
+    })
+    |> Repo.update(prefix: keyspace_name, consistency: :quorum)
   end
 
   def fetch_device_registration_limit(realm_name) do

--- a/apps/astarte_pairing/test/astarte_pairing/engine_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/engine_test.exs
@@ -20,8 +20,6 @@ defmodule Astarte.Pairing.EngineTest do
   use ExUnit.Case
 
   alias Astarte.Core.Device
-  alias Astarte.Pairing.Config
-  alias Astarte.Core.CQLUtils
   alias Astarte.Pairing.CredentialsSecret
   alias Astarte.Pairing.DatabaseTestHelper
   alias Astarte.Pairing.Engine
@@ -226,7 +224,7 @@ defmodule Astarte.Pairing.EngineTest do
     test "fails with never registered device_id" do
       device_id = DatabaseTestHelper.unregistered_128_bit_hw_id()
 
-      assert {:error, :device_not_registered} = Engine.unregister_device(@test_realm, device_id)
+      assert {:error, :device_not_found} = Engine.unregister_device(@test_realm, device_id)
     end
 
     test "succeeds with registered and confirmed device_id, and makes it possible to register it again" do

--- a/apps/astarte_pairing_api/lib/astarte_pairing_api/rpc/pairing.ex
+++ b/apps/astarte_pairing_api/lib/astarte_pairing_api/rpc/pairing.ex
@@ -212,12 +212,6 @@ defmodule Astarte.Pairing.API.RPC.Pairing do
     {:error, :forbidden}
   end
 
-  defp extract_reply(
-         {:generic_error_reply, %GenericErrorReply{error_name: "device_not_registered"}}
-       ) do
-    {:error, :device_not_found}
-  end
-
   defp extract_reply({:generic_error_reply, error_struct = %GenericErrorReply{}}) do
     error_map = Map.from_struct(error_struct)
 

--- a/apps/astarte_pairing_api/test/astarte_pairing_api/agent/agent_test.exs
+++ b/apps/astarte_pairing_api/test/astarte_pairing_api/agent/agent_test.exs
@@ -157,11 +157,11 @@ defmodule Astarte.Pairing.API.AgentTest do
                                    reply: {:generic_ok_reply, %GenericOkReply{}}
                                  }
                                  |> Reply.encode()
-    @encoded_device_not_registered_response %Reply{
+    @encoded_device_not_found_response %Reply{
                                               reply:
                                                 {:generic_error_reply,
                                                  %GenericErrorReply{
-                                                   error_name: "device_not_registered"
+                                                   error_name: "device_not_found"
                                                  }}
                                             }
                                             |> Reply.encode()
@@ -205,7 +205,7 @@ defmodule Astarte.Pairing.API.AgentTest do
                  device_id: @test_device_id
                } = unregister_call
 
-        {:ok, @encoded_device_not_registered_response}
+        {:ok, @encoded_device_not_found_response}
       end)
 
       assert {:error, :device_not_found} = Agent.unregister_device(@test_realm, @test_device_id)

--- a/apps/astarte_pairing_api/test/astarte_pairing_api_web/controllers/agent_controller_test.exs
+++ b/apps/astarte_pairing_api/test/astarte_pairing_api_web/controllers/agent_controller_test.exs
@@ -212,11 +212,11 @@ defmodule Astarte.Pairing.APIWeb.AgentControllerTest do
                                    reply: {:generic_ok_reply, %GenericOkReply{}}
                                  }
                                  |> Reply.encode()
-    @encoded_device_not_registered_response %Reply{
+    @encoded_device_not_found_response %Reply{
                                               reply:
                                                 {:generic_error_reply,
                                                  %GenericErrorReply{
-                                                   error_name: "device_not_registered"
+                                                   error_name: "device_not_found"
                                                  }}
                                             }
                                             |> Reply.encode()
@@ -240,11 +240,11 @@ defmodule Astarte.Pairing.APIWeb.AgentControllerTest do
         {:ok, @encoded_pubkey_response}
       end)
       |> expect(:rpc_call, fn _serialized_call, @rpc_destination, @timeout ->
-        {:ok, @encoded_device_not_registered_response}
+        {:ok, @encoded_device_not_found_response}
       end)
 
       conn = delete(conn, agent_path(conn, :delete, @realm, @device_id))
-      assert json_response(conn, 404)["errors"] == %{"detail" => "Device not found"}
+      assert json_response(conn, 403)["errors"] == %{"detail" => "Forbidden"}
     end
 
     test "renders errors when unauthorized", %{conn: conn} do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Pairing runs queries through CQEx, which is deprecated, and we need to rework the project interaction with the database.

This change moves the remaining queries to Ecto with Exandra.
