### PR TITLE
fix(dup): device deletion queries

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -832,7 +832,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
         update: [set: [dup_end_ack: true]]
       )
 
-    with {:ok, _} <- Repo.update_all(query, []) do
+    with {:ok, _} <- Repo.safe_update_all(query, []) do
       :ok
     end
   end
@@ -847,7 +847,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
         update: [set: [dup_start_ack: true]]
       )
 
-    with {:ok, _} <- Repo.update_all(query, []) do
+    with {:ok, _} <- Repo.safe_update_all(query, []) do
       :ok
     end
   end


### PR DESCRIPTION
previously, Repo.update_all was used, which returns a tuple in the form `{integer(), any()}`, which was not matched by Queries' functions and made impl crash at line 188 for a failed match to `:ok`

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
