### PR TITLE
fix(appengine): submillis consistency

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -203,7 +203,7 @@ defmodule Astarte.AppEngine.API.Device.Queries do
       |> DatabaseQuery.put(:endpoint_id, endpoint_id)
       |> DatabaseQuery.put(:path, path)
       |> DatabaseQuery.put(:reception_timestamp, div(reception_timestamp, 1000))
-      |> DatabaseQuery.put(:reception_timestamp_submillis, rem(reception_timestamp, 100))
+      |> DatabaseQuery.put(:reception_timestamp_submillis, rem(reception_timestamp, 1000))
       |> DatabaseQuery.put(:datetime_value, value_timestamp)
 
     DatabaseQuery.call!(db_client, insert_query)
@@ -320,7 +320,7 @@ defmodule Astarte.AppEngine.API.Device.Queries do
       |> DatabaseQuery.put(:path, path)
       |> DatabaseQuery.put(:value_timestamp, div(timestamp, 1000))
       |> DatabaseQuery.put(:reception_timestamp, div(timestamp, 1000))
-      |> DatabaseQuery.put(:reception_timestamp_submillis, rem(timestamp, 100))
+      |> DatabaseQuery.put(:reception_timestamp_submillis, rem(timestamp, 1000))
       |> DatabaseQuery.put(:value, to_db_friendly_type(value))
 
     # TODO: |> DatabaseQuery.consistency(insert_consistency(interface_descriptor, endpoint))
@@ -408,7 +408,7 @@ defmodule Astarte.AppEngine.API.Device.Queries do
       |> DatabaseQuery.put(:path, path)
       |> DatabaseQuery.put(:value_timestamp, div(timestamp, 1000))
       |> DatabaseQuery.put(:reception_timestamp, div(timestamp, 1000))
-      |> DatabaseQuery.put(:reception_timestamp_submillis, rem(timestamp, 100))
+      |> DatabaseQuery.put(:reception_timestamp_submillis, rem(timestamp, 1000))
       |> DatabaseQuery.merge(query_values)
 
     # TODO: |> DatabaseQuery.consistency(insert_consistency(interface_descriptor, endpoint))


### PR DESCRIPTION
other services use 4 digits for the submillis while in appengine we use 3.

still, the old method used div(1000) for the timestamp and rem(100) for the submillis

if we do the math, we notice things don't quite match
- 1234567890 |> div(1000) = 1234567
- 1234567890 |> rem(100) = 90

the 8 is missing.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
