### PR TITLE
Realm Management: use standard CL for queries

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -50,6 +50,7 @@ defmodule Astarte.RealmManagement.Queries do
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.TaggedSimpleTrigger
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.TriggerTargetContainer
   alias Astarte.Core.Triggers.Trigger
+  alias Astarte.DataAccess.Consistency
   alias Astarte.RealmManagement.Migrations.CreateDatastreamIndividualMultiInterface
 
   import Ecto.Query
@@ -230,12 +231,14 @@ defmodule Astarte.RealmManagement.Queries do
         )
       end
 
+    consistency = Consistency.domain_model(:write)
+
     Exandra.execute_batch(
       Repo,
       %Exandra.Batch{
         queries: [interface_query | endpoints_queries]
       },
-      consistency: :each_quorum
+      consistency: consistency
     )
   end
 
@@ -332,13 +335,12 @@ defmodule Astarte.RealmManagement.Queries do
       doc: doc
     ]
 
-    update_query_base =
+    update_query =
       from Interface,
         prefix: ^keyspace,
         where: [name: ^interface_name],
-        where: [major_version: ^major]
-
-    update_query = put_changes(update_query_base, changes)
+        where: [major_version: ^major],
+        update: [set: ^changes]
 
     update_interface_query = Repo.to_sql(:update_all, update_query)
 
@@ -355,22 +357,15 @@ defmodule Astarte.RealmManagement.Queries do
         )
       end
 
+    consistency = Consistency.domain_model(:write)
+
     Exandra.execute_batch(
       Repo,
       %Exandra.Batch{
         queries: [update_interface_query | insert_mapping_queries]
-      }
+      },
+      consistency: consistency
     )
-  end
-
-  # TODO: here due to an Exandra bug: it does not support `:set` with a list.
-  # When fixed we could just write `update: [set: ^changes]` in the original query.
-  defp put_changes(query, []), do: query
-
-  defp put_changes(query, [{key, value} | rest]) do
-    query
-    |> Ecto.Query.update(set: [{^key, ^value}])
-    |> put_changes(rest)
   end
 
   def update_interface_storage(_realm_name, _interface_descriptor, []) do
