### PR TITLE
refactor(RM): runtime migrations to `exandra`

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/bigint.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/bigint.ex
@@ -1,0 +1,46 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagement.BigInt do
+  @moduledoc """
+  Ecto type for Cassandra/Scylla bigints, aka 64-bit signed longs.
+  """
+  use Ecto.Type
+
+  @type t() :: integer()
+
+  @min_bigint -2 ** 63
+  @max_bigint 2 ** 63 - 1
+
+  @doc false
+  @impl Ecto.Type
+  def type, do: :bigint
+
+  @impl Ecto.Type
+  @spec load(t() | any()) :: {:ok, t()} | :error
+  def load(n) when is_integer(n) and n >= @min_bigint and n <= @max_bigint, do: {:ok, n}
+  def load(_), do: :error
+
+  @impl Ecto.Type
+  @spec dump(t() | any()) :: {:ok, t()} | :error
+  def dump(n), do: load(n)
+
+  @impl Ecto.Type
+  @spec cast(t() | any()) :: {:ok, t()} | :error
+  def cast(n), do: load(n)
+end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/c_system.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/c_system.ex
@@ -17,15 +17,22 @@
 #
 
 defmodule CSystem do
+  alias Astarte.RealmManagement.Repo
+  import Ecto.Query
+
   @agreement_sleep_millis 200
 
-  def run_with_schema_agreement(conn, opts \\ [], fun) when is_function(fun) do
+  @type function_result :: any()
+
+  @spec run_with_schema_agreement(Keyword.t(), (-> function_result())) ::
+          function_result() | {:error, :no_schema_change} | {:error, :timeout}
+  def run_with_schema_agreement(opts \\ [], fun) when is_function(fun) do
     timeout = Keyword.get(opts, :timeout, 30000)
     expect_change = Keyword.get(opts, :expect_change, false)
 
-    with {:ok, initial} <- wait_schema_agreement(conn, timeout),
+    with {:ok, initial} <- wait_schema_agreement(timeout),
          out = fun.(),
-         {:ok, final} <- wait_schema_agreement(conn, timeout) do
+         {:ok, final} <- wait_schema_agreement(timeout) do
       unless expect_change and initial == final do
         out
       else
@@ -34,58 +41,71 @@ defmodule CSystem do
     end
   end
 
-  def wait_schema_agreement(conn, timeout) when is_integer(timeout) and timeout >= 0 do
-    case schema_versions(conn) do
-      {:ok, [version]} ->
+  @spec wait_schema_agreement(integer()) ::
+          {:ok, Astarte.RealmManagement.UUID.t()} | {:error, :timeout}
+  def wait_schema_agreement(timeout) when is_integer(timeout) and timeout >= 0 do
+    case schema_versions() do
+      [version] ->
         {:ok, version}
 
-      {:ok, _versions} ->
+      _versions ->
         millis = min(timeout, @agreement_sleep_millis)
 
-        if millis == 0 do
-          {:error, :timeout}
-        else
-          Process.sleep(millis)
-          wait_schema_agreement(conn, timeout - millis)
+        case millis do
+          0 ->
+            {:error, :timeout}
+
+          _ ->
+            Process.sleep(millis)
+            wait_schema_agreement(timeout - millis)
         end
-
-      any_other ->
-        any_other
     end
   end
 
-  def schema_versions(conn) do
-    with {:ok, local_version} <- query_local_schema_version(conn),
-         {:ok, peers_versions} <- query_peers_schema_versions(conn) do
-      {:ok, Enum.uniq([local_version | peers_versions])}
-    end
+  @spec schema_versions :: [Astarte.RealmManagement.UUID.t()]
+  def schema_versions do
+    local_version = query_local_schema_version()
+    peers_version = query_peers_schema_versions()
+
+    [local_version | peers_version]
+    |> Enum.uniq()
   end
 
-  def query_peers_schema_versions(conn) do
-    query = "SELECT schema_version FROM system.peers"
-
-    with {:ok, res} <- Xandra.execute(conn, query, %{}, consistency: :one) do
-      schema_versions =
-        res
-        |> Stream.map(&Map.fetch!(&1, :schema_version))
-        |> Stream.uniq()
-        |> Enum.to_list()
-
-      {:ok, schema_versions}
-    end
+  @spec schema_versions :: [Astarte.RealmManagement.UUID.t()]
+  def query_peers_schema_versions do
+    from(p in "peers", select: p.schema_version)
+    |> Repo.all(prefix: "system", consistency: :one)
+    |> Enum.uniq()
   end
 
