### PR TITLE
refactor(RM): move delete_simple_trigger

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -770,8 +770,7 @@ defmodule Astarte.RealmManagement.Engine do
   def delete_trigger(realm_name, trigger_name) do
     _ = Logger.info("Going to delete trigger.", trigger_name: trigger_name, tag: "delete_trigger")
 
-    with {:ok, client} <- get_database_client(realm_name),
-         {:ok, trigger} <- Queries.retrieve_trigger(realm_name, trigger_name) do
+    with {:ok, trigger} <- Queries.retrieve_trigger(realm_name, trigger_name) do
       _ =
         Logger.info("Deleting trigger.",
           trigger_name: trigger_name,
@@ -781,10 +780,9 @@ defmodule Astarte.RealmManagement.Engine do
       delete_all_simple_triggers_succeeded =
         Enum.all?(trigger.simple_triggers_uuids, fn simple_trigger_uuid ->
           Queries.delete_simple_trigger(
-            client,
+            realm_name,
             trigger.trigger_uuid,
-            simple_trigger_uuid,
-            realm_name
+            simple_trigger_uuid
           ) == :ok
         end)
 


### PR DESCRIPTION
Based on #1107 
Moves `delete_simple_trigger` to `exandra` and `ecto`

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
