### PR TITLE
refactor(appengine): use datetimes for data insertion

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/datetime.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/datetime.ex
@@ -40,4 +40,14 @@ defmodule Astarte.AppEngine.API.DateTime do
 
   @spec cast(t() | any()) :: {:ok, t()} | :error
   def cast(datetime_or_timestamp_or_any), do: load(datetime_or_timestamp_or_any)
+
+  def split_submillis(timestamp) do
+    timestamp_ms = DateTime.truncate(timestamp, :millisecond)
+    submillis = timestamp |> DateTime.to_unix(:microsecond) |> rem(1000)
+    # `DateTime`s are microsecond precision, individual_properties's submillis
+    # have one extra digit. Keep the unit consistent with DUP
+    decimicrosecond_submillis = submillis * 10
+
+    {timestamp_ms, decimicrosecond_submillis}
+  end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/datetime.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/datetime.ex
@@ -1,0 +1,43 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.AppEngine.API.DateTime do
+  @moduledoc """
+  Ecto type for DateTimes with millisecond precision.
+  """
+  use Ecto.Type
+
+  @type t :: DateTime.t()
+
+  @doc false
+  def type, do: :utc_datetime_msec
+
+  @spec load(t() | any()) :: {:ok, t()} | :error
+  def load(%DateTime{} = datetime), do: {:ok, datetime}
+  def load(timestamp) when is_integer(timestamp), do: {:ok, DateTime.from_unix!(timestamp)}
+  def load(_other), do: :error
+
+  # xandra accepts both integers and datetimes, it can do the job for us
+  @spec dump(t() | any()) :: {:ok, t()} | :error
+  def dump(%DateTime{} = datetime), do: {:ok, datetime}
+  def dump(timestamp) when is_integer(timestamp), do: {:ok, timestamp}
+  def dump(_other), do: :error
+
+  @spec cast(t() | any()) :: {:ok, t()} | :error
+  def cast(datetime_or_timestamp_or_any), do: load(datetime_or_timestamp_or_any)
+end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -256,10 +256,6 @@ defmodule Astarte.AppEngine.API.Device do
 
       now = DateTime.utc_now()
 
-      timestamp_micro =
-        now
-        |> DateTime.to_unix(:microsecond)
-
       db_max_ttl =
         if mapping.database_retention_policy == :use_ttl do
           min(realm_max_ttl, mapping.database_retention_ttl)
@@ -284,7 +280,7 @@ defmodule Astarte.AppEngine.API.Device do
         mapping,
         path,
         value,
-        timestamp_micro,
+        now,
         opts
       )
 
@@ -411,10 +407,6 @@ defmodule Astarte.AppEngine.API.Device do
        ) do
     now = DateTime.utc_now()
 
-    timestamp_micro =
-      now
-      |> DateTime.to_unix(:microsecond)
-
     with {:ok, mappings} <-
            Mappings.fetch_interface_mappings(
              realm_name,
@@ -460,7 +452,7 @@ defmodule Astarte.AppEngine.API.Device do
         nil,
         path,
         value,
-        timestamp_micro,
+        now,
         opts
       )
 

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/devices/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/devices/device.ex
@@ -18,6 +18,7 @@
 
 defmodule Astarte.AppEngine.API.Devices.Device do
   use TypedEctoSchema
+  alias Astarte.AppEngine.API.DateTime, as: DateTimeMs
   alias Astarte.AppEngine.API.UUID
 
   @primary_key {:device_id, UUID, autogenerate: false}
@@ -39,16 +40,16 @@ defmodule Astarte.AppEngine.API.Devices.Device do
       types: [:string, :integer],
       value: :integer
 
-    field :first_credentials_request, :utc_datetime_usec
-    field :first_registration, :utc_datetime_usec
+    field :first_credentials_request, DateTimeMs
+    field :first_registration, DateTimeMs
     field :groups, Exandra.Map, key: :string, value: UUID
     field :inhibit_credentials_request, :boolean
     field :introspection, Exandra.Map, key: :string, value: :integer
     field :introspection_minor, Exandra.Map, key: :string, value: :integer
-    field :last_connection, :utc_datetime_usec
+    field :last_connection, DateTimeMs
     field :last_credentials_request_ip, Exandra.Inet
 
-    field :last_disconnection, :utc_datetime_usec
+    field :last_disconnection, DateTimeMs
     field :last_seen_ip, Exandra.Inet
 
     field :old_introspection,

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/realms/individual_datastream.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/realms/individual_datastream.ex
@@ -16,43 +16,44 @@
 # limitations under the License.
 #
 
-defmodule Astarte.AppEngine.API.Realms.IndividualProperty do
+defmodule Astarte.AppEngine.API.Realms.IndividualDatastream do
   use TypedEctoSchema
   alias Astarte.AppEngine.API.DateTime, as: DateTimeMs
   alias Astarte.AppEngine.API.UUID
 
   @primary_key false