@@ -399,7 +394,9 @@ defmodule Astarte.RealmManagement.Queries do
       ADD (#{add_cols})
       """
 
-    with {:ok, _} <- Repo.query(update_storage_statement) do
+    consistency = Consistency.domain_model(:write)
+
+    with {:ok, _} <- Repo.query(update_storage_statement, [], consistency: consistency) do
       :ok
     end
   end
@@ -435,12 +432,14 @@ defmodule Astarte.RealmManagement.Queries do
       Repo.to_sql(:delete_all, interface_query)
     ]
 
+    consistency = Consistency.domain_model(:write)
+
     Exandra.execute_batch(
       Repo,
       %Exandra.Batch{
         queries: queries
       },
-      consistency: :each_quorum
+      consistency: consistency
     )
   end
 
@@ -453,8 +452,9 @@ defmodule Astarte.RealmManagement.Queries do
       ) do
     keyspace = Realm.keyspace_name(realm_name)
     delete_statement = "DROP TABLE IF EXISTS #{keyspace}.#{table_name}"
+    consistency = Consistency.domain_model(:write)
 
-    _ = Repo.query!(delete_statement)
+    _ = Repo.query!(delete_statement, [], consistency: consistency)
     _ = Logger.info("Deleted #{table_name} table.", tag: "db_delete_interface_table")
     :ok
   end
@@ -483,7 +483,9 @@ defmodule Astarte.RealmManagement.Queries do
         where: [group: ^group_name],
         limit: 1
 
-    Repo.some?(devices_query, prefix: keyspace, consistency: :quorum)
+    consistency = Consistency.domain_model(:read)
+
+    Repo.some?(devices_query, prefix: keyspace, consistency: consistency)
   end
 
   def devices_with_data_on_interface(realm_name, interface_name) do
@@ -495,7 +497,9 @@ defmodule Astarte.RealmManagement.Queries do
         select: map.key,
         where: [group: ^group_name]
 
-    Repo.fetch_all(query, prefix: keyspace, consistency: :quorum)
+    consistency = Consistency.domain_model(:read)
+
+    Repo.fetch_all(query, prefix: keyspace, consistency: consistency)
   end
 
   def delete_devices_with_data_on_interface(realm_name, interface_name) do
@@ -504,7 +508,9 @@ defmodule Astarte.RealmManagement.Queries do
 
     query = from KvStore, where: [group: ^group_name]
 
-    _ = Repo.delete_all(query, prefix: keyspace, consistency: :each_quorum)
+    consistency = Consistency.domain_model(:write)
+
+    _ = Repo.delete_all(query, prefix: keyspace, consistency: consistency)
 
     :ok
   end
@@ -524,7 +530,9 @@ defmodule Astarte.RealmManagement.Queries do
       from table_name,
         where: [device_id: ^device_id, interface_id: ^interface_id]
 
-    _ = Repo.delete_all(query, prefix: keyspace, consistency: :each_quorum)
+    consistency = Consistency.device_info(:write)
+
+    _ = Repo.delete_all(query, prefix: keyspace, consistency: consistency)
 
     :ok
   end
@@ -577,7 +585,9 @@ defmodule Astarte.RealmManagement.Queries do
           path: ^path
         ]
 
-    _ = Repo.delete_all(query, prefix: keyspace, consistency: :quorum)
+    consistency = Consistency.device_info(:write)
+
+    _ = Repo.delete_all(query, prefix: keyspace, consistency: consistency)
 
     :ok
   end
@@ -597,7 +607,9 @@ defmodule Astarte.RealmManagement.Queries do
         select: [:endpoint_id, :path],
         where: [device_id: ^device_id, interface_id: ^interface_id]
 
-    with {:ok, properties} <- Repo.fetch_all(query, prefix: keyspace, consistency: :quorum) do
+    consistency = Consistency.device_info(:read)
+
+    with {:ok, properties} <- Repo.fetch_all(query, prefix: keyspace, consistency: consistency) do
       properties =
         Enum.map(properties, fn property ->
           [endpoint_id: property.endpoint_id, path: property.path]
@@ -621,7 +633,9 @@ defmodule Astarte.RealmManagement.Queries do
       from IndividualProperty,
         where: [device_id: ^device_id, interface_id: ^interface_id]
 
-    _ = Repo.delete_all(query, consistency: :each_quorum, prefix: keyspace)
+    consistency = Consistency.device_info(:write)
+
+    _ = Repo.delete_all(query, consistency: consistency, prefix: keyspace)
 
     :ok
   end
@@ -634,8 +648,10 @@ defmodule Astarte.RealmManagement.Queries do
         select: [:major_version, :minor_version],
         where: [name: ^interface_name]
 
+    consistency = Consistency.domain_model(:read)
+
     with {:ok, interface_versions_map} <-
-           Repo.fetch_all(interface_versions_query, prefix: keyspace, consistency: :quorum) do
+           Repo.fetch_all(interface_versions_query, prefix: keyspace, consistency: consistency) do
       case interface_versions_map do
         [] ->
           {:error, :interface_not_found}
@@ -659,7 +675,9 @@ defmodule Astarte.RealmManagement.Queries do
         where: i.name == ^interface_name,
         where: i.major_version == ^interface_major
 
-    Repo.some?(query, prefix: keyspace, consistency: :quorum)
+    consistency = Consistency.domain_model(:read)
+
+    Repo.some?(query, prefix: keyspace, consistency: consistency)
   end
 
   defp normalize_interface_name(interface_name) do
@@ -676,7 +694,10 @@ defmodule Astarte.RealmManagement.Queries do
         distinct: true,
         select: i.name
 
-    with {:ok, names} <- Repo.fetch_all(all_names_query, prefix: keyspace, consistency: :quorum) do
+    consistency = Consistency.domain_model(:read)
+
+    with {:ok, names} <-
+           Repo.fetch_all(all_names_query, prefix: keyspace, consistency: consistency) do
       Enum.reduce_while(names, :ok, fn name, _acc ->
         if normalize_interface_name(name) == normalized_interface do
           if name == interface_name do
@@ -696,17 +717,19 @@ defmodule Astarte.RealmManagement.Queries do
   def fetch_interface(realm_name, interface_name, interface_major) do
     keyspace = Realm.keyspace_name(realm_name)
 
+    consistency = Consistency.domain_model(:read)
+
     with {:ok, interface} <-
            Repo.fetch_by(
              Interface,
              [name: interface_name, major_version: interface_major],
              prefix: keyspace,
-             consistency: :quorum,
+             consistency: consistency,
              error: :interface_not_found
            ),
          endpoints_query = from(Endpoint, where: [interface_id: ^interface.interface_id]),
          {:ok, mappings} <-
-           Repo.fetch_all(endpoints_query, prefix: keyspace, consistency: :quorum) do
+           Repo.fetch_all(endpoints_query, prefix: keyspace, consistency: consistency) do
       mappings =
         Enum.map(mappings, fn endpoint ->
           %Mapping{}
@@ -746,7 +769,9 @@ defmodule Astarte.RealmManagement.Queries do
         distinct: true,
         select: i.name
 
-    Repo.fetch_all(query, prefix: keyspace, consistency: :quorum)
+    consistency = Consistency.domain_model(:read)
+
+    Repo.fetch_all(query, prefix: keyspace, consistency: consistency)
   end
 
   def has_interface_simple_triggers?(realm_name, object_id) do
@@ -756,15 +781,19 @@ defmodule Astarte.RealmManagement.Queries do
       from SimpleTrigger,
         where: [object_id: ^object_id, object_type: 2]
 
-    Repo.some?(simple_triggers_query, prefix: keyspace, consistency: :quorum)
+    consistency = Consistency.domain_model(:read)
+
+    Repo.some?(simple_triggers_query, prefix: keyspace, consistency: consistency)
   end
 
   def get_jwt_public_key_pem(realm_name) do
     keyspace = Realm.keyspace_name(realm_name)
 
+    consistency = Consistency.domain_model(:read)
+
     KvStore.fetch_value("auth", "jwt_public_key_pem", :string,
       prefix: keyspace,
-      consistency: :quorum,
+      consistency: consistency,
       error: :public_key_not_found
     )
   end
@@ -772,13 +801,15 @@ defmodule Astarte.RealmManagement.Queries do
   def update_jwt_public_key_pem(realm_name, jwt_public_key_pem) do
     keyspace = Realm.keyspace_name(realm_name)
 
+    consistency = Consistency.domain_model(:write)
+
     %{
       group: "auth",
       key: "jwt_public_key_pem",
       value: jwt_public_key_pem,
       value_type: :string
     }
-    |> KvStore.insert(prefix: keyspace)
+    |> KvStore.insert(prefix: keyspace, consistency: consistency)
   end
 
   def install_trigger(realm_name, trigger) do
@@ -802,8 +833,10 @@ defmodule Astarte.RealmManagement.Queries do
       value: Trigger.encode(trigger)
     }
 
-    with :ok <- KvStore.insert(insert_by_name, prefix: keyspace),
-         :ok <- KvStore.insert(insert, prefix: keyspace) do
+    consistency = Consistency.domain_model(:write)
+
+    with :ok <- KvStore.insert(insert_by_name, prefix: keyspace, consistency: consistency),
+         :ok <- KvStore.insert(insert, prefix: keyspace, consistency: consistency) do
       :ok
     else
       not_ok ->
@@ -851,8 +884,10 @@ defmodule Astarte.RealmManagement.Queries do
         value: astarte_ref
       }
 
-    with {:ok, _} <- Repo.insert(simple_trigger, prefix: keyspace),
-         :ok <- KvStore.insert(kv_insert, prefix: keyspace) do
+    opts = [prefix: keyspace, consistency: Consistency.domain_model(:write)]
+
+    with {:ok, _} <- Repo.insert(simple_trigger, opts),
+         :ok <- KvStore.insert(kv_insert, opts) do
       :ok
     end
   end
@@ -884,8 +919,10 @@ defmodule Astarte.RealmManagement.Queries do
         value: trigger_policy
       }
 
-    with :ok <- KvStore.insert(triggers_with_policy, prefix: keyspace),
-         :ok <- KvStore.insert(trigger_to_policy, prefix: keyspace) do
+    opts = [prefix: keyspace, consistency: Consistency.domain_model(:write)]
+
+    with :ok <- KvStore.insert(triggers_with_policy, opts),
+         :ok <- KvStore.insert(trigger_to_policy, opts) do
       :ok
     end
   end
@@ -893,11 +930,14 @@ defmodule Astarte.RealmManagement.Queries do
   def retrieve_trigger_uuid(realm_name, trigger_name) do
     keyspace = Realm.keyspace_name(realm_name)
 
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read),
+      error: :trigger_not_found
+    ]
+
     with {:ok, uuid} <-
-           KvStore.fetch_value("triggers-by-name", trigger_name, :binary,
-             prefix: keyspace,
-             error: :trigger_not_found
-           ) do
+           KvStore.fetch_value("triggers-by-name", trigger_name, :binary, opts) do
       {:ok, :uuid.uuid_to_string(uuid)}
     end
   end
@@ -925,8 +965,10 @@ defmodule Astarte.RealmManagement.Queries do
         prefix: ^keyspace,
         where: [group: "trigger_to_policy", key: ^trigger_uuid]
 
-    _ = Repo.delete_all(triggers_with_policy)
-    _ = Repo.delete_all(trigger_to_policy)
+    consistency = Consistency.domain_model(:write)
+
+    _ = Repo.delete_all(triggers_with_policy, consistency: consistency)
+    _ = Repo.delete_all(trigger_to_policy, consistency: consistency)
 
     :ok
   end
@@ -946,8 +988,10 @@ defmodule Astarte.RealmManagement.Queries do
         |> where(group: "triggers", key: ^trigger_uuid)
         |> put_query_prefix(keyspace)
 
-      _ = Repo.delete_all(trigger_by_name_query)
-      _ = Repo.delete_all(triggers_query)
+      consistency = Consistency.domain_model(:write)
+
+      _ = Repo.delete_all(trigger_by_name_query, consistency: consistency)
+      _ = Repo.delete_all(triggers_query, consistency: consistency)
 
       :ok
     end
@@ -961,7 +1005,9 @@ defmodule Astarte.RealmManagement.Queries do
         select: store.key,
         where: [group: "triggers-by-name"]
 
-    Repo.fetch_all(query, prefix: keyspace)
+    opts = [prefix: keyspace, consistency: Consistency.domain_model(:read)]
+
+    Repo.fetch_all(query, opts)
   end
 
   def retrieve_trigger(realm_name, trigger_name) do
@@ -975,7 +1021,13 @@ defmodule Astarte.RealmManagement.Queries do
           select: store.value,
           where: [group: "triggers", key: ^trigger_uuid]
 
-      with {:ok, result} <- Repo.fetch_one(query, prefix: keyspace, error: :trigger_not_found) do
+      opts = [
+        prefix: keyspace,
+        consistency: Consistency.domain_model(:read),
+        error: :trigger_not_found
+      ]
+
+      with {:ok, result} <- Repo.fetch_one(query, opts) do
         {:ok, Trigger.decode(result)}
       end
     end
@@ -998,8 +1050,13 @@ defmodule Astarte.RealmManagement.Queries do
             simple_trigger_id: ^simple_trigger_uuid
           ]
 
-      with {:ok, trigger_data} <-
-             Repo.fetch_one(query, prefix: keyspace, error: :simple_trigger_not_found) do
+      opts = [
+        prefix: keyspace,
+        consistency: Consistency.domain_model(:read),
+        error: :simple_trigger_not_found
+      ]
+
+      with {:ok, trigger_data} <- Repo.fetch_one(query, opts) do
         {
           :ok,
           %TaggedSimpleTrigger{
@@ -1037,8 +1094,10 @@ defmodule Astarte.RealmManagement.Queries do
           prefix: ^keyspace,
           where: [group: "simple-triggers-by-uuid", key: ^simple_trigger_uuid]
 
-      _ = Repo.delete_all(delete_astarte_ref_query)
-      _ = Repo.delete_all(delete_simple_trigger_query)
+      consistency = Consistency.domain_model(:write)
+
+      _ = Repo.delete_all(delete_astarte_ref_query, consistency: consistency)
+      _ = Repo.delete_all(delete_simple_trigger_query, consistency: consistency)
 
       :ok
     end
@@ -1054,7 +1113,13 @@ defmodule Astarte.RealmManagement.Queries do
         select: store.value,
         where: [groups: "simple-triggers-by-uuid", key: ^simple_trigger_uuid]
 
-    with {:ok, result} <- Repo.fetch_one(query, prefix: keyspace, error: :trigger_not_found) do
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read),
+      error: :trigger_not_found
+    ]
+
+    with {:ok, result} <- Repo.fetch_one(query, opts) do
       AstarteReference.decode(result)
     end
   end
@@ -1068,7 +1133,12 @@ defmodule Astarte.RealmManagement.Queries do
       value: policy_proto
     }
 
-    KvStore.insert(params, prefix: keyspace)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:write)
+    ]
+
+    KvStore.insert(params, opts)
   end
 
   def get_trigger_policies_list(realm_name) do
@@ -1079,7 +1149,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: store.key,
         where: [group: "trigger_policy"]
 
-    Repo.fetch_all(query, prefix: keyspace, consistency: :quorum)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read)
+    ]
+
+    Repo.fetch_all(query, opts)
   end
 
   def fetch_trigger_policy(realm_name, policy_name) do
@@ -1090,7 +1165,13 @@ defmodule Astarte.RealmManagement.Queries do
         select: store.value,
         where: [group: "trigger_policy", policy_name: ^policy_name]
 
-    Repo.fetch_one(query, prefix: keyspace, error: :policy_not_found)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read),
+      error: :policy_not_found
+    ]
+
+    Repo.fetch_one(query, opts)
   end
 
   def check_policy_has_triggers(realm_name, policy_name) do
@@ -1103,7 +1184,12 @@ defmodule Astarte.RealmManagement.Queries do
         where: [group: ^group_name],
         limit: 1
 
-    Repo.some?(query, prefix: keyspace, consistency: :quorum)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read)
+    ]
+
+    Repo.some?(query, opts)
   end
 
   def delete_trigger_policy(realm_name, policy_name) do
@@ -1132,9 +1218,11 @@ defmodule Astarte.RealmManagement.Queries do
         prefix: ^keyspace,
         where: [group: "trigger_to_policy"]
 
-    _ = Repo.delete_all(delete_policy_query, consistency: :each_quorum)
-    _ = Repo.delete_all(delete_triggers_with_policy_group_query, consistency: :each_quorum)
-    _ = Repo.delete_all(delete_trigger_to_policy_query, consistency: :each_quorum)
+    consistency = Consistency.domain_model(:write)
+
+    _ = Repo.delete_all(delete_policy_query, consistency: consistency)
+    _ = Repo.delete_all(delete_triggers_with_policy_group_query, consistency: consistency)
+    _ = Repo.delete_all(delete_trigger_to_policy_query, consistency: consistency)
 
     :ok
   end
@@ -1146,7 +1234,12 @@ defmodule Astarte.RealmManagement.Queries do
       from store in KvStore,
         where: [group: "trigger_policy", key: ^policy_name]
 
-    Repo.some?(query, prefix: keyspace, consistency: :quorum)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read)
+    ]
+
+    Repo.some?(query, opts)
   end
 
   def check_device_exists(realm_name, device_id) do
@@ -1157,7 +1250,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: device.device_id,
         where: [device_id: ^device_id]
 
-    Repo.some?(query, prefix: keyspace, consistency: :quorum)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    Repo.some?(query, opts)
   end
 
   def table_exist?(realm_name, table_name) do
@@ -1168,7 +1266,7 @@ defmodule Astarte.RealmManagement.Queries do
         select: schema.table_name,
         where: [table_name: ^table_name, keyspace_name: ^keyspace]
 
-    Repo.some?(query)
+    Repo.some?(query, consistency: Consistency.domain_model(:read))
   end
 
   def insert_device_into_deletion_in_progress(realm_name, device_id) do
@@ -1181,7 +1279,12 @@ defmodule Astarte.RealmManagement.Queries do
       dup_end_ack: false
     }
 
-    Repo.insert!(deletion, consistency: :quorum, prefix: keyspace)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    Repo.insert!(deletion, opts)
     :ok
   end
 
@@ -1194,7 +1297,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: device.introspection,
         where: [device_id: ^device_id]
 
-    Repo.one(query, prefix: keyspace, consistency: :quorum)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    Repo.one(query, opts)
   end
 
   def retrieve_interface_descriptor!(
@@ -1204,11 +1312,13 @@ defmodule Astarte.RealmManagement.Queries do
       ) do
     keyspace = Realm.keyspace_name(realm_name)
 
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read)
+    ]
+
     interface =
-      Repo.get_by!(Interface, [name: interface_name, major_version: interface_major],
-        prefix: keyspace,
-        consistency: :quorum
-      )
+      Repo.get_by!(Interface, [name: interface_name, major_version: interface_major], opts)
 
     %InterfaceDescriptor{
       name: interface.name,
@@ -1237,7 +1347,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: [:device_id, :interface_id, :endpoint_id, :path],
         where: [device_id: ^device_id]
 
-    Repo.all(query, prefix: keyspace)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    Repo.all(query, opts)
   end
 
   def delete_individual_datastream_values!(
@@ -1259,7 +1374,12 @@ defmodule Astarte.RealmManagement.Queries do
           path: ^path
         ]
 
-    _ = Repo.delete_all(query, prefix: keyspace_name, consistency: :local_quorum)
+    opts = [
+      prefix: keyspace_name,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    _ = Repo.delete_all(query, opts)
 
     :ok
   end
@@ -1274,7 +1394,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: [:device_id, :interface_id],
         where: [device_id: ^device_id]
 
-    Repo.all(query, prefix: keyspace)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    Repo.all(query, opts)
   end
 
   def delete_individual_properties_values!(realm_name, device_id, interface_id) do
@@ -1285,7 +1410,12 @@ defmodule Astarte.RealmManagement.Queries do
       from IndividualProperty,
         where: [device_id: ^device_id, interface_id: ^interface_id]
 
-    _ = Repo.delete_all(query, prefix: keyspace_name, consistency: :local_quorum)
+    opts = [
+      prefix: keyspace_name,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    _ = Repo.delete_all(query, opts)
 
     :ok
   end
@@ -1300,7 +1430,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: [:device_id, :path],
         where: [device_id: ^device_id]
 
-    Repo.all(query, prefix: keyspace)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    Repo.all(query, opts)
   end
 
   def delete_object_datastream_values!(realm_name, device_id, path, table_name) do
@@ -1311,7 +1446,12 @@ defmodule Astarte.RealmManagement.Queries do
       from table_name,
         where: [device_id: ^device_id, path: ^path]
 
-    _ = Repo.delete_all(query, prefix: keyspace_name, consistency: :local_quorum)
+    opts = [
+      prefix: keyspace_name,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    _ = Repo.delete_all(query, opts)
 
     :ok
   end
@@ -1325,7 +1465,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: [:object_name],
         where: [object_uuid: ^device_id]
 
-    Repo.all(query, prefix: keyspace)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    Repo.all(query, opts)
   end
 
   def delete_alias_values!(realm_name, device_alias) do
@@ -1336,7 +1481,12 @@ defmodule Astarte.RealmManagement.Queries do
       from Name,
         where: [object_name: ^device_alias]
 
-    _ = Repo.delete_all(query, prefix: keyspace_name, consistency: :local_quorum)
+    opts = [
+      prefix: keyspace_name,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    _ = Repo.delete_all(query, opts)
 
     :ok
   end
@@ -1350,7 +1500,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: [:group_name, :insertion_uuid, :device_id],
         where: [device_id: ^device_id]
 
-    Repo.all(query, prefix: keyspace)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    Repo.all(query, opts)
   end
 
   def delete_group_values!(realm_name, device_id, group_name, insertion_uuid) do
@@ -1360,7 +1515,12 @@ defmodule Astarte.RealmManagement.Queries do
       from GroupedDevice,
         where: [group_name: ^group_name, insertion_uuid: ^insertion_uuid, device_id: ^device_id]
 
-    _ = Repo.delete_all(query, prefix: keyspace_name, consistency: :local_quorum)
+    opts = [
+      prefix: keyspace_name,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    _ = Repo.delete_all(query, opts)
 
     :ok
   end
@@ -1374,7 +1534,12 @@ defmodule Astarte.RealmManagement.Queries do
         select: [:group, :key],
         where: [key: ^device_id]
 
-    Repo.all(query, prefix: keyspace)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    Repo.all(query, opts)
   end
 
   def delete_kv_store_entry!(realm_name, group, key) do
@@ -1385,7 +1550,12 @@ defmodule Astarte.RealmManagement.Queries do
       from KvStore,
         where: [group: ^group, key: ^key]
 
-    _ = Repo.delete_all(query, prefix: keyspace_name, consistency: :local_quorum)
+    opts = [
+      prefix: keyspace_name,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    _ = Repo.delete_all(query, opts)
 
     :ok
   end
@@ -1398,7 +1568,13 @@ defmodule Astarte.RealmManagement.Queries do
       from RealmsDevice,
         where: [device_id: ^device_id]
 
-    _ = Repo.delete_all(query, prefix: keyspace_name, consistency: :local_quorum)
+    # TODO check
+    opts = [
+      prefix: keyspace_name,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    _ = Repo.delete_all(query, opts)
 
     :ok
   end
@@ -1411,7 +1587,12 @@ defmodule Astarte.RealmManagement.Queries do
       from DeletionInProgress,
         where: [device_id: ^device_id]
 
-    _ = Repo.delete_all(query, prefix: keyspace_name, consistency: :local_quorum)
+    opts = [
+      prefix: keyspace_name,
+      consistency: Consistency.device_info(:write)
+    ]
+
+    _ = Repo.delete_all(query, opts)
 
     :ok
   end
@@ -1419,14 +1600,24 @@ defmodule Astarte.RealmManagement.Queries do
   def retrieve_realms!() do
     keyspace = Realm.astarte_keyspace_name()
 
-    Repo.all(Realm, prefix: keyspace, consistency: :local_quorum)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read)
+    ]
+
+    Repo.all(Realm, opts)
   end
 
   def retrieve_devices_to_delete!(realm_name) do
     keyspace = Realm.keyspace_name(realm_name)
 
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
     from(DeletionInProgress)
-    |> Repo.all(prefix: keyspace, consistency: :local_quorum)
+    |> Repo.all(opts)
     |> Enum.filter(&DeletionInProgress.all_ack?/1)
   end
 
@@ -1438,15 +1629,29 @@ defmodule Astarte.RealmManagement.Queries do
         select: realm.device_registration_limit,
         where: [realm_name: ^realm_name]
 
-    Repo.fetch_one(query, prefix: keyspace, consistency: :one, error: :realm_not_found)
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read),
+      error: :realm_not_found
+    ]
+
+    Repo.fetch_one(query, opts)
   end
 
   def get_datastream_maximum_storage_retention(realm_name) do
     keyspace = Realm.keyspace_name(realm_name)
 
-    case KvStore.fetch_value("realm_config", "datastream_maximum_storage_retention", :integer,
-           prefix: keyspace,
-           error: :fetch_error
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read),
+      error: :fetch_error
+    ]
+
+    case KvStore.fetch_value(
+           "realm_config",
+           "datastream_maximum_storage_retention",
+           :integer,
+           opts
          ) do
       {:ok, value} -> {:ok, value}
       # not found means default maximum storage retention of 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
See https://github.com/astarte-platform/astarte_data_access/pull/98. Use the standard consistency classes as defined there:
- "Domain Model": operations related to all Astarte entities, such as triggers, interfaces, policies etc
- "Device Info": operations related to Device metadata (e.g. connection status), time series metadata (as they refer to a specific device), property data (as they specify the domain specific status of a device)
- "Time series": operations related to datastreams
    
Note that, in the specific context of device deletion, we use the `device_info` class. When a device is deleted, all messages that it sent or received on interfaces have to be deleted, other than all its information (e.g. aliases, groups, ...). In order to be consistent in the whole deletion operation, we keep the consistency class of device information also for deleting messages

#### Special notes for your reviewer:
Moved RM away from #1153 for ease of review


##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

