### PR TITLE
refactor(RM): move delete_interface_storage

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -417,7 +417,7 @@ defmodule Astarte.RealmManagement.Engine do
   def execute_interface_deletion(client, realm_name, name, major) do
     with {:ok, interface_row} <- Interface.retrieve_interface_row(realm_name, name, major),
          {:ok, descriptor} <- InterfaceDescriptor.from_db_result(interface_row),
-         :ok <- Queries.delete_interface_storage(client, descriptor, realm_name),
+         :ok <- Queries.delete_interface_storage(client, realm_name, descriptor),
          :ok <- Queries.delete_devices_with_data_on_interface(realm_name, name) do
       _ =
         Logger.info("Interface deletion started.",


### PR DESCRIPTION
based on #1097 

moves `delete_interface_storage` to use `exandra` and `ecto`

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
