### PR TITLE
AE: do not crash on some device status queries

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -483,7 +483,7 @@ defmodule Astarte.AppEngine.API.Device.Queries do
   end
 
   def deletion_in_progress?(realm_name, device_id) do
-    keyspace = keyspace_name(realm_name)
+    keyspace = DataAccessRealm.keyspace_name(realm_name)
     do_deletion_in_progress?(keyspace, device_id)
   end
 
@@ -557,7 +557,7 @@ defmodule Astarte.AppEngine.API.Device.Queries do
   end
 
   def find_all_aliases(realm_name, alias_list) do
-    keyspace = keyspace_name(realm_name)
+    keyspace = DataAccessRealm.keyspace_name(realm_name)
 
     # Queries are chunked to avoid hitting scylla's `max_clustering_key_restrictions_per_query`
     alias_list
@@ -572,7 +572,7 @@ defmodule Astarte.AppEngine.API.Device.Queries do
       do: :ok
 
   def merge_device_status(realm_name, device, changes, alias_tags_to_delete, aliases_to_update) do
-    keyspace = keyspace_name(realm_name)
+    keyspace = DataAccessRealm.keyspace_name(realm_name)
 
     device_query = merge_device_status_device_query(keyspace, device.device_id, changes)
 


### PR DESCRIPTION
A regression was introduced that made AE crash on some device status queries (merge_device_status, deletion in progress check, list aliases). Fix it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

