### PR TITLE
refactor(RM): move `delete_trigger_policy_link`

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -789,7 +789,8 @@ defmodule Astarte.RealmManagement.Engine do
         end)
 
       delete_policy_link_succeeded =
-        Queries.delete_trigger_policy_link(client, trigger.trigger_uuid, trigger.policy) == :ok
+        Queries.delete_trigger_policy_link(realm_name, trigger.trigger_uuid, trigger.policy) ==
+          :ok
 
       if delete_all_simple_triggers_succeeded and delete_policy_link_succeeded do
         Queries.delete_trigger(client, trigger_name, realm_name)


### PR DESCRIPTION
Based on #1105 
Moves `delete_trigger_policy_link` to `exandra` and `ecto`

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests 

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
