### PR TITLE
ci(CI): refactor Astarte CI

### DIFF
--- a/.github/workflows/astarte-appengine-api-workflow.yaml
+++ b/.github/workflows/astarte-appengine-api-workflow.yaml
@@ -1,0 +1,35 @@
+name: Build and Test Astarte Appengine API
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_appengine_api'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-appengine-api-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_appengine_api
+  pull_request:
+    paths:
+    - 'apps/astarte_appengine_api'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-appengine-api-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_appengine_api:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_appengine_api"
+    secrets: inherit

--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -1,21 +1,18 @@
 name: Build and Test Astarte Apps
 
 on:
-  # Run when pushing to stable branches
-  push:
-    paths:
-    - 'apps/**'
-    - '.github/workflows/astarte-apps-build-workflow.yaml'
-    branches:
-    - 'master'
-    - 'release-*'
-  # Run on branch/tag creation
-  create:
-  # Run on pull requests matching apps
-  pull_request:
-    paths:
-    - 'apps/**'
-    - '.github/workflows/astarte-apps-build-workflow.yaml'
+  workflow_dispatch:
+    inputs:
+      app:
+        type: string
+        description: ""
+        required: true
+  workflow_call:
+    inputs:
+      app:
+        type: string
+        description: ""
+        required: true
 
 env:
   elixir_version: "1.14.5"
@@ -25,55 +22,42 @@ jobs:
   test-dialyzer:
     name: Check Dialyzer
     runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        app:
-        - astarte_appengine_api
-        - astarte_data_updater_plant
-        - astarte_housekeeping
-        - astarte_housekeeping_api
-        - astarte_pairing
-        - astarte_pairing_api
-        - astarte_realm_management
-        - astarte_realm_management_api
-        - astarte_trigger_engine
     env:
       MIX_ENV: ci
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v4
       with:
-        path: apps/${{ matrix.app }}/deps
-        key: ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
+        path: apps/${{ inputs.app }}/deps
+        key: ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', inputs.app, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-dialyzer-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-
     - uses: actions/cache@v4
       with:
-        path: apps/${{ matrix.app }}/_build
-        key: ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
+        path: apps/${{ inputs.app }}/_build
+        key: ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-dialyzer-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-
     - uses: actions/cache@v4
       id: plt_cache
       with:
-        path: apps/${{ matrix.app }}/dialyzer_cache
-        key: ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
+        path: apps/${{ inputs.app }}/dialyzer_cache
+        key: ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-
     - uses: erlef/setup-beam@v1.15
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}
     - name: Install Dependencies
-      working-directory: ./apps/${{ matrix.app }}
+      working-directory: ./apps/${{ inputs.app }}
       run: mix deps.get
     - name: Create PLTs dir
-      working-directory: ./apps/${{ matrix.app }}
+      working-directory: ./apps/${{ inputs.app }}
       if: ${{ steps.plt_cache.outputs.cache-hit != 'true' }}
       run: mkdir -p dialyzer_cache && mix dialyzer --plt
     - name: Run dialyzer
-      working-directory: ./apps/${{ matrix.app }}
+      working-directory: ./apps/${{ inputs.app }}
       # FIXME: This should be set to fail when dialyzer issues are fixed
       run: mix dialyzer || exit 0
 
@@ -86,16 +70,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        app:
-        - astarte_appengine_api
-        - astarte_data_updater_plant
-        - astarte_housekeeping
-        - astarte_housekeeping_api
-        - astarte_pairing
-        - astarte_pairing_api
-        - astarte_realm_management
-        - astarte_realm_management_api
-        - astarte_trigger_engine
         database:
         - "cassandra:3.11.15"
         - "scylladb/scylla:5.2.2"
@@ -123,37 +97,37 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/cache@v4
       with:
-        path: apps/${{ matrix.app }}/deps
-        key: ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', matrix.app, '/mix.lock')) }}
+        path: apps/${{ inputs.app }}/deps
+        key: ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', inputs.app, '/mix.lock')) }}
         restore-keys: |
-          ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+          ${{ runner.os }}-apps-mix-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-
     # Caching _build is causing tests to fail rather unexpectedly.
     # TODO try to undestand why and restore the cache step.
     # - uses: actions/cache@v1
     #   with:
-    #     path: apps/${{ matrix.app }}/_build
-    #     key: ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-${{ github.sha }}
+    #     path: apps/${{ inputs.app }}/_build
+    #     key: ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-${{ github.sha }}
     #     restore-keys: |
-    #       ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ matrix.app }}-
+    #       ${{ runner.os }}-apps-_build-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-
     - uses: erlef/setup-beam@v1.15
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}
     - name: Install Dependencies
-      working-directory: ./apps/${{ matrix.app }}
+      working-directory: ./apps/${{ inputs.app }}
       run: mix deps.get
     - name: Check formatting
-      working-directory: ./apps/${{ matrix.app }}
+      working-directory: ./apps/${{ inputs.app }}
       run: mix format --check-formatted
     - name: Setup Events Exchange
-      if: matrix.app == 'astarte_appengine_api'
+      if: inputs.app == 'astarte_appengine_api'
       run: |
         wget http://guest:guest@localhost:15672/cli/rabbitmqadmin -O rabbitmqadmin
         chmod +x ./rabbitmqadmin
         ./rabbitmqadmin declare exchange name=astarte_events type=direct
         rm rabbitmqadmin
     - name: Compile
-      working-directory: ./apps/${{ matrix.app }}
+      working-directory: ./apps/${{ inputs.app }}
       run: mix do compile
     - uses: actions/setup-node@v1
       with:
