### PR TITLE
refactor(RM): move install_trigger_policy_link

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/astarte/kv_store.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/astarte/kv_store.ex
@@ -77,6 +77,7 @@ defmodule Astarte.RealmManagement.Astarte.KvStore do
         :integer -> "intAsBlob(?)"
         :big_integer -> "bigintAsBlob(?)"
         :string -> "varcharAsBlob(?)"
+        :uuid -> "uuidAsBlob(?)"
       end
 
     sql =

--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -510,7 +510,8 @@ defmodule Astarte.RealmManagement.Engine do
          # TODO: these should be batched together
          :ok <-
            install_simple_triggers(realm_name, simple_trigger_maps, trigger_uuid, t_container),
-         :ok <- install_trigger_policy_link(client, trigger_uuid, trigger_policy_name, realm_name) do
+         :ok <-
+           install_trigger_policy_link(realm_name, trigger_uuid, trigger_policy_name) do
       _ =
         Logger.info("Installing trigger.",
           trigger_name: trigger_name,
@@ -701,17 +702,17 @@ defmodule Astarte.RealmManagement.Engine do
     end)
   end
 
-  defp install_trigger_policy_link(_client, _trigger_uuid, nil, _realm_name) do
+  defp install_trigger_policy_link(_realm_name, _trigger_uuid, nil) do
     :ok
   end
 
-  defp install_trigger_policy_link(_client, _trigger_uuid, "", _realm_name) do
+  defp install_trigger_policy_link(_realm_name, _trigger_uuid, "") do
     :ok
   end
 
-  defp install_trigger_policy_link(client, trigger_uuid, trigger_policy_name, realm_name) do
+  defp install_trigger_policy_link(realm_name, trigger_uuid, trigger_policy_name) do
     with :ok <- verify_trigger_policy_exists(realm_name, trigger_policy_name) do
-      Queries.install_trigger_policy_link(client, trigger_uuid, trigger_policy_name)
+      Queries.install_trigger_policy_link(realm_name, trigger_uuid, trigger_policy_name)
     end
   end
 


### PR DESCRIPTION
Based on #1103, see there for context
Moves `install_trigger_policy` to `exandra` and `ecto`

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
