### PR TITLE
refactor(AE): VerneMQ RPC

### DIFF
--- a/apps/astarte_appengine_api/config/test.exs
+++ b/apps/astarte_appengine_api/config/test.exs
@@ -32,6 +32,10 @@ config :astarte_appengine_api,
        :data_updater_plant_rpc_client,
        Astarte.AppEngine.API.RPC.DataUpdaterPlant.ClientMock
 
+config :astarte_appengine_api,
+       :vernemq_plugin_rpc_client,
+       Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+
 config :stream_data,
   max_runs: 50
 

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/application.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/application.ex
@@ -51,10 +51,9 @@ defmodule Astarte.AppEngine.API.Application do
       {Cluster.Supervisor,
        [Config.cluster_topologies!(), [name: Astarte.AppEngine.API.ClusterSupervisor]]},
       {Horde.Registry, [keys: :unique, name: Registry.DataUpdaterRPC, members: :auto]},
+      {Horde.Registry, [keys: :unique, name: Registry.VMQPluginRPC, members: :auto]},
       Astarte.AppEngine.APIWeb.Telemetry,
       {Phoenix.PubSub, name: Astarte.AppEngine.API.PubSub},
-      # TODO: still needed for VerneMQ RPC, remove once moved to erlang clustering
-      Astarte.RPC.AMQP.Client,
       Astarte.AppEngine.API.Rooms.MasterSupervisor,
       Astarte.AppEngine.API.Rooms.AMQPClient,
       Astarte.AppEngine.APIWeb.Endpoint,

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rpc/vmq_plugin.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rpc/vmq_plugin.ex
@@ -22,38 +22,22 @@ defmodule Astarte.AppEngine.API.RPC.VMQPlugin do
   """
   require Logger
 
-  alias Astarte.RPC.Protocol.VMQ.Plugin, as: Protocol
-
-  alias Astarte.RPC.Protocol.VMQ.Plugin.{
-    Call,
-    GenericErrorReply,
-    GenericOkReply,
-    Publish,
-    PublishReply,
-    Reply
-  }
-
-  alias Astarte.AppEngine.API.Config
-
-  require Logger
-
-  @rpc_client Config.rpc_client!()
-  @destination Protocol.amqp_queue()
+  @rpc_behaviour Application.compile_env(
+                   :astarte_appengine_api,
+                   :vernemq_plugin_rpc_client,
+                   Astarte.AppEngine.API.RPC.VMQPlugin.Client
+                 )
 
   def publish(topic, payload, qos)
       when is_binary(topic) and is_binary(payload) and is_integer(qos) and qos >= 0 and qos <= 2 do
     with {:ok, tokens} <- split_topic(topic) do
-      _ = Logger.debug("Going to publish value on MQTT.")
-
-      %Publish{
+      data = %{
         topic_tokens: tokens,
         payload: payload,
         qos: qos
       }
-      |> encode_call(:publish)
-      |> @rpc_client.rpc_call(@destination)
-      |> decode_reply()
-      |> extract_reply()
+
+      @rpc_behaviour.publish(data)
     end
   end
 
@@ -62,47 +46,5 @@ defmodule Astarte.AppEngine.API.RPC.VMQPlugin do
       [] -> {:error, :empty_topic}
       tokens -> {:ok, tokens}
     end
-  end
-
-  defp encode_call(call, callname) do
-    %Call{call: {callname, call}}
-    |> Call.encode()
-  end
-
-  defp decode_reply({:ok, encoded_reply}) when is_binary(encoded_reply) do
-    %Reply{reply: reply} = Reply.decode(encoded_reply)
-
-    _ = Logger.debug("Got reply from VWQ: #{inspect(reply)}.")
-
-    reply
-  end
-
-  defp decode_reply({:error, reason}) do
-    _ = Logger.warning("RPC error: #{inspect(reason)}.", tag: "rpc_remote_exception")
-    {:error, reason}
-  end
-
-  defp extract_reply({:publish_reply, %PublishReply{} = reply}) do
-    _ = Logger.debug("Got publish reply from VMQ.")
-
-    {:ok, %{local_matches: reply.local_matches, remote_matches: reply.remote_matches}}
-  end
-
-  defp extract_reply({:generic_ok_reply, %GenericOkReply{}}) do
-    _ = Logger.debug("Got ok reply from VMQ.")
-
-    :ok
-  end
-
-  defp extract_reply({:generic_error_reply, %GenericErrorReply{error_name: "session_not_found"}}) do
-    {:error, :session_not_found}
-  end
-
-  defp extract_reply({:generic_error_reply, error_struct = %GenericErrorReply{}}) do
-    error_map = Map.from_struct(error_struct)
-
-    _ = Logger.error("Error while publishing value on MQTT.", tag: "vmq_publish_error")
-
-    {:error, error_map}
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rpc/vmq_plugin/behaviour.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rpc/vmq_plugin/behaviour.ex
@@ -18,12 +18,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-Mox.defmock(MockRPCClient, for: Astarte.RPC.Client)
+defmodule Astarte.AppEngine.API.RPC.VMQPlugin.Behaviour do
+  @moduledoc false
 
-Mox.defmock(Astarte.AppEngine.API.RPC.DataUpdaterPlant.ClientMock,
-  for: Astarte.AppEngine.API.RPC.DataUpdaterPlant.Behaviour
-)
-
-Mox.defmock(Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock,
-  for: Astarte.AppEngine.API.RPC.VMQPlugin.Behaviour
-)
+  @callback publish(%{topic_tokens: list(binary()), payload: binary(), qos: 0 | 1 | 2}) ::
+              {:ok, %{local_matches: integer(), remote_matches: integer()}} | {:error, term()}
+end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rpc/vmq_plugin/client.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rpc/vmq_plugin/client.ex
@@ -18,12 +18,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-Mox.defmock(MockRPCClient, for: Astarte.RPC.Client)
+defmodule Astarte.AppEngine.API.RPC.VMQPlugin.Client do
+  @moduledoc false
+  @behaviour Astarte.AppEngine.API.RPC.VMQPlugin.Behaviour
 
-Mox.defmock(Astarte.AppEngine.API.RPC.DataUpdaterPlant.ClientMock,
-  for: Astarte.AppEngine.API.RPC.DataUpdaterPlant.Behaviour
-)
-
-Mox.defmock(Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock,
-  for: Astarte.AppEngine.API.RPC.VMQPlugin.Behaviour
-)
+  @impl Astarte.AppEngine.API.RPC.VMQPlugin.Behaviour
+  def publish(data) do
+    case Horde.Registry.lookup(Registry.VMQPluginRPC, :server) do
+      [] -> {:error, :no_rpc_server}
+      [{pid, _value}] -> GenServer.call(pid, {:publish, data})
+    end
+  end
+end

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/data_transmitter_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/data_transmitter_test.exs
@@ -44,49 +44,45 @@ defmodule Astarte.AppEngine.APIWeb.DataTransmitterTest do
   @timestamp DateTime.utc_now()
   @metadata %{some: "metadata"}
 
-  @encoded_generic_ok_reply %Reply{
-                              reply: {:generic_ok_reply, %GenericOkReply{}}
-                            }
-                            |> Reply.encode()
-
   test "datastream push with no opts" do
-    MockRPCClient
-    |> expect(:rpc_call, fn serialized_call, @vmq_plugin_destination ->
-      assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+    answer = {:ok, %{local_matches: 0, remote_matches: 0}}
 
+    Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+    |> expect(:publish, fn data ->
       encoded_payload = Cyanide.encode!(%{v: @payload})
 
-      assert %Publish{
+      assert %{
                topic_tokens: [@realm, @encoded_device_id, @interface | @path_tokens],
                payload: ^encoded_payload,
                qos: 0
-             } = publish_call
+             } = data
 
-      {:ok, @encoded_generic_ok_reply}
+      answer
     end)
 
-    assert :ok = DataTransmitter.push_datastream(@realm, @device_id, @interface, @path, @payload)
+    assert ^answer =
+             DataTransmitter.push_datastream(@realm, @device_id, @interface, @path, @payload)
   end
 
   test "datastream push with opts" do
-    MockRPCClient
-    |> expect(:rpc_call, fn serialized_call, @vmq_plugin_destination ->
-      assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+    answer = {:ok, %{local_matches: 0, remote_matches: 0}}
 
+    Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+    |> expect(:publish, fn data ->
       encoded_payload = Cyanide.encode!(%{v: @payload, m: @metadata, t: @timestamp})
 
-      assert %Publish{
+      assert %{
                topic_tokens: [@realm, @encoded_device_id, @interface | @path_tokens],
                payload: ^encoded_payload,
                qos: 1
-             } = publish_call
+             } = data
 
-      {:ok, @encoded_generic_ok_reply}
+      answer
     end)
 
     opts = [metadata: @metadata, timestamp: @timestamp, qos: 1]
 
-    assert :ok =
+    assert ^answer =
              DataTransmitter.push_datastream(
                @realm,
                @device_id,
@@ -98,43 +94,43 @@ defmodule Astarte.AppEngine.APIWeb.DataTransmitterTest do
   end
 
   test "set property with no opts" do
-    MockRPCClient
-    |> expect(:rpc_call, fn serialized_call, @vmq_plugin_destination ->
-      assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+    answer = {:ok, %{local_matches: 0, remote_matches: 0}}
 
+    Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+    |> expect(:publish, fn data ->
       encoded_payload = Cyanide.encode!(%{v: @payload})
 
-      assert %Publish{
+      assert %{
                topic_tokens: [@realm, @encoded_device_id, @interface | @path_tokens],
                payload: ^encoded_payload,
                qos: 2
-             } = publish_call
+             } = data
 
-      {:ok, @encoded_generic_ok_reply}
+      answer
     end)
 
-    assert :ok = DataTransmitter.set_property(@realm, @device_id, @interface, @path, @payload)
+    assert ^answer = DataTransmitter.set_property(@realm, @device_id, @interface, @path, @payload)
   end
 
   test "set property with opts" do
-    MockRPCClient
-    |> expect(:rpc_call, fn serialized_call, @vmq_plugin_destination ->
-      assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+    answer = {:ok, %{local_matches: 0, remote_matches: 0}}
 
+    Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+    |> expect(:publish, fn data ->
       encoded_payload = Cyanide.encode!(%{v: @payload, m: @metadata, t: @timestamp})
 
-      assert %Publish{
-               topic_tokens: [@realm, @encoded_device_id, @interface | @path_tokens],
-               payload: ^encoded_payload,
-               qos: 2
-             } = publish_call
+      %{
+        topic_tokens: [@realm, @encoded_device_id, @interface | @path_tokens],
+        payload: ^encoded_payload,
+        qos: 2
+      } = data
 
-      {:ok, @encoded_generic_ok_reply}
+      answer
     end)
 
     opts = [metadata: @metadata, timestamp: @timestamp]
 
-    assert :ok =
+    assert ^answer =
              DataTransmitter.set_property(
                @realm,
                @device_id,
@@ -146,19 +142,19 @@ defmodule Astarte.AppEngine.APIWeb.DataTransmitterTest do
   end
 
   test "unset property" do
-    MockRPCClient
-    |> expect(:rpc_call, fn serialized_call, @vmq_plugin_destination ->
-      assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+    answer = {:ok, %{local_matches: 0, remote_matches: 0}}
 
-      assert %Publish{
-               topic_tokens: [@realm, @encoded_device_id, @interface | @path_tokens],
-               payload: <<>>,
-               qos: 2
-             } = publish_call
+    Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+    |> expect(:publish, fn data ->
+      %{
+        topic_tokens: [@realm, @encoded_device_id, @interface | @path_tokens],
+        payload: <<>>,
+        qos: 2
+      } = data
 
-      {:ok, @encoded_generic_ok_reply}
+      answer
     end)
 
-    assert :ok = DataTransmitter.unset_property(@realm, @device_id, @interface, @path)
+    assert ^answer = DataTransmitter.unset_property(@realm, @device_id, @interface, @path)
   end
 end

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_test.exs
@@ -153,6 +153,8 @@ defmodule Astarte.AppEngine.API.DeviceTest do
     DatabaseTestHelper.seed_data()
   end
 
+  setup :verify_on_exit!
+
   setup_all do
     {:ok, _client} = DatabaseTestHelper.create_test_keyspace()
 
@@ -1044,24 +1046,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
       request_ts_1 = DateTime.utc_now()
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^test_interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(1)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, test_interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(
@@ -1083,24 +1080,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
       request_ts_2 = DateTime.utc_now()
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^test_interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(1)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, test_interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(
@@ -1154,25 +1146,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
       request_ts_1 = DateTime.utc_now()
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^test_interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           # Remote match
-           reply: tagged_publish_reply(0, 1)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, test_interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 0, remote_matches: 1}}
       end)
 
       assert Device.update_interface_values(
@@ -1194,25 +1180,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
       request_ts_2 = DateTime.utc_now()
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^test_interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           # Multiple matches
-           reply: tagged_publish_reply(2, 3)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, test_interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 2, remote_matches: 3}}
       end)
 
       assert Device.update_interface_values(
@@ -1264,24 +1244,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
       path = "/1/samplingPeriod"
       par = %{}
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^test_interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(0)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, test_interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 0, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(
@@ -1383,24 +1358,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
       request_ts_1 = DateTime.utc_now()
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(1)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(
@@ -1422,24 +1392,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
       request_ts_2 = DateTime.utc_now()
 
-      MockRPCClient
-      |> expect(:rpc_call, 2, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(1)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(
@@ -1488,26 +1453,24 @@ defmodule Astarte.AppEngine.API.DeviceTest do
       server_owned_value = %{"binaryblobarray" => Enum.map(values, &Base.encode64/1)}
       par = nil
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
-
-        encoded_payload =
-          %{v: %{"binaryblobarray" => Enum.map(values, &{0, &1})}} |> Cyanide.encode!()
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
         path_tokens = String.split(path, "/")
+        assert ^topic_tokens = [test_realm, device_id, interface | path_tokens]
 
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
+        blob = Enum.map(values, &%Cyanide.Binary{subtype: :generic, data: &1})
 
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(1)
-         }
-         |> Reply.encode()}
+        assert %{"v" => %{"binaryblobarray" => ^blob}} =
+                 Cyanide.decode!(payload)
+
+        assert 2 = qos
+        {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(
@@ -1535,25 +1498,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
       request_ts_1 = DateTime.utc_now()
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           # Remote match
-           reply: tagged_publish_reply(0, 1)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 0, remote_matches: 1}}
       end)
 
       assert Device.update_interface_values(
@@ -1575,25 +1532,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
 
       request_ts_2 = DateTime.utc_now()
 
-      MockRPCClient
-      |> expect(:rpc_call, 2, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           # Multiple matches
-           reply: tagged_publish_reply(2, 3)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 2, remote_matches: 3}}
       end)
 
       assert Device.update_interface_values(
@@ -1641,24 +1592,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
       value = %{"enable" => true, "samplingPeriod" => 10}
       par = nil
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(0)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 0, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(
@@ -1691,24 +1637,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
       path = "/1/samplingPeriod"
       par = %{}
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^test_interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(1)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, test_interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(
@@ -1755,24 +1696,19 @@ defmodule Astarte.AppEngine.API.DeviceTest do
       value = %{"enable" => true, "samplingPeriod" => 10}
       par = nil
 
-      MockRPCClient
-      |> expect(:rpc_call, fn serialized_call, _destination ->
-        assert %Call{call: {:publish, %Publish{} = publish_call}} = Call.decode(serialized_call)
+      Astarte.AppEngine.API.RPC.VMQPlugin.ClientMock
+      |> expect(:publish, fn data ->
+        %{
+          topic_tokens: topic_tokens,
+          payload: payload,
+          qos: qos
+        } = data
 
-        encoded_payload = Cyanide.encode!(%{v: value})
         path_tokens = String.split(path, "/")
-
-        assert %Publish{
-                 topic_tokens: [^test_realm, ^device_id, ^test_interface | ^path_tokens],
-                 payload: ^encoded_payload,
-                 qos: 2
-               } = publish_call
-
-        {:ok,
-         %Reply{
-           reply: tagged_publish_reply(1)
-         }
-         |> Reply.encode()}
+        assert ^topic_tokens = [test_realm, device_id, test_interface | path_tokens]
+        assert %{"v" => ^value} = Cyanide.decode!(payload)
+        assert 2 = qos
+        {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
       assert Device.update_interface_values(

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/channels/rooms_channel_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/channels/rooms_channel_test.exs
@@ -32,14 +32,6 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
   alias Astarte.Core.Triggers.SimpleEvents.IncomingDataEvent
   alias Astarte.Core.Triggers.SimpleEvents.SimpleEvent
 
-  alias Astarte.RPC.Protocol.DataUpdaterPlant, as: Protocol
-  alias Astarte.RPC.Protocol.DataUpdaterPlant.Call
-  alias Astarte.RPC.Protocol.DataUpdaterPlant.DeleteVolatileTrigger
-  alias Astarte.RPC.Protocol.DataUpdaterPlant.GenericErrorReply
-  alias Astarte.RPC.Protocol.DataUpdaterPlant.GenericOkReply
-  alias Astarte.RPC.Protocol.DataUpdaterPlant.InstallVolatileTrigger
-  alias Astarte.RPC.Protocol.DataUpdaterPlant.Reply
-
   import Mox
 
   @all_access_regex ".*"
@@ -57,8 +49,6 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
   @group_name "my_group"
   @authorized_group_watch_path "groups/#{@group_name}/#{@interface_exact}#{@path}"
   @authorized_group "groups/#{@group_name}"
-
-  @dup_rpc_destination Protocol.amqp_queue()
 
   @name "testwatch"
 
@@ -81,20 +71,6 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
   @timestamp 1_573_233_693_478
 
   @unauthorized_reason %{reason: "unauthorized"}
-
-  @encoded_generic_ok_reply %Reply{
-                              reply: {:generic_ok_reply, %GenericOkReply{async_operation: false}}
-                            }
-                            |> Reply.encode()
-
-  @error_string "unsupported_interface_aggregation"
-  @encoded_generic_error_reply %Reply{
-                                 error: true,
-                                 reply:
-                                   {:generic_error_reply,
-                                    %GenericErrorReply{error_name: @error_string}}
-                               }
-                               |> Reply.encode()
 
   @event_simple_trigger_id Utils.get_uuid()
   @event_value 1000


### PR DESCRIPTION
Based on #1191
Requires astarte-platform/astarte_vmq_plugin#102

This PR moves the communication between AppEngine and the Astarte VerneMQ Plugin outside of `astarte_rpc`. The new strategy consists in having an rpc server shared among all VerneMQ Plugin replicas (see astarte-platform/astarte_vmq_plugin#102 for context) and making RPC calls to shuch server. AppEngine calls have to be reworked to accomodate for the changes