### PR TITLE
refactor(appengine): centralize insert to sql definition

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -596,16 +596,14 @@ defmodule Astarte.AppEngine.API.Device.Queries do
 
   def insert_alias(realm_name, device_id, alias_tag, alias_value) do
     keyspace = keyspace_name(realm_name)
-    names_table = Name.__schema__(:source)
 
-    insert_alias_to_names_statement = """
-    INSERT INTO #{keyspace}.#{names_table}
-    (object_name, object_type, object_uuid)
-    VALUES (?, 1, ?)
-    """
+    name = %Name{
+      object_name: alias_value,
+      object_type: 1,
+      object_uuid: device_id
+    }
 
-    insert_alias_to_names_params = [alias_value, device_id]
-    insert_alias_to_names_query = {insert_alias_to_names_statement, insert_alias_to_names_params}
+    insert_alias_to_names_query = Repo.insert_to_sql(name, prefix: keyspace)
 
     new_alias = %{alias_tag => alias_value}
 


### PR DESCRIPTION
using the standard ecto functions, there is no way to get the sql and params for an insertion from the adapter, which is instead the case for every other query type.

this pr defines a function, `insert_to_sql`, which behaves a bit like `to_sql` for insertions.

instead of using `Exandra.Connection.insert`, the logic was re-implemented here as for the little effort of copy-pasting the logic here, we get the added benefit of being able to declare custom syntax for the parameters, like using `intAsBlob(?)` for an insertion in the KvStore, while exandra is limited to just `?` directly.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [X] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
