### PR TITLE
DUP: use standard CL for queries

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/trigger_policy/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/trigger_policy/queries.ex
@@ -21,6 +21,7 @@ defmodule Astarte.DataUpdaterPlant.TriggerPolicy.Queries do
 
   import Ecto.Query
 
+  alias Astarte.DataAccess.Consistency
   alias Astarte.DataUpdaterPlant.Repo
   alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Realms.Realm
@@ -39,7 +40,7 @@ defmodule Astarte.DataUpdaterPlant.TriggerPolicy.Queries do
         where: kvstore.group == "trigger_to_policy" and kvstore.key == ^trigger_id,
         select: kvstore.value
 
-    case Repo.one(query) do
+    case Repo.one(query, consistency: Consistency.domain_model(:read)) do
       nil -> {:error, :policy_not_found}
       value -> {:ok, value}
     end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
See https://github.com/astarte-platform/astarte_data_access/pull/98. Use the standard consistency classes as defined there:

- "Domain Model": operations related to all Astarte entities, such as triggers, interfaces, policies etc
- "Device Info": operations related to Device metadata (e.g. connection status), time series metadata (as they refer to a specific device), property data (as they specify the domain specific status of a device)
- "Time series": operations related to datastreams

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Use the standard approach to CL, instead of a case-by-case one.

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

