### PR TITLE
fix(dup): last_connection / last_disconnection timestamp unit

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -130,7 +130,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     Queries.set_device_connected!(
       new_state.realm,
       new_state.device_id,
-      DateTime.from_unix!(timestamp_ms, :microsecond),
+      DateTime.from_unix!(timestamp_ms, :millisecond),
       ip_address
     )
 
@@ -2244,7 +2244,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     Queries.set_device_disconnected!(
       state.realm,
       state.device_id,
-      DateTime.from_unix!(timestamp_ms, :microsecond),
+      DateTime.from_unix!(timestamp_ms, :millisecond),
       state.total_received_msgs,
       state.total_received_bytes,
       state.interface_exchanged_msgs,

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -457,6 +457,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
 
   defp set_connection_info!(realm, device_id, timestamp, ip_address) do
     keyspace_name = Realm.keyspace_name(realm)
+    timestamp = Ecto.Type.cast!(:utc_datetime_usec, timestamp)
 
     %Device{device_id: device_id}
     |> Ecto.Changeset.change(
@@ -515,6 +516,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
         interface_exchanged_bytes
       ) do
     keyspace_name = Realm.keyspace_name(realm)
+    timestamp_ms = Ecto.Type.cast!(:utc_datetime_usec, timestamp_ms)
 
     %Device{device_id: device_id}
     |> Ecto.Changeset.change(


### PR DESCRIPTION
a regression was introduced in 2c66918c1ba02e93566af1762e3203c1f591df0e, where timestamps were in millisecond precision, but `DateTime.from_unix!` was given microsecond precision. This caused datetimes to be incorrect.

this was the result after setting up astarte in 5 minutes and running astarte-stream-qt5-test

```
❯ docker compose exec -it scylla cqlsh -e 'select last_connection from test.devices;'

 last_connection
---------------------------------
 1970-01-21 03:48:22.216000+0000
```

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
