### PR TITLE
Add libcluster topology for VerneMQ discovery in DUP

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -265,6 +265,14 @@ defmodule Astarte.DataUpdaterPlant.Config do
           type: :binary,
           default: "app=astarte-data-updater-plant"
 
+  @envdoc "The Endpoint label to use to query Kubernetes to find vernemq instances. Defaults to `app=astarte-vernemq`."
+  app_env :vernemq_clustering_kubernetes_selector,
+          :astarte_data_updater_plant,
+          :vernemq_clustering_kubernetes_selector,
+          os_env: "VERNEMQ_CLUSTERING_KUBERNETES_SELECTOR",
+          type: :binary,
+          default: "app=astarte-vernemq"
+
   @envdoc "The Kubernetes namespace to use when `kubernetes` Erlang clustering strategy is used. Defaults to `astarte`."
   app_env :clustering_kubernetes_namespace,
           :astarte_data_updater_plant,
@@ -514,6 +522,18 @@ defmodule Astarte.DataUpdaterPlant.Config do
               kubernetes_namespace: clustering_kubernetes_namespace!(),
               polling_interval: 10_000
             ]
+          ],
+          vernemq_k8s: [
+            strategy: Elixir.Cluster.Strategy.Kubernetes,
+            config: [
+              mode: :hostname,
+              kubernetes_service_name: "astarte-vernemq",
+              kubernetes_node_basename: "VerneMQ",
+              kubernetes_ip_lookup_mode: :pods,
+              kubernetes_selector: vernemq_clustering_kubernetes_selector!(),
+              kubernetes_namespace: clustering_kubernetes_namespace!(),
+              polling_interval: 10_000
+            ]
           ]
         ]
 
@@ -525,6 +545,14 @@ defmodule Astarte.DataUpdaterPlant.Config do
               polling_interval: 5_000,
               query: "astarte-data-updater-plant",
               node_basename: "astarte_data_updater_plant"
+            ]
+          ],
+          vernemq: [
+            strategy: Elixir.Cluster.Strategy.DNSPoll,
+            config: [
+              polling_interval: 5_000,
+              query: "vernemq",
+              node_basename: "VerneMQ"
             ]
           ]
         ]


### PR DESCRIPTION
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

This PR introduces a libcluster topology to enable the DUP service to automatically discover and connect to all VerneMQ replicas across different environments.

- Docker-compose: a topology tailored for this environment is added, relying on DNS facilities provided by Docker to discover VerneMQ nodes at known domain names, i.e. the name of the VerneMQ service as defined in docker-compose.yaml.
- Kubernetes: for production scenarios, VerneMQ is deployed by the Astarte Operator as a StatefulSet. As such, the libcluster strategy attempts first attempts to discover node IPs by querying for app labels, as in the other Kubernetes strategy already defined. Then it assumes specific names for the Erlang nodes using the discovered IPs and the fact that nodes in the StatefulSet have deterministic names that include a progressive counter such as `VerneMQ@<service_name>-0.<service_name>.<namespace>.svc.<cluster_domain>`

This change is a prerequisite to allow DUP to communicate with VerneMQ for RPC operations, using Erlang's native message passing.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

