### PR TITLE
fix: kubernetes clustering

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/config.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/config.ex
@@ -140,16 +140,16 @@ defmodule Astarte.AppEngine.API.Config do
           :astarte_data_updater_plant,
           :clustering_strategy,
           os_env: "CLUSTERING_STRATEGY",
-          type: Astarte.AppEngine.API.ClusteringStrategy,
+          type: Astarte.AppEngine.API.Config.ClusteringStrategy,
           default: "none"
 
-  @envdoc "The Kubernetes selector to use when `kubernetes` Erlang clustering strategy is used. Defaults to `app=astarte-data-updater-plant`."
-  app_env :clustering_kubernetes_selector,
+  @envdoc "The Endpoint label to use to query Kubernetes to find data updater plant instances. Defaults to `app=astarte-data-updater-plant`."
+  app_env :dup_clustering_kubernetes_selector,
           :astarte_data_updater_plant,
-          :clustering_kubernetes_selector,
-          os_env: "CLUSTERING_KUBERNETES_SELECTOR",
+          :dup_clustering_kubernetes_selector,
+          os_env: "DATA_UPDATER_PLANT_CLUSTERING_KUBERNETES_SELECTOR",
           type: :binary,
-          default: "clustering=astarte"
+          default: "app=astarte-data-updater-plant"
 
   @envdoc "The Kubernetes namespace to use when `kubernetes` Erlang clustering strategy is used. Defaults to `astarte`."
   app_env :clustering_kubernetes_namespace,
@@ -272,8 +272,8 @@ defmodule Astarte.AppEngine.API.Config do
             strategy: Elixir.Cluster.Strategy.Kubernetes,
             config: [
               mode: :ip,
-              kubernetes_node_basename: "astarte",
-              kubernetes_selector: clustering_kubernetes_selector!(),
+              kubernetes_node_basename: "astarte_data_updater_plant",
+              kubernetes_selector: dup_clustering_kubernetes_selector!(),
               kubernetes_namespace: clustering_kubernetes_namespace!(),
               polling_interval: 10_000
             ]

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/config/clustering_strategy.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/config/clustering_strategy.ex
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule AstarteAppengineApi.ClusteringStrategy do
+defmodule Astarte.AppEngine.API.Config.ClusteringStrategy do
   @moduledoc """
   Clustering strategy for node discovery with libcluster.
   """

--- a/apps/astarte_appengine_api/rel/env.sh.eex
+++ b/apps/astarte_appengine_api/rel/env.sh.eex
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+export RELEASE_DISTRIBUTION=name
+
+if [ -z "$MY_POD_IP" ]
+then
+    HOSTNAME=`hostname -i`
+    export RELEASE_NODE="<%= @release.name %>@$HOSTNAME"
+else
+    export RELEASE_NODE="<%= @release.name %>@$MY_POD_IP"
+fi

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -254,16 +254,16 @@ defmodule Astarte.DataUpdaterPlant.Config do
           :astarte_data_updater_plant,
           :clustering_strategy,
           os_env: "CLUSTERING_STRATEGY",
-          type: Astarte.DataUpdaterPlant.ClusteringStrategy,
+          type: Astarte.DataUpdaterPlant.Config.ClusteringStrategy,
           default: "none"
 
-  @envdoc "The Kubernetes selector to use when `kubernetes` Erlang clustering strategy is used. Defaults to `clustering=astarte`."
-  app_env :clustering_kubernetes_selector,
+  @envdoc "The endpoint label to query to get other data updater plant instances. Defaults to `app=astarte-data-updater-plant`."
+  app_env :dup_clustering_kubernetes_selector,
           :astarte_data_updater_plant,
-          :clustering_kubernetes_selector,
-          os_env: "CLUSTERING_KUBERNETES_SELECTOR",
+          :dup_clustering_kubernetes_selector,
+          os_env: "DATA_UPDATER_PLANT_CLUSTERING_KUBERNETES_SELECTOR",
           type: :binary,
-          default: "clustering=astarte"
+          default: "app=astarte-data-updater-plant"
 
   @envdoc "The Kubernetes namespace to use when `kubernetes` Erlang clustering strategy is used. Defaults to `astarte`."
   app_env :clustering_kubernetes_namespace,
@@ -509,8 +509,8 @@ defmodule Astarte.DataUpdaterPlant.Config do
             strategy: Elixir.Cluster.Strategy.Kubernetes,
             config: [
               mode: :ip,
-              kubernetes_node_basename: "astarte",
-              kubernetes_selector: clustering_kubernetes_selector!(),
+              kubernetes_node_basename: "astarte_data_updater_plant",
+              kubernetes_selector: dup_clustering_kubernetes_selector!(),
               kubernetes_namespace: clustering_kubernetes_namespace!(),
               polling_interval: 10_000
             ]

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config/clustering_strategy.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config/clustering_strategy.ex
@@ -18,7 +18,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-defmodule AstarteDataUpdaterPlant.ClusteringStrategy do
+defmodule Astarte.DataUpdaterPlant.Config.ClusteringStrategy do
   @moduledoc """
   The clustering strategy that the node should use to discover other nodes.
   """

--- a/apps/astarte_data_updater_plant/rel/env.sh.eex
+++ b/apps/astarte_data_updater_plant/rel/env.sh.eex
@@ -1,10 +1,11 @@
 #!/bin/sh
 
+export RELEASE_DISTRIBUTION=name
+
 if [ -z "$MY_POD_IP" ]
 then
-    export RELEASE_DISTRIBUTION=sname
-    export RELEASE_NODE=<%= @release.name %>
+    HOSTNAME=`hostname -i`
+    export RELEASE_NODE="<%= @release.name %>@$HOSTNAME"
 else
-    export RELEASE_DISTRIBUTION=name
-    export RELEASE_NODE=astarte@${MY_POD_IP}
+    export RELEASE_NODE="<%= @release.name %>@$MY_POD_IP"
 fi


### PR DESCRIPTION
Kubernetes clustering strategies were misconfigured and required to an unnecessary update from the operator. This PR introduces the necessary fixes to solve 2 main issues:
- DUP clustering strategy should only be responsible for finding other DUP instances. Up to not a general clustering approach was used to allow all nodes to find each other. What we actually want to do is allow DUP instances to find each other and leave to appegine to find DUP instances to talk to (that logic is in fact moved into appengine). DUP clustering strategy now only tries to find other DUP nodes and by default leverages already available endpoint labels to query the kubernetes API.
- As anticipated, AppEngine instances should only be responsible for finding DUP instances. With this changes they not try anymore to find other appengine instances (as it is not necessary). They also leverage already existing endpoint labels, this requires less spin/changes with the operator.
