### PR TITLE
fix(RM): Resolve UUID format issue and correct query filtering

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -1104,12 +1104,12 @@ defmodule Astarte.RealmManagement.Queries do
   defp retrieve_simple_trigger_astarte_ref(realm_name, simple_trigger_uuid) do
     keyspace = Realm.keyspace_name(realm_name)
 
-    simple_trigger_uuid = :uuid.uuid_to_string(simple_trigger_uuid)
+    simple_trigger_uuid = :uuid.uuid_to_string(simple_trigger_uuid, :binary_standard)
 
     query =
       from store in KvStore,
         select: store.value,
-        where: [groups: "simple-triggers-by-uuid", key: ^simple_trigger_uuid]
+        where: [group: "simple-triggers-by-uuid", key: ^simple_trigger_uuid]
 
     opts = [
       prefix: keyspace,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:


Bug:
Internal server error occurred when trying to open a trigger to view, due to two issues:
1. The UUID was not being properly converted to a string, causing a type mismatch in the query.
2. The query used the incorrect field name `groups` instead of `group`, which caused it to fail when fetching data from the database.

Fix:
- Ensures proper conversion of UUIDs to strings by using `:uuid.uuid_to_string` with the `:binary_standard` format.
- Fixed the typo in the query by changing `groups` to `group`.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