-  def query_local_schema_version(conn) do
-    query = "SELECT schema_version FROM system.local WHERE key='local'"
+  @spec schema_versions :: Astarte.RealmManagement.UUID.t()
+  def query_local_schema_version do
+    from(l in "local", select: l.schema_version)
+    |> Repo.get_by!([key: "local"], prefix: "system", consistency: :one)
+  end
 
-    with {:ok, res} <- Xandra.execute(conn, query, %{}, consistency: :one) do
-      schema_version =
-        res
-        |> Enum.take(1)
-        |> List.first()
-        |> Map.fetch!(:schema_version)
+  @spec execute_schema_change(String.t()) ::
+          {:ok, Ecto.Adapters.SQL.query_result()} | {:error, Exception.t()} | Xandra.Error.t()
+  def execute_schema_change(query) do
+    query_params = []
 
-      {:ok, schema_version}
+    result =
+      run_with_schema_agreement(fn ->
+        Repo.query(query, query_params, consistency: :each_quorum, timeout: 60_000)
+      end)
+
+    case result do
+      {:error, :timeout} ->
+        %Xandra.Error{reason: :agreement_timeout, message: "Schema agreement wait timeout."}
+
+      {:error, :no_schema_change} ->
+        %Xandra.Error{
+          reason: :no_schema_change,
+          message: "Statement did not change the schema_version."
+        }
+
+      any ->
+        any
     end
   end
 end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/device.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/device.ex
@@ -19,7 +19,7 @@
 defmodule Astarte.RealmManagement.Realms.Device do
   use TypedEctoSchema
 
-  @primary_key {:device_id, Astarte.DataAccess.UUID, autogenerate: false}
+  @primary_key {:device_id, Astarte.RealmManagement.UUID, autogenerate: false}
   typed_schema "devices" do
     field :aliases, Exandra.Map, key: :string, value: :string
     field :attributes, Exandra.Map, key: :string, value: :string
@@ -40,7 +40,7 @@ defmodule Astarte.RealmManagement.Realms.Device do
 
     field :first_credentials_request, :utc_datetime_usec
     field :first_registration, :utc_datetime_usec
-    field :groups, Exandra.Map, key: :string, value: Astarte.DataAccess.UUID
+    field :groups, Exandra.Map, key: :string, value: Astarte.RealmManagement.UUID
     field :inhibit_credentials_request, :boolean
     field :introspection, Exandra.Map, key: :string, value: :integer
     field :introspection_minor, Exandra.Map, key: :string, value: :integer

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/endpoint.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/endpoint.ex
@@ -48,8 +48,8 @@ defmodule Astarte.RealmManagement.Realms.Endpoint do
 
   @primary_key false
   typed_schema "endpoints" do
-    field :interface_id, Astarte.DataAccess.UUID, primary_key: true
-    field :endpoint_id, Astarte.DataAccess.UUID, primary_key: true
+    field :interface_id, Astarte.RealmManagement.UUID, primary_key: true
+    field :endpoint_id, Astarte.RealmManagement.UUID, primary_key: true
     field :allow_unset, :boolean
     field :database_retention_policy, DatabaseRetentionPolicy
     field :database_retention_ttl, :integer

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/grouped_device.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/grouped_device.ex
@@ -20,7 +20,7 @@
 defmodule Astarte.RealmManagement.Realms.GroupedDevice do
   use TypedEctoSchema
 
-  alias Astarte.DataAccess.UUID
+  alias Astarte.RealmManagement.UUID
 
   @primary_key false
   typed_schema "grouped_devices" do

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/individual_datastream.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/individual_datastream.ex
@@ -20,16 +20,19 @@
 # use `astarte_data_access` when it will be merged
 defmodule Astarte.RealmManagement.Realms.IndividualDatastream do
   use TypedEctoSchema
+  alias Astarte.RealmManagement.UUID
+  alias Astarte.RealmManagement.SmallInt
+  alias Astarte.RealmManagement.BigInt
 
   @primary_key false
   typed_schema "individual_datastreams" do
-    field :device_id, Astarte.DataAccess.UUID, primary_key: true
-    field :interface_id, Astarte.DataAccess.UUID, primary_key: true
-    field :endpoint_id, Astarte.DataAccess.UUID, primary_key: true
+    field :device_id, UUID, primary_key: true
+    field :interface_id, UUID, primary_key: true
+    field :endpoint_id, UUID, primary_key: true
     field :path, :string, primary_key: true
     field :value_timestamp, :utc_datetime_usec, primary_key: true
     field :reception_timestamp, :utc_datetime_usec, primary_key: true
-    field :reception_timestamp_submillis, :integer, primary_key: true
+    field :reception_timestamp_submillis, SmallInt, primary_key: true
     field :binaryblob_value, :binary
     field :binaryblobarray_value, {:array, :binary}
     field :boolean_value, :boolean