@@ -163,12 +137,12 @@ jobs:
         npm install -g wait-for-cassandra
         wait-for-cassandra -T 120000 -h $CASSANDRA_NODES
     - name: Test and Coverage
-      working-directory: ./apps/${{ matrix.app }}
+      working-directory: ./apps/${{ inputs.app }}
       run: mix coveralls.json  --exclude wip -o coverage_results
       env:
         CFSSL_API_URL: http://localhost:${{ job.services.cfssl.ports[8080] }}
     - name: Upload Coverage Results to CodeCov
       # Don't upload more than once per component
       if: matrix.database == 'scylladb/scylla:5.2.2'
-      working-directory: ./apps/${{ matrix.app }}
+      working-directory: ./apps/${{ inputs.app }}
       run: bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/astarte-data-updater-plant-workflow.yaml
+++ b/.github/workflows/astarte-data-updater-plant-workflow.yaml
@@ -1,0 +1,35 @@
+name: Build and Test Astarte Data Updater Plant
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_data_updater_plant'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-data-updater-plant-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_data_updater_plant
+  pull_request:
+    paths:
+    - 'apps/astarte_data_updater_plant'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-data-updater-plant-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_data_updater_plant:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_data_updater_plant"
+    secrets: inherit

--- a/.github/workflows/astarte-housekeeping-api-workflow.yaml
+++ b/.github/workflows/astarte-housekeeping-api-workflow.yaml
@@ -1,0 +1,37 @@
+name: Build and Test Astarte Housekeeping API
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_housekeeping'
+    - 'apps/astarte_housekeeping_api'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-housekeeping-api-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_housekeeping_api
+  pull_request:
+    paths:
+    - 'apps/astarte_housekeeping'
+    - 'apps/astarte_housekeeping_api'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-housekeeping-api-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_housekeeping_api:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_housekeeping_api"
+    secrets: inherit

--- a/.github/workflows/astarte-housekeeping-workflow.yaml
+++ b/.github/workflows/astarte-housekeeping-workflow.yaml
@@ -1,0 +1,35 @@
+name: Build and Test Astarte Housekeeping
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_housekeeping'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-housekeeping-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_housekeeping
+  pull_request:
+    paths:
+    - 'apps/astarte_housekeeping'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-housekeeping-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_housekeeping:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_housekeeping"
+    secrets: inherit

--- a/.github/workflows/astarte-pairing-api-workflow.yaml
+++ b/.github/workflows/astarte-pairing-api-workflow.yaml
@@ -1,0 +1,37 @@
+name: Build and Test Astarte Pairing API
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_pairing'
+    - 'apps/astarte_pairing_api'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-pairing-api-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_pairing_api
+  pull_request:
+    paths:
+    - 'apps/astarte_pairing'
+    - 'apps/astarte_pairing_api'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-pairing-api-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_pairing_api:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_pairing_api"
+    secrets: inherit

--- a/.github/workflows/astarte-pairing-workflow.yaml
+++ b/.github/workflows/astarte-pairing-workflow.yaml
@@ -1,0 +1,35 @@
+name: Build and Test Astarte Pairing
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_pairing'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-pairing-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_pairing
+  pull_request:
+    paths:
+    - 'apps/astarte_pairing'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-pairing-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_pairing:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_pairing"
+    secrets: inherit

--- a/.github/workflows/astarte-realm-management-api-workflow.yaml
+++ b/.github/workflows/astarte-realm-management-api-workflow.yaml
@@ -1,0 +1,37 @@
+name: Build and Test Astarte Realm Management API
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_realm_management'
+    - 'apps/astarte_realm_management_api'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-realm-management-api-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_realm_managemenet_api
+  pull_request:
+    paths:
+    - 'apps/astarte_realm_management'
+    - 'apps/astarte_realm_management_api'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-realm-management-api-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_realm_managemenet_api:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_realm_management_api"
+    secrets: inherit

--- a/.github/workflows/astarte-realm-management-workflow.yaml
+++ b/.github/workflows/astarte-realm-management-workflow.yaml
@@ -1,0 +1,35 @@
+name: Build and Test Astarte Realm Management
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_realm_management'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-realm-management-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_realm_management
+  pull_request:
+    paths:
+    - 'apps/astarte_realm_management'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-realm-management-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_realm_management:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_realm_management"
+    secrets: inherit

--- a/.github/workflows/astarte-trigger-engine-workflow.yaml
+++ b/.github/workflows/astarte-trigger-engine-workflow.yaml
@@ -1,0 +1,35 @@
+name: Build and Test Astarte Trigger Engine
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+    - 'apps/astarte_trigger_engine'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-trigger-engine-workflow.yaml'
+    branches:
+    - 'master'
+    - 'release-*'
+  # Run on branch/tag creation
+  create:
+  # Run on pull requests for astarte_trigger_engine
+  pull_request:
+    paths:
+    - 'apps/astarte_trigger_engine'
+    - '.github/workflows/astarte-apps-build-workflow.yaml'
+    - '.github/workflows/astarte-trigger-engine-workflow.yaml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_trigger_engine:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_trigger_engine"
+    secrets: inherit


### PR DESCRIPTION
Up to now build test and coverage workflows were triggered on every app on every code change. This was quite wasteful in terms of resources, as unnecessary checks were run on unchanged code.

This PR separates the workflows of every app into its own workflow, that gets triggered only when there are some changes in the relevant application.

`api` application's workflows get also triggered when there is a change in the non-`api` counterpart (to ensure that the communication between the two is consistent).