### PR TITLE
refactor(device): preparations for merge_device_status

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
@@ -112,6 +112,10 @@ defmodule Astarte.AppEngine.API.Device.DeviceStatus do
 
     # groups_map could be nil, default to empty map
     groups = Map.keys(groups_map || %{})
+    last_connection = truncate_datetime(last_connection)
+    last_disconnection = truncate_datetime(last_disconnection)
+    first_registration = truncate_datetime(first_registration)
+    first_credentials_request = truncate_datetime(first_credentials_request)
 
     %DeviceStatus{
       id: Device.encode_device_id(device_id),
@@ -132,6 +136,9 @@ defmodule Astarte.AppEngine.API.Device.DeviceStatus do
       groups: groups
     }
   end
+
+  defp truncate_datetime(nil), do: nil
+  defp truncate_datetime(datetime), do: datetime |> DateTime.truncate(:millisecond)
 
   defp ip_string(nil) do
     nil

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -451,15 +451,24 @@ defmodule Astarte.AppEngine.API.Device.Queries do
     |> to_string()
   end
 
+  def retrieve_device_for_status(realm_name, device_id) do
+    keyspace = keyspace_name(realm_name)
+    do_retrieve_device_for_status(keyspace, device_id)
+  end
+
   def retrieve_device_status(realm_name, device_id) do
     keyspace = keyspace_name(realm_name)
-    fields = [:device_id | @device_status_columns_without_device_id]
 
-    query = from(DatabaseDevice, prefix: ^keyspace, select: ^fields)
-
-    with {:ok, device} <- Repo.fetch(query, device_id, error: :device_not_found) do
+    with {:ok, device} <- do_retrieve_device_for_status(keyspace, device_id) do
       {:ok, build_device_status(keyspace, device)}
     end
+  end
+
+  defp do_retrieve_device_for_status(keyspace, device_id) do
+    fields = [:device_id | @device_status_columns_without_device_id]
+    query = from(DatabaseDevice, prefix: ^keyspace, select: ^fields)
+
+    Repo.fetch(query, device_id, error: :device_not_found)
   end
 
   defp deletion_in_progress?(keyspace, device_id) do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_group_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/device_status_by_group_controller_test.exs
@@ -97,25 +97,6 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusByGroupControllerTest do
     "groups" => [@group_name],
     "deletion_in_progress" => false
   }
-  @expected_device_status_long_timestamps %{
-    "connected" => false,
-    "id" => @expected_device_id,
-    "aliases" => %{"display_name" => "device_a"},
-    "introspection" => @expected_introspection,
-    "last_credentials_request_ip" => "198.51.100.89",
-    "last_seen_ip" => "198.51.100.81",
-    "attributes" => %{"attribute_key" => "device_a_attribute"},
-    "credentials_inhibited" => false,
-    "total_received_bytes" => 4_500_000,
-    "total_received_msgs" => 45000,
-    "previous_interfaces" => @expected_previous_interfaces,
-    "groups" => [@group_name],
-    "deletion_in_progress" => false,
-    "first_credentials_request" => "2016-08-20T09:44:00.000000Z",
-    "first_registration" => "2016-08-15T09:44:00.000000Z",
-    "last_connection" => "2017-09-28T03:45:00.000000Z",
-    "last_disconnection" => "2017-09-29T18:25:00.000000Z"
-  }
 
   setup_all do
     {:ok, _client} = DatabaseTestHelper.create_test_keyspace()
@@ -189,7 +170,7 @@ defmodule Astarte.AppEngine.APIWeb.DeviceStatusByGroupControllerTest do
       end
 
       assert Enum.find(devices, &(Map.get(&1, "id") == @expected_device_id)) ==
-               @expected_device_status_long_timestamps
+               @expected_device_status
     end
 
     test "implements pagination correctly", %{conn: conn} do


### PR DESCRIPTION
Preparation commits for #1057.

- add a function to device queries to return the device to then build the status. This is needed to be able to build the device_status struct in a second moment.
- Have `DeviceStatus.from_db_row` trim the timestamps to millisecond precision, like the version in the Queries module. This also restores a test from before the refactors done lately.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [X] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
