### PR TITLE
DUP tests: consistently define object aggregated value types

### DIFF
--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
@@ -1062,7 +1062,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
       make_timestamp("2017-10-26T08:48:50+00:00")
     )
 
-    payload2 = Cyanide.encode!(%{"v" => %{"value" => 0}})
+    payload2 = Cyanide.encode!(%{"v" => %{"value" => 0.0}})
 
     DataUpdater.handle_data(
       realm,
@@ -1343,14 +1343,14 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     assert device_row == [
              connected: false,
              total_received_msgs: 45018,
-             total_received_bytes: 4_501_003,
+             total_received_bytes: 4_501_007,
              exchanged_msgs_by_interface: [
                {["com.example.TestObject", 1], 5},
                {["com.test.LCDMonitor", 1], 6},
                {["com.test.SimpleStreamTest", 1], 1}
              ],
              exchanged_bytes_by_interface: [
-               {["com.example.TestObject", 1], 243},
+               {["com.example.TestObject", 1], 247},
                {["com.test.LCDMonitor", 1], 291},
                {["com.test.SimpleStreamTest", 1], 45}
              ]


### PR DESCRIPTION
The `/value` endpoint in the `com.example.TestObject` interface is defined to handle `double` data. However, in tests it received an integer value. This worked due to a bug in the CQex driver.

Similar to https://github.com/astarte-platform/astarte/pull/1044.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests

#### What this PR does / why we need it:
Be consistent with the type declared and use a float instead of an integer, and update the bytes count consequently.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
