### PR TITLE
refactor(DUP): VerneMQ RPC

### DIFF
--- a/apps/astarte_data_updater_plant/config/test.exs
+++ b/apps/astarte_data_updater_plant/config/test.exs
@@ -11,3 +11,7 @@ config :logger, :console,
 
 config :astarte_data_updater_plant, :astarte_instance_id, "test"
 config :astarte_data_updater_plant, :rpc_client, MockRPCClient
+
+config :astarte_data_updater_plant,
+       :vernemq_plugin_rpc_client,
+       Astarte.DataUpdaterPlant.RPC.VMQPlugin.ClientMock

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_pipeline_supervisor.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_pipeline_supervisor.ex
@@ -34,6 +34,7 @@ defmodule Astarte.DataUpdaterPlant.DataPipelineSupervisor do
       {Horde.Registry, [keys: :unique, name: Registry.DataUpdater, members: :auto]},
       {Horde.Registry, [keys: :unique, name: Registry.DataUpdaterRPC, members: :auto]},
       {Horde.Registry, [keys: :unique, name: Registry.AMQPDataConsumer, members: :auto]},
+      {Horde.Registry, [keys: :unique, name: Registry.VMQPluginRPC, members: :auto]},
       {Horde.DynamicSupervisor,
        [
          name: Supervisor.MessageTracker,
@@ -55,8 +56,7 @@ defmodule Astarte.DataUpdaterPlant.DataPipelineSupervisor do
        connection_pools: [Config.events_producer_pool_config!()]},
       AMQPEventsProducer,
       ConsumersSupervisor,
-      Astarte.DataUpdaterPlant.RPC.Supervisor,
-      Astarte.RPC.AMQP.Client
+      Astarte.DataUpdaterPlant.RPC.Supervisor
     ]
 
     Supervisor.init(children, strategy: :rest_for_one)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -2291,7 +2291,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
     with :ok <- Queries.set_pending_empty_cache(realm, device_id, true),
          :ok <- force_disconnection(realm, encoded_device_id) do
