### PR TITLE
DUP: do not crash when resending properties to device

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -2756,7 +2756,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       %Mapping{value_type: value_type} = mapping
 
       column_name =
-        CQLUtils.mapping_value_type_to_db_type(value_type) |> String.to_existing_atom()
+        CQLUtils.type_to_db_column_name(value_type) |> String.to_existing_atom()
 
       Queries.retrieve_property_values(realm, device_id, interface_descriptor, mapping)
       |> Enum.reduce_while(:ok, fn %{:path => path, ^column_name => value}, _acc ->

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -720,7 +720,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
 
     %Mapping{endpoint_id: endpoint_id, value_type: value_type} = mapping
 
-    column_name = CQLUtils.mapping_value_type_to_db_type(value_type) |> String.to_existing_atom()
+    column_name = CQLUtils.type_to_db_column_name(value_type) |> String.to_existing_atom()
     keyspace_name = Realm.keyspace_name(realm)
 
     from(storage)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
A regression was introduced in which the individual_properties column queried when (re)sending properties to the device was named with the type instead of the actual column name. Fix it.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

