### PR TITLE
Move keyspace translations to public functions in query files

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/auth/auth.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/auth/auth.ex
@@ -18,14 +18,10 @@
 
 defmodule Astarte.AppEngine.API.Auth do
   alias Astarte.AppEngine.API.Queries
-  alias Astarte.AppEngine.API.Config
-  alias Astarte.Core.CQLUtils
 
   require Logger
 
   def fetch_public_key(realm) do
-    keyspace = CQLUtils.realm_name_to_keyspace_name(realm, Config.astarte_instance_id!())
-
-    Queries.fetch_public_key(keyspace)
+    Queries.fetch_public_key(realm)
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -40,7 +40,7 @@ defmodule Astarte.AppEngine.API.Device do
   alias Astarte.DataAccess.Device, as: DeviceQueries
   alias Astarte.DataAccess.Interface, as: InterfaceQueries
   alias Ecto.Changeset
-  alias Astarte.Core.CQLUtils
+
   require Logger
 
   def list_devices!(realm_name, params) do

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/health.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/health.ex
@@ -17,15 +17,12 @@
 #
 
 defmodule Astarte.AppEngine.API.Health do
-  alias Astarte.AppEngine.API.Realm
   alias Astarte.AppEngine.API.Queries
 
   require Logger
 
   def get_health do
-    astarte_keyspace = Realm.keyspace_name("astarte")
-
-    case Queries.check_astarte_health(astarte_keyspace, :quorum) do
+    case Queries.check_astarte_health(:quorum) do
       :ok ->
         :ok
 
@@ -33,7 +30,7 @@ defmodule Astarte.AppEngine.API.Health do
         {:error, :bad_health}
 
       {:error, :health_check_bad} ->
-        case Queries.check_astarte_health(astarte_keyspace, :one) do
+        case Queries.check_astarte_health(:one) do
           :ok -> {:error, :degraded_health}
           _error -> {:error, :bad_health}
         end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/queries.ex
@@ -17,14 +17,16 @@
 
 defmodule Astarte.AppEngine.API.Queries do
   alias Astarte.AppEngine.API.KvStore
-  alias Astarte.AppEngine.API.Realm
+  alias Astarte.AppEngine.API.Realm, as: DataAccessRealm
   alias Astarte.AppEngine.API.Repo
 
   require Logger
   import Ecto.Query
   @keyspace_does_not_exist_regex ~r/Keyspace (.*) does not exist/
 
-  def fetch_public_key(keyspace_name) do
+  def fetch_public_key(realm_name) do
+    keyspace_name = DataAccessRealm.keyspace_name(realm_name)
+
     schema_query =
       from r in KvStore,
         prefix: ^keyspace_name,
@@ -77,7 +79,9 @@ defmodule Astarte.AppEngine.API.Queries do
     end
   end
 
-  def check_astarte_health(astarte_keyspace, consistency) do
+  def check_astarte_health(consistency) do
+    astarte_keyspace = DataAccessRealm.astarte_keyspace_name()
+
     schema_query =
       from kv in KvStore,
         prefix: ^astarte_keyspace,
@@ -85,7 +89,7 @@ defmodule Astarte.AppEngine.API.Queries do
         select: count(kv.value)
 
     realm_query =
-      from Realm,
+      from DataAccessRealm,
         prefix: ^astarte_keyspace,
         where: [realm_name: "_invalid^name_"]
 

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/realms/realm.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/realms/realm.ex
@@ -21,6 +21,7 @@ defmodule Astarte.AppEngine.API.Realm do
   use TypedEctoSchema
 
   alias Astarte.Core.CQLUtils
+  alias Astarte.Core.Realm
   alias Astarte.DataAccess.Config
 
   @primary_key {:realm_name, :string, autogenerate: false}
@@ -29,7 +30,15 @@ defmodule Astarte.AppEngine.API.Realm do
   end
 
   @spec keyspace_name(String.t()) :: String.t()
+
   def keyspace_name(realm_name) do
-    CQLUtils.realm_name_to_keyspace_name(realm_name, Config.astarte_instance_id!())
+    case Realm.valid_name?(realm_name) do
+      true -> CQLUtils.realm_name_to_keyspace_name(realm_name, Config.astarte_instance_id!())
+      _ -> raise ArgumentError, "invalid realm name"
+    end
+  end
+
+  def astarte_keyspace_name() do
+    CQLUtils.realm_name_to_keyspace_name("astarte", Config.astarte_instance_id!())
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/queries.ex
@@ -19,14 +19,14 @@
 defmodule Astarte.AppEngine.API.Rooms.Queries do
   alias Astarte.AppEngine.API.Devices.Device, as: DatabaseDevice
   alias Astarte.Core.Device
-  alias Astarte.AppEngine.API.Realm
+  alias Astarte.AppEngine.API.Realm, as: DataAccessRealm
   alias Astarte.AppEngine.API.Repo
 
   require Logger
 
   def verify_device_exists(realm_name, encoded_device_id) do
     with {:ok, decoded_device_id} <- Device.decode_device_id(encoded_device_id) do
-      keyspace = Realm.keyspace_name(realm_name)
+      keyspace = DataAccessRealm.keyspace_name(realm_name)
 
       result =
         Repo.fetch(DatabaseDevice, decoded_device_id,

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/stats/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/stats/queries.ex
@@ -18,7 +18,7 @@
 
 defmodule Astarte.AppEngine.API.Stats.Queries do
   alias Astarte.Core.Device
-  alias Astarte.AppEngine.API.Realm
+  alias Astarte.AppEngine.API.Realm, as: DataAccessRealm
   alias Astarte.AppEngine.API.Repo
   alias Astarte.AppEngine.API.Devices.Device
   alias Astarte.AppEngine.API.Stats.DevicesStats
@@ -28,7 +28,7 @@ defmodule Astarte.AppEngine.API.Stats.Queries do
   import Ecto.Query
 
   def for_realm(realm_name) do
-    keyspace = Realm.keyspace_name(realm_name)
+    keyspace = DataAccessRealm.keyspace_name(realm_name)
 
     device_count = Repo.aggregate(Device, :count, prefix: keyspace)
 


### PR DESCRIPTION
Fix astarte keyspace encoding, check and fix for functions that used to require a plain or encoded realm name in order to generally have:
def functions -> accepts plain realm name, encode into keyspace and then use that
defp -> accepts only keyspaces

There are actually one or two occurrences that require a rework to match the above case(s), but this would affect the entire application logic (maybe in another PR?)