@@ -40,8 +43,8 @@ defmodule Astarte.RealmManagement.Realms.IndividualDatastream do
     field :doublearray_value, {:array, :float}
     field :integer_value, :integer
     field :integerarray_value, {:array, :integer}
-    field :longinteger_value, :integer
-    field :longintegerarray_value, {:array, :integer}
+    field :longinteger_value, BigInt
+    field :longintegerarray_value, {:array, BigInt}
     field :string_value, :string
     field :stringarray_value, {:array, :string}
   end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/individual_properties.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/individual_properties.ex
@@ -22,27 +22,30 @@
 # use `astarte_data_access` when it will be merged
 defmodule Astarte.RealmManagement.Realms.IndividualProperty do
   use TypedEctoSchema
+  alias Astarte.RealmManagement.UUID
+  alias Astarte.RealmManagement.SmallInt
+  alias Astarte.RealmManagement.BigInt
 
   @primary_key false
   typed_schema "individual_properties" do
     field :reception, :utc_datetime_usec, virtual: true
-    field :device_id, Astarte.DataAccess.UUID, primary_key: true
-    field :interface_id, Astarte.DataAccess.UUID, primary_key: true
-    field :endpoint_id, Astarte.DataAccess.UUID, primary_key: true
+    field :device_id, UUID, primary_key: true
+    field :interface_id, UUID, primary_key: true
+    field :endpoint_id, UUID, primary_key: true
     field :path, :string, primary_key: true
     field :reception_timestamp, :utc_datetime_usec
-    field :reception_timestamp_submillis, :integer
+    field :reception_timestamp_submillis, SmallInt
     field :double_value, :float
     field :integer_value, :integer
     field :boolean_value, :boolean
-    field :longinteger_value, :integer
+    field :longinteger_value, BigInt
     field :string_value, :string
     field :binaryblob_value, :binary
     field :datetime_value, :utc_datetime_usec
     field :doublearray_value, {:array, :float}
     field :integerarray_value, {:array, :integer}
     field :booleanarray_value, {:array, :boolean}
-    field :longintegerarray_value, {:array, :integer}
+    field :longintegerarray_value, {:array, BigInt}
     field :stringarray_value, {:array, :string}
     field :binaryblobarray_value, {:array, :binary}
     field :datetimearray_value, {:array, :utc_datetime_usec}

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/interface.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/interface.ex
@@ -54,7 +54,7 @@ defmodule Astarte.RealmManagement.Realms.Interface do
     field :automaton_transitions, :binary
     field :description, :string
     field :doc, :string
-    field :interface_id, Astarte.DataAccess.UUID
+    field :interface_id, Astarte.RealmManagement.UUID
     field :minor_version, :integer
     field :ownership, Ownership
     field :storage, :string

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/name.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/name.ex
@@ -23,6 +23,6 @@ defmodule Astarte.RealmManagement.Realms.Name do
   typed_schema "names" do
     field :object_name, :string, primary_key: true
     field :object_type, :integer, primary_key: true
-    field :object_uuid, Astarte.DataAccess.UUID
+    field :object_uuid, Astarte.RealmManagement.UUID
   end
 end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/realms/simple_trigger.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realms/simple_trigger.ex
@@ -20,7 +20,7 @@
 defmodule Astarte.RealmManagement.Realms.SimpleTrigger do
   use TypedEctoSchema
 
-  alias Astarte.DataAccess.UUID
+  alias Astarte.RealmManagement.UUID
 
   @primary_key false
   typed_schema "simple_triggers" do

--- a/apps/astarte_realm_management/lib/astarte_realm_management/smallint.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/smallint.ex
@@ -15,27 +15,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# SPDX-License-Identifier: Apache-2.0
-#
 
-defmodule Astarte.RealmManagement.Realms.DeletionInProgress do
-  @moduledoc false
+defmodule Astarte.RealmManagement.SmallInt do
+  @moduledoc """
+  Ecto type for Cassandra/Scylla smallints, aka u16.
+  """
+  use Ecto.Type
 
-  use TypedEctoSchema
+  @type t() :: non_neg_integer()
 
-  alias __MODULE__, as: Data
+  @max_smallint 2 ** 16 - 1
 
-  @primary_key false
-  schema "deletion_in_progress" do
-    field :device_id, Astarte.RealmManagement.UUID, primary_key: true
-    field :vmq_ack, :boolean
-    field :dup_start_ack, :boolean
-    field :dup_end_ack, :boolean
-  end
+  @doc false
+  @impl Ecto.Type
+  def type, do: :smallint
 
