### PR TITLE
Backends: Use standard consistency levels in queries

### DIFF
--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/queries.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/queries.ex
@@ -17,6 +17,7 @@
 #
 
 defmodule Astarte.TriggerEngine.AMQPConsumer.Queries do
+  alias Astarte.DataAccess.Consistency
   alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.TriggerEngine.Repo
@@ -32,7 +33,7 @@ defmodule Astarte.TriggerEngine.AMQPConsumer.Queries do
         prefix: ^keyspace_name,
         where: k.group == "trigger_policy"
 
-    case Repo.safe_fetch_all(query, []) do
+    case Repo.safe_fetch_all(query, consistency: Consistency.domain_model(:read)) do
       {:ok, policies} ->
         {:ok, Enum.map(policies, &extract_name_and_data/1)}
 
@@ -50,7 +51,7 @@ defmodule Astarte.TriggerEngine.AMQPConsumer.Queries do
         prefix: ^keyspace_name,
         select: r.realm_name
 
-    case Repo.safe_fetch_all(query, []) do
+    case Repo.safe_fetch_all(query, consistency: Consistency.domain_model(:read)) do
       {:ok, realms} ->
         {:ok, realms}
 

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/events_consumer.ex
@@ -26,6 +26,7 @@ defmodule Astarte.TriggerEngine.EventsConsumer do
   alias Astarte.Core.Triggers.SimpleEvents.SimpleEvent
   alias Astarte.Core.Triggers.Trigger
   alias Astarte.TriggerEngine.Repo
+  alias Astarte.DataAccess.Consistency
   alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Realms.Realm
 
@@ -323,7 +324,9 @@ defmodule Astarte.TriggerEngine.EventsConsumer do
         where: kvstore.group == "triggers" and kvstore.key == ^trigger_id,
         select: kvstore.value
 
-    with encoded_trigger when encoded_trigger != nil <- Repo.one(query),
+    opts = [consistency: Consistency.domain_model(:read)]
+
+    with encoded_trigger when encoded_trigger != nil <- Repo.one(query, opts),
          trigger <- Trigger.decode(encoded_trigger),
          {:ok, action} <- Jason.decode(trigger.action) do
       {:ok, %{action: action, trigger_name: trigger.name}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
See https://github.com/astarte-platform/astarte_data_access/pull/98. Use the standard consistency classes as defined there:
- "Domain Model": operations related to all Astarte entities, such as triggers, interfaces, policies etc
- "Device Info": operations related to Device metadata (e.g. connection status), time series metadata (as they refer to a specific device), property data (as they specify the domain specific status of a device)
- "Time series": operations related to datastreams

See also #1146 

#### Which issue(s) this PR fixes:

Use the standard approach to CL, instead of a case-by-case one.

#### Special notes for your reviewer:
This PR groups together changes to minor Astarte services (Trigger Engine, Housekeeping, Pairing) in order to move faster

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

