### PR TITLE
Pairing: let it crash on database errors

### DIFF
--- a/apps/astarte_pairing/test/astarte_pairing/engine_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/engine_test.exs
@@ -63,7 +63,9 @@ defmodule Astarte.Pairing.EngineTest do
 
   describe "get_agent_public_key_pem" do
     test "fails with non-existing realm" do
-      assert {:error, :realm_not_found} = Engine.get_agent_public_key_pems("nonexisting")
+      assert_raise Xandra.Error, "Keyspace nonexisting does not exist", fn ->
+        Engine.get_agent_public_key_pems("nonexisting")
+      end
     end
 
     test "successful call" do
@@ -214,7 +216,9 @@ defmodule Astarte.Pairing.EngineTest do
       realm = "nonexisting"
       device_id = TestHelper.random_128_bit_hw_id()
 
-      assert {:error, :realm_not_found} = Engine.unregister_device(realm, device_id)
+      assert_raise Xandra.Error, "Keyspace nonexisting does not exist", fn ->
+        Engine.unregister_device(realm, device_id)
+      end
     end
 
     test "fails with invalid device_id" do
@@ -292,15 +296,16 @@ defmodule Astarte.Pairing.EngineTest do
     test "fails with unexisting realm", %{hw_id: hw_id, secret: secret} do
       realm = "unexisting"
 
-      assert {:error, :realm_not_found} =
-               Engine.get_credentials(
-                 @astarte_protocol,
-                 @astarte_credentials_params,
-                 realm,
-                 hw_id,
-                 secret,
-                 @valid_ip
-               )
+      assert_raise Xandra.Error, "Keyspace unexisting does not exist", fn ->
+        Engine.get_credentials(
+          @astarte_protocol,
+          @astarte_credentials_params,
+          realm,
+          hw_id,
+          secret,
+          @valid_ip
+        )
+      end
     end
 
     test "fails with not registered device" do

--- a/apps/astarte_pairing/test/astarte_pairing/rpc/handler_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/rpc/handler_test.exs
@@ -127,23 +127,9 @@ defmodule Astarte.Pairing.RPC.HandlerTest do
         %Call{call: {:get_agent_public_key_pems, %GetAgentPublicKeyPEMs{realm: "invalid"}}}
         |> Call.encode()
 
-      {:ok, reply} = Handler.handle_rpc(encoded)
-
-      expected_err_reply = %Reply{
-        error: true,
-        reply:
-          {:generic_error_reply,
-           %GenericErrorReply{
-             error_name: "realm_not_found",
-             error_data: nil,
-             user_readable_error_name: nil,
-             user_readable_message: nil,
-             user_readable_message: nil
-           }},
-        version: 0
-      }
-
-      assert Reply.decode(reply) == expected_err_reply
+      assert_raise Xandra.Error, "Keyspace invalid does not exist", fn ->
+        Handler.handle_rpc(encoded)
+      end
     end
 
     test "successful call" do
@@ -183,23 +169,9 @@ defmodule Astarte.Pairing.RPC.HandlerTest do
         %Call{call: {:get_info, %GetInfo{realm: "invalid", hw_id: hw_id, secret: secret}}}
         |> Call.encode()
 
-      {:ok, reply} = Handler.handle_rpc(encoded)
-
-      expected_err_reply = %Reply{
-        error: true,
-        reply:
-          {:generic_error_reply,
-           %GenericErrorReply{
-             error_name: "realm_not_found",
-             error_data: nil,
-             user_readable_error_name: nil,
-             user_readable_message: nil,
-             user_readable_message: nil
-           }},
-        version: 0
-      }
-
-      assert Reply.decode(reply) == expected_err_reply
+      assert_raise Xandra.Error, "Keyspace invalid does not exist", fn ->
+        Handler.handle_rpc(encoded)
+      end
     end
 
     test "successful call with pending device", %{hw_id: hw_id, secret: secret} do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

This change avoids catching and managing Xandra errors within the Pairing code dedicated to interacting with the database, where the concern does not require handling expections.

Exceptions and temporary failures are better handled by whomever calls Pairing functionality: in this case RPC, in the future it might be directly a Phoenix conn handling a request.

Note that Astarte RPC already handles failures by responding with a generic error to the caller.
The exception is logged for operational purposes, so developers can troubleshoot the issue, but these kind of database errors are not of much use to API users.