-  typed_schema "individual_properties" do
+  typed_schema "individual_datastreams" do
     field :reception, DateTimeMs, virtual: true
     field :device_id, UUID, primary_key: true
     field :interface_id, UUID, primary_key: true
     field :endpoint_id, UUID, primary_key: true
     field :path, :string, primary_key: true
-    field :reception_timestamp, DateTimeMs
-    field :reception_timestamp_submillis, :integer
-    field :double_value, :float
-    field :integer_value, :integer
-    field :boolean_value, :boolean
-    field :longinteger_value, :integer
-    field :string_value, :string
+    field :value_timestamp, DateTimeMs, primary_key: true
+    field :reception_timestamp, DateTimeMs, primary_key: true
+    field :reception_timestamp_submillis, :integer, primary_key: true
     field :binaryblob_value, :binary
-    field :datetime_value, DateTimeMs
-    field :doublearray_value, {:array, :float}
-    field :integerarray_value, {:array, :integer}
-    field :booleanarray_value, {:array, :boolean}
-    field :longintegerarray_value, {:array, :integer}
-    field :stringarray_value, {:array, :string}
     field :binaryblobarray_value, {:array, :binary}
+    field :boolean_value, :boolean
+    field :booleanarray_value, {:array, :boolean}
+    field :datetime_value, DateTimeMs
     field :datetimearray_value, {:array, DateTimeMs}
+    field :double_value, :float
+    field :doublearray_value, {:array, :float}
+    field :integer_value, :integer
+    field :integerarray_value, {:array, :integer}
+    field :longinteger_value, :integer
+    field :longintegerarray_value, {:array, :integer}
+    field :string_value, :string
+    field :stringarray_value, {:array, :string}
   end
 
-  def prepare_for_db(%{reception: nil} = individual_property), do: individual_property
+  def prepare_for_db(%{reception: nil} = individual_datastream), do: individual_datastream
 
-  def prepare_for_db(individual_property) do
-    {reception_ms, submillis} = DateTimeMs.split_submillis(individual_property.reception)
+  def prepare_for_db(individual_datastream) do
+    {reception_ms, submillis} = DateTimeMs.split_submillis(individual_datastream.reception)
 
     %{
-      individual_property
+      individual_datastream
       | reception_timestamp: reception_ms,
         reception_timestamp_submillis: submillis
     }

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/realms/individual_property.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/realms/individual_property.ex
@@ -18,16 +18,17 @@
 
 defmodule Astarte.AppEngine.API.Realms.IndividualProperty do
   use TypedEctoSchema
+  alias Astarte.AppEngine.API.DateTime, as: DateTimeMs
   alias Astarte.AppEngine.API.UUID
 
   @primary_key false
   typed_schema "individual_properties" do
-    field :reception, :utc_datetime_usec, virtual: true
+    field :reception, DateTimeMs, virtual: true
     field :device_id, UUID, primary_key: true
     field :interface_id, UUID, primary_key: true
     field :endpoint_id, UUID, primary_key: true
     field :path, :string, primary_key: true
-    field :reception_timestamp, :utc_datetime_usec
+    field :reception_timestamp, DateTimeMs
     field :reception_timestamp_submillis, :integer
     field :double_value, :float
     field :integer_value, :integer
@@ -35,14 +36,14 @@ defmodule Astarte.AppEngine.API.Realms.IndividualProperty do
     field :longinteger_value, :integer
     field :string_value, :string
     field :binaryblob_value, :binary
-    field :datetime_value, :utc_datetime_usec
+    field :datetime_value, DateTimeMs
     field :doublearray_value, {:array, :float}
     field :integerarray_value, {:array, :integer}
     field :booleanarray_value, {:array, :boolean}
     field :longintegerarray_value, {:array, :integer}
     field :stringarray_value, {:array, :string}
     field :binaryblobarray_value, {:array, :binary}
-    field :datetimearray_value, {:array, :utc_datetime_usec}
+    field :datetimearray_value, {:array, DateTimeMs}
   end
 
   def reception(individual_property) do


### PR DESCRIPTION
using integer timestamps, especially when doing calculations on them,
is error prone and we've just recently resolved a bug that was caused
by a double "microsecond to millisecond" conversion.

elixir has something more solid than that: `DateTime`s.

default Ecto types only allow full second or microsecond precision,
but cql timestamps use millisecond precision. To avoid precision errors,
a new Ecto DateTime type has been created, which allows millisecond
precision (althogh no check is made: Xandra handles that itself).

although currently unused, the submillis should now use the correct
number of digits.

an unused and nonfunctioning function in `IndividualProperty` has been
removed

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes submillis precision probably?

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [X] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
