### PR TITLE
chore(AE): use standard CL for queries

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -1100,6 +1100,7 @@ defmodule Astarte.AppEngine.API.Device do
         realm_name,
         device_id,
         interface_row,
+        endpoint_rows,
         path,
         columns,
         opts

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/queries.ex
@@ -19,6 +19,7 @@ defmodule Astarte.AppEngine.API.Queries do
   alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.AppEngine.API.Repo
+  alias Astarte.DataAccess.Consistency
 
   require Logger
   import Ecto.Query
@@ -33,7 +34,7 @@ defmodule Astarte.AppEngine.API.Queries do
         select: fragment("blobAsVarchar(?)", r.value),
         where: r.group == "auth" and r.key == "jwt_public_key_pem"
 
-    opts = [uuid_format: :binary, consistency: :quorum]
+    opts = [uuid_format: :binary, consistency: Consistency.domain_model(:read)]
 
     case safe_query(schema_query, opts) do
       {:ok, %{rows: [[pem]]}} ->

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/queries.ex
@@ -19,8 +19,10 @@
 defmodule Astarte.AppEngine.API.Rooms.Queries do
   alias Astarte.DataAccess.Devices.Device, as: DatabaseDevice
   alias Astarte.Core.Device
-  alias Astarte.DataAccess.Realms.Realm
   alias Astarte.AppEngine.API.Repo
+  alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.DataAccess.Devices.Device, as: DatabaseDevice
+  alias Astarte.DataAccess.Consistency
 
   require Logger
 
@@ -28,11 +30,13 @@ defmodule Astarte.AppEngine.API.Rooms.Queries do
     with {:ok, decoded_device_id} <- Device.decode_device_id(encoded_device_id) do
       keyspace = Realm.keyspace_name(realm_name)
 
-      result =
-        Repo.fetch(DatabaseDevice, decoded_device_id,
-          error: :device_does_not_exist,
-          prefix: keyspace
-        )
+      opts = [
+        prefix: keyspace,
+        consistency: Consistency.device_info(:read),
+        error: :device_does_not_exist
+      ]
+
+      result = Repo.fetch(DatabaseDevice, decoded_device_id, opts)
 
       case result do
         {:ok, _device} ->

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/stats/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/stats/queries.ex
@@ -21,6 +21,7 @@ defmodule Astarte.AppEngine.API.Stats.Queries do
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.AppEngine.API.Repo
   alias Astarte.DataAccess.Devices.Device
+  alias Astarte.DataAccess.Consistency
   alias Astarte.AppEngine.API.Stats.DevicesStats
 
   require Logger
@@ -39,7 +40,9 @@ defmodule Astarte.AppEngine.API.Stats.Queries do
         prefix: ^keyspace,
         where: [connected: true]
 
-    online_count = Repo.aggregate(online_query, :count)
+    consistency = Consistency.device_info(:read)
+
+    online_count = Repo.aggregate(online_query, :count, consistency: consistency)
 
     %DevicesStats{
       total_devices: device_count,


### PR DESCRIPTION
Moved consistency management to `data_access` `Consistency` module, in compliance with other astarte modules, see astarte-platform/astarte_data_access#98 #1154 #1153 for more reference

Supersede #1157 