-  def all_ack?(%Data{} = deletion) do
-    %Data{vmq_ack: vmq, dup_start_ack: dup_start, dup_end_ack: dup_end} = deletion
+  @impl Ecto.Type
+  @spec load(t() | any()) :: {:ok, t()} | :error
+  def load(n) when is_integer(n) and n >= 0 and n <= @max_smallint, do: {:ok, n}
+  def load(_), do: :error
 
-    vmq and dup_start and dup_end
-  end
+  @impl Ecto.Type
+  @spec dump(t() | any()) :: {:ok, t()} | :error
+  def dump(n), do: load(n)
+
+  @impl Ecto.Type
+  @spec cast(t() | any()) :: {:ok, t()} | :error
+  def cast(n), do: load(n)
 end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/uuid.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/uuid.ex
@@ -18,7 +18,7 @@
 
 # TODO: Copied from astarte_data_access PR #71, see: https://github.com/astarte-platform/astarte_data_access/pull/71
 # use `astarte_data_access` when it will be merged
-defmodule Astarte.DataAccess.UUID do
+defmodule Astarte.RealmManagement.UUID do
   @moduledoc """
   Ecto type for UUIDs, just like Ecto.UUID.
   The difference is that its internal representation, and thus its result after `load/1`,

--- a/apps/astarte_realm_management/priv/repo/migrations/20250305120046_create_datastream_individual_multi_interface.exs
+++ b/apps/astarte_realm_management/priv/repo/migrations/20250305120046_create_datastream_individual_multi_interface.exs
@@ -1,0 +1,30 @@
+defmodule Astarte.RealmManagement.Repo.Migrations.CreateDatastreamIndividualMultiInterface do
+  use Ecto.Migration
+
+  def up do
+    create table("individual_datastreams", primary_key: false) do
+      add(:device_id, :uuid, primary_key: true)
+      add(:interface_id, :uuid, primary_key: true)
+      add(:endpoint_id, :uuid, primary_key: true)
+      add(:path, :varchar, primary_key: true)
+      add(:value_timestamp, :timestamp, partition_key: true)
+      add(:reception_timestamp, :timestamp, partition_key: true)
+      add(:reception_timestamp_submillis, :smallint, partition_key: true)
+
+      add(:double_value, :double)
+      add(:integer_value, :int)
+      add(:boolean_value, :boolean)
+      add(:longinteger_value, :bigint)
+      add(:string_value, :varchar)
+      add(:binaryblob_value, :blob)
+      add(:datetime_value, :timestamp)
+      add(:doublearray_value, :"list<double>")
+      add(:integerarray_value, :"list<int>")
+      add(:booleanarray_value, :"list<boolean>")
+      add(:longintegerarray_value, :"list<bigint>")
+      add(:stringarray_value, :"list<varchar>")
+      add(:binaryblobarray_value, :"list<blob>")
+      add(:datetimearray_value, :"list<timestamp>")
+    end
+  end
+end

--- a/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/queries_test.exs
@@ -286,7 +286,7 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
     assert Queries.get_interfaces_list(realm_name) == {:ok, []}
 
-    Queries.install_new_interface(client, realm_name, intdoc, automaton)
+    Queries.install_new_interface(realm_name, intdoc, automaton)
 
     assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, true}
@@ -398,7 +398,7 @@ defmodule Astarte.RealmManagement.QueriesTest do
 
     assert Queries.get_interfaces_list(realm_name) == {:ok, []}
 
-    Queries.install_new_interface(client, realm_name, intdoc, automaton)
+    Queries.install_new_interface(realm_name, intdoc, automaton)
 
     assert Queries.is_interface_major_available?(realm_name, interface_name, major_version) ==
              {:ok, true}
@@ -499,7 +499,7 @@ defmodule Astarte.RealmManagement.QueriesTest do
     {:ok, doc} = Ecto.Changeset.apply_action(interface_changeset, :insert)
 
     {:ok, automaton} = Astarte.Core.Mapping.EndpointsAutomaton.build(doc.mappings)
-    Queries.install_new_interface(client, realm_name, doc, automaton)
+    Queries.install_new_interface(realm_name, doc, automaton)
 
     endpoint_id = retrieve_endpoint_id(client, "com.timestamp.Test", 1, "/test/0/v")
 


### PR DESCRIPTION
- `UUID` modules moved to `Astarte.RealmManagement.UUID` (was `Astarte.DataAccess.UUID`). individual properties and individual datastream use the appropriate scylla types for their fields.
- Migrations to install and update interfaces are run trough the `Repo` module instead of `CQEx`
