### PR TITLE
 DUP: move INSERT queries from CQEx to Ecto

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/repo.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/repo.ex
@@ -48,6 +48,15 @@ defmodule Astarte.DataUpdaterPlant.Repo do
     end
   end
 
+  def safe_insert_all(source, entries, opts \\ []) do
+    try do
+      {:ok, insert_all(source, entries, opts)}
+    catch
+      error ->
+        handle_xandra_error(error)
+    end
+  end
+
   def safe_update_all(queryable, updates, opts \\ []) do
     try do
       {:ok, update_all(queryable, updates, opts)}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->



#### What this PR does / why we need it:
Same old, same old: replace the unsupported CQEx driver with Ecto (specifically, to use the Exandra adapter).
This also implies some refactor, as we don't need to pass around the CQEx client anymore.
This final PR removes CQEx from DUP's `lib/` directory.

Apart from the obvious, two small changes are significant:
- Data from unreliable mappings are inserted with ONE consistency instead of ANY, as it is not suppoted by Exandra (see `Queries.insert_value_into_db` and https://github.com/whatyouhide/xandra/issues/380)
- `Queries.fetch_path_expiry` uses once again `datetime_value` as reference field. Not using it was a mistake from a previous PR.

#### Special notes for your reviewer:
The API of existing query functions is kept as it was.
##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

