### PR TITLE
fix(dup): don't crash on register_device_with_interface

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -630,13 +630,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     encoded_device_id = CoreDevice.encode_device_id(device_id)
 
     devices_by_interface = %{
-      "group" => "devices-by-interface-#{interface_name}-v#{interface_major}",
-      "key" => encoded_device_id
+      group: "devices-by-interface-#{interface_name}-v#{interface_major}",
+      key: encoded_device_id
     }
 
     devices_on_interface = %{
-      "group" => "devices-with-data-on-interface-#{interface_name}-v#{interface_major}",
-      "key" => encoded_device_id
+      group: "devices-with-data-on-interface-#{interface_name}-v#{interface_major}",
+      key: encoded_device_id
     }
 
     opts = [prefix: keyspace_name, consistency: :each_quorum]


### PR DESCRIPTION
previously string keys were given to exandra in `insert_all`. however, when given an actual schema (ie, not a string with a table name), ecto expects atom keys for the values.

this resulted in a crash with the log
%ArgumentError{message: \"unknown field `"group"` in schema Astarte.DataUpdaterPlant.DataUpdater.KvStore given to insert_all. ...}

the fix is to just use atom keys

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
