### PR TITLE
refactor(RM): move `update_jwt_public_key_pem`

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -39,7 +39,6 @@ defmodule Astarte.RealmManagement.Engine do
   alias Astarte.RealmManagement.Engine.MappingUpdates
   alias Astarte.RealmManagement.Queries
   alias Astarte.RealmManagement.Config
-  alias CQEx.Client, as: DatabaseClient
 
   def get_health() do
     _ = Logger.debug("Get health.")
@@ -464,24 +463,8 @@ defmodule Astarte.RealmManagement.Engine do
   end
 
   def update_jwt_public_key_pem(realm_name, jwt_public_key_pem) do
-    keyspace_name =
-      CQLUtils.realm_name_to_keyspace_name(realm_name, Config.astarte_instance_id!())
-
-    cqex_options =
-      Config.cqex_options!()
-      |> Keyword.put(:keyspace, keyspace_name)
-
-    with {:ok, client} <-
-           DatabaseClient.new(
-             Config.cassandra_node!(),
-             cqex_options
-           ) do
-      _ = Logger.info("Updating JWT public key PEM.", tag: "updating_jwt_pub_key")
-      Queries.update_jwt_public_key_pem(client, jwt_public_key_pem)
-    else
-      {:error, :shutdown} ->
-        {:error, :realm_not_found}
-    end
+    _ = Logger.info("Updating JWT public key PEM.", tag: "updating_jwt_pub_key")
+    Queries.update_jwt_public_key_pem(realm_name, jwt_public_key_pem)
   end
 
   def install_trigger(

--- a/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
@@ -570,19 +570,19 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
   test "update JWT public key PEM" do
     DatabaseTestHelper.connect_to_test_database()
-    client = connect_to_test_realm("autotestrealm")
+    realm_name = "autotestrealm"
 
     new_pem = "not_exactly_a_PEM_but_will_do"
-    assert Queries.update_jwt_public_key_pem(client, new_pem) == :ok
-    assert Queries.get_jwt_public_key_pem("autotestrealm") == {:ok, new_pem}
+    assert Queries.update_jwt_public_key_pem(realm_name, new_pem) == :ok
+    assert Queries.get_jwt_public_key_pem(realm_name) == {:ok, new_pem}
 
     # Put the PEM fixture back
     assert Queries.update_jwt_public_key_pem(
-             client,
+             realm_name,
              DatabaseTestHelper.jwt_public_key_pem_fixture()
            ) == :ok
 
-    assert Queries.get_jwt_public_key_pem("autotestrealm") ==
+    assert Queries.get_jwt_public_key_pem(realm_name) ==
              {:ok, DatabaseTestHelper.jwt_public_key_pem_fixture()}
   end
 


### PR DESCRIPTION
Moves `update_jwt_public_key_pem` to `exandra` and `ecto`

* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
