### PR TITLE
test(te): avoid 6 seconds sleep

### DIFF
--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_consumer_tracker.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_consumer_tracker.ex
@@ -47,6 +47,13 @@ defmodule Astarte.TriggerEngine.AMQPConsumer.AMQPConsumerTracker do
 
   @impl true
   def handle_info(:update_consumers, state) do
+    update_consumers()
+    schedule_update()
+
+    {:noreply, state}
+  end
+
+  def update_consumers do
     registered_consumers =
       Registry.select(Registry.AMQPConsumerRegistry, [{{:"$1", :_, :_}, [], [:"$1"]}])
 
@@ -67,9 +74,7 @@ defmodule Astarte.TriggerEngine.AMQPConsumer.AMQPConsumerTracker do
 
     Enum.each(outdated_consumers, &remove_outdated_consumer/1)
 
-    schedule_update()
-
-    {:noreply, state}
+    :ok
   end
 
   defp schedule_update() do


### PR DESCRIPTION
6 second sleeps were introduced as a way to mitigate a race condition with the consumer update.

by making the call to update_consumer synchronous, we are sure that all new/removed consumers are _at least scheduled_ for start/termination before sending additional messages to the AMQPConsumerRegistry

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