-      new_state = set_device_disconnected(realm, timestamp)
+      new_state = set_device_disconnected(state, timestamp)
 
       Logger.info("Successfully forced device disconnection.", tag: "forced_device_disconnection")
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin.ex
@@ -21,60 +21,42 @@ defmodule Astarte.DataUpdaterPlant.RPC.VMQPlugin do
   This module sends RPC to VMQPlugin
   """
 
-  alias Astarte.RPC.Protocol.VMQ.Plugin, as: Protocol
-
-  alias Astarte.RPC.Protocol.VMQ.Plugin.{
-    Call,
-    Delete,
-    Disconnect,
-    GenericErrorReply,
-    GenericOkReply,
-    Publish,
-    PublishReply,
-    Reply
-  }
-
-  alias Astarte.DataUpdaterPlant.Config
-
-  @rpc_client Config.rpc_client!()
-  @destination Protocol.amqp_queue()
+  @rpc_client Application.compile_env(
+                :astarte_data_updater_plant,
+                :vernemq_plugin_rpc_client,
+                Astarte.DataUpdaterPlant.RPC.VMQPlugin.Client
+              )
 
   def publish(topic, payload, qos)
       when is_binary(topic) and is_binary(payload) and is_integer(qos) and qos >= 0 and qos <= 2 do
     with {:ok, tokens} <- split_topic(topic) do
-      %Publish{
+      data = %{
         topic_tokens: tokens,
         payload: payload,
         qos: qos
       }
-      |> encode_call(:publish)
-      |> @rpc_client.rpc_call(@destination)
-      |> decode_reply()
-      |> extract_reply()
+
+      @rpc_client.publish(data)
     end
   end
 
   def delete(realm_name, device_id) do
-    %Delete{
+    data = %{
       realm_name: realm_name,
       device_id: device_id
     }
-    |> encode_call(:delete)
-    |> @rpc_client.rpc_call(@destination)
-    |> decode_reply()
-    |> extract_reply()
+
+    @rpc_client.delete(data)
   end
 
   def disconnect(client_id, discard_state)
       when is_binary(client_id) and is_boolean(discard_state) do
-    %Disconnect{
+    data = %{
       client_id: client_id,
       discard_state: discard_state
     }
-    |> encode_call(:disconnect)
-    |> @rpc_client.rpc_call(@destination)
-    |> decode_reply()
-    |> extract_reply()
+
+    @rpc_client.disconnect(data)
   end
 
   defp split_topic(topic) do
@@ -82,41 +64,5 @@ defmodule Astarte.DataUpdaterPlant.RPC.VMQPlugin do
       [] -> {:error, :empty_topic}
       tokens -> {:ok, tokens}
     end
-  end
-
-  defp encode_call(call, callname) do
-    %Call{call: {callname, call}}
-    |> Call.encode()
-  end
-
-  defp decode_reply({:ok, encoded_reply}) when is_binary(encoded_reply) do
-    %Reply{reply: reply} = Reply.decode(encoded_reply)
-    reply
-  end
-
-  defp decode_reply({:error, "exception"}) do
-    {:error, :vmq_plugin_rpc_exception}
-  end
-
-  defp extract_reply({:generic_ok_reply, %GenericOkReply{}}) do
-    :ok
-  end
-
-  defp extract_reply({:publish_reply, %PublishReply{} = reply}) do
-    {:ok, %{local_matches: reply.local_matches, remote_matches: reply.remote_matches}}
-  end
-
-  defp extract_reply({:generic_error_reply, %GenericErrorReply{error_name: "not_found"}}) do
-    {:error, :not_found}
-  end
-
-  defp extract_reply({:generic_error_reply, error_struct = %GenericErrorReply{}}) do
-    error_map = Map.from_struct(error_struct)
-
-    {:error, error_map}
-  end
-
-  defp extract_reply({:error, :vmq_plugin_rpc_exception} = error) do
-    error
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin/behaviour.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin/behaviour.ex
@@ -1,0 +1,33 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.RPC.VMQPlugin.Behaviour do
+  @moduledoc false
+
+  @callback publish(data :: %{topic_tokens: list(binary()), payload: binary(), qos: 0 | 1 | 2}) ::
+              :ok
+              | {:ok, %{local_matches: integer(), remote_matches: integer()}}
+              | {:error, term()}
+
+  @callback delete(data :: %{realm_name: binary(), device_id: binary()}) :: :ok | {:error, term()}
+
+  @callback disconnect(data :: %{client_id: binary(), discard_state: boolean()}) ::
+              :ok | {:error, term()}
+end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin/client.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/rpc/vmq_plugin/client.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.RPC.VMQPlugin.Client do
+  @moduledoc false
+  @behaviour Astarte.DataUpdaterPlant.RPC.VMQPlugin.Behaviour
+
+  defp rpc_server(), do: {:via, Horde.Registry, {Registry.VMQPluginRPC, :server}}
+
+  @impl Astarte.DataUpdaterPlant.RPC.VMQPlugin.Behaviour
+  def publish(data) do
+    rpc_server()
+    |> GenServer.call({:publish, data})
+  end
+
+  @impl Astarte.DataUpdaterPlant.RPC.VMQPlugin.Behaviour
+  def delete(data) do
+    rpc_server()
+    |> GenServer.call({:delete, data})
+  end
+
+  @impl Astarte.DataUpdaterPlant.RPC.VMQPlugin.Behaviour
+  def disconnect(data) do
+    rpc_server()
+    |> GenServer.call({:disconnect, data})
+  end
+end

--- a/apps/astarte_data_updater_plant/test/support/mocks.ex
+++ b/apps/astarte_data_updater_plant/test/support/mocks.ex
@@ -1,1 +1,5 @@
 Mox.defmock(MockRPCClient, for: Astarte.RPC.Client)
+
+Mox.defmock(Astarte.DataUpdaterPlant.RPC.VMQPlugin.ClientMock,
+  for: Astarte.DataUpdaterPlant.RPC.VMQPlugin.Behaviour
+)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,7 +245,7 @@ services:
 
   # VerneMQ
   vernemq:
-    image: astarte/vernemq:1.2.0
+    image: astarte/vernemq:1.2-snapshot
     env_file:
       - ./.env
     environment:


### PR DESCRIPTION
Reworks the RPC strategy between `DUP` and `VerneMQ`, using `GenServer` calls instead of the `astarte_rpc` library