### PR TITLE
fix(CI): Match services folders

### DIFF
--- a/.github/workflows/astarte-appengine-api-workflow.yaml
+++ b/.github/workflows/astarte-appengine-api-workflow.yaml
@@ -4,7 +4,7 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_appengine_api'
+    - 'apps/astarte_appengine_api/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-appengine-api-workflow.yaml'
     branches:
@@ -15,7 +15,7 @@ on:
   # Run on pull requests for astarte_appengine_api
   pull_request:
     paths:
-    - 'apps/astarte_appengine_api'
+    - 'apps/astarte_appengine_api/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-appengine-api-workflow.yaml'
 

--- a/.github/workflows/astarte-data-updater-plant-workflow.yaml
+++ b/.github/workflows/astarte-data-updater-plant-workflow.yaml
@@ -4,7 +4,7 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_data_updater_plant'
+    - 'apps/astarte_data_updater_plant/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-data-updater-plant-workflow.yaml'
     branches:
@@ -15,7 +15,7 @@ on:
   # Run on pull requests for astarte_data_updater_plant
   pull_request:
     paths:
-    - 'apps/astarte_data_updater_plant'
+    - 'apps/astarte_data_updater_plant/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-data-updater-plant-workflow.yaml'
 

--- a/.github/workflows/astarte-housekeeping-api-workflow.yaml
+++ b/.github/workflows/astarte-housekeeping-api-workflow.yaml
@@ -4,8 +4,8 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_housekeeping'
-    - 'apps/astarte_housekeeping_api'
+    - 'apps/astarte_housekeeping/**'
+    - 'apps/astarte_housekeeping_api/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-housekeeping-api-workflow.yaml'
     branches:
@@ -16,8 +16,8 @@ on:
   # Run on pull requests for astarte_housekeeping_api
   pull_request:
     paths:
-    - 'apps/astarte_housekeeping'
-    - 'apps/astarte_housekeeping_api'
+    - 'apps/astarte_housekeeping/**'
+    - 'apps/astarte_housekeeping_api/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-housekeeping-api-workflow.yaml'
 

--- a/.github/workflows/astarte-housekeeping-workflow.yaml
+++ b/.github/workflows/astarte-housekeeping-workflow.yaml
@@ -4,7 +4,7 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_housekeeping'
+    - 'apps/astarte_housekeeping/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-housekeeping-workflow.yaml'
     branches:
@@ -15,7 +15,7 @@ on:
   # Run on pull requests for astarte_housekeeping
   pull_request:
     paths:
-    - 'apps/astarte_housekeeping'
+    - 'apps/astarte_housekeeping/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-housekeeping-workflow.yaml'
 

--- a/.github/workflows/astarte-pairing-api-workflow.yaml
+++ b/.github/workflows/astarte-pairing-api-workflow.yaml
@@ -4,8 +4,8 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_pairing'
-    - 'apps/astarte_pairing_api'
+    - 'apps/astarte_pairing/**'
+    - 'apps/astarte_pairing_api/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-pairing-api-workflow.yaml'
     branches:
@@ -16,8 +16,8 @@ on:
   # Run on pull requests for astarte_pairing_api
   pull_request:
     paths:
-    - 'apps/astarte_pairing'
-    - 'apps/astarte_pairing_api'
+    - 'apps/astarte_pairing/**'
+    - 'apps/astarte_pairing_api/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-pairing-api-workflow.yaml'
 

--- a/.github/workflows/astarte-pairing-workflow.yaml
+++ b/.github/workflows/astarte-pairing-workflow.yaml
@@ -4,7 +4,7 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_pairing'
+    - 'apps/astarte_pairing/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-pairing-workflow.yaml'
     branches:
@@ -15,7 +15,7 @@ on:
   # Run on pull requests for astarte_pairing
   pull_request:
     paths:
-    - 'apps/astarte_pairing'
+    - 'apps/astarte_pairing/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-pairing-workflow.yaml'
 

--- a/.github/workflows/astarte-realm-management-api-workflow.yaml
+++ b/.github/workflows/astarte-realm-management-api-workflow.yaml
@@ -4,8 +4,8 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_realm_management'
-    - 'apps/astarte_realm_management_api'
+    - 'apps/astarte_realm_management/**'
+    - 'apps/astarte_realm_management_api/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-realm-management-api-workflow.yaml'
     branches:
@@ -16,8 +16,8 @@ on:
   # Run on pull requests for astarte_realm_managemenet_api
   pull_request:
     paths:
-    - 'apps/astarte_realm_management'
-    - 'apps/astarte_realm_management_api'
+    - 'apps/astarte_realm_management/**'
+    - 'apps/astarte_realm_management_api/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-realm-management-api-workflow.yaml'
 

--- a/.github/workflows/astarte-realm-management-workflow.yaml
+++ b/.github/workflows/astarte-realm-management-workflow.yaml
@@ -4,7 +4,7 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_realm_management'
+    - 'apps/astarte_realm_management/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-realm-management-workflow.yaml'
     branches:
@@ -15,7 +15,7 @@ on:
   # Run on pull requests for astarte_realm_management
   pull_request:
     paths:
-    - 'apps/astarte_realm_management'
+    - 'apps/astarte_realm_management/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-realm-management-workflow.yaml'
 

--- a/.github/workflows/astarte-trigger-engine-workflow.yaml
+++ b/.github/workflows/astarte-trigger-engine-workflow.yaml
@@ -4,7 +4,7 @@ on:
   # Run when pushing to stable branches
   push:
     paths:
-    - 'apps/astarte_trigger_engine'
+    - 'apps/astarte_trigger_engine/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-trigger-engine-workflow.yaml'
     branches:
@@ -15,7 +15,7 @@ on:
   # Run on pull requests for astarte_trigger_engine
   pull_request:
     paths:
-    - 'apps/astarte_trigger_engine'
+    - 'apps/astarte_trigger_engine/**'
     - '.github/workflows/astarte-apps-build-workflow.yaml'
     - '.github/workflows/astarte-trigger-engine-workflow.yaml'
 


### PR DESCRIPTION
Single services CI workflows did not run because github did not match subfolders with only parent folder name. Fixing
