### PR TITLE
Fix Dockerfile Warnings for Casing and ENV Format

### DIFF
--- a/apps/astarte_appengine_api/Dockerfile
+++ b/apps/astarte_appengine_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates

--- a/apps/astarte_data_updater_plant/Dockerfile
+++ b/apps/astarte_data_updater_plant/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates

--- a/apps/astarte_housekeeping/Dockerfile
+++ b/apps/astarte_housekeeping/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates

--- a/apps/astarte_housekeeping_api/Dockerfile
+++ b/apps/astarte_housekeeping_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates

--- a/apps/astarte_pairing/Dockerfile
+++ b/apps/astarte_pairing/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates

--- a/apps/astarte_pairing_api/Dockerfile
+++ b/apps/astarte_pairing_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates

--- a/apps/astarte_realm_management/Dockerfile
+++ b/apps/astarte_realm_management/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates

--- a/apps/astarte_realm_management_api/Dockerfile
+++ b/apps/astarte_realm_management_api/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates

--- a/apps/astarte_trigger_engine/Dockerfile
+++ b/apps/astarte_trigger_engine/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -37,7 +37,7 @@ RUN chown -R nobody /app
 RUN apt-get -qq update
 
 # Set the locale
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get -qq install openssl ca-certificates


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Fix two warnings found in the Dockerfiles of multiple apps:

1. **FromAsCasing**: The `as` keyword casing was inconsistent. This has been fixed by updating the `as` keyword to match the correct casing convention.

2. **LegacyKeyValueFormat**: The format used for setting environment variables with `ENV` was outdated. The legacy `ENV key value` format has been updated to the proper `ENV key=value` format.

These changes help eliminate the warnings and ensure the Dockerfiles are compliant with best practices.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

