### PR TITLE
DUP: do not crash on binaryblob insertion

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -134,6 +134,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     timestamp = div(reception_timestamp, 10000)
     reception_timestamp_submillis = rem(reception_timestamp, 10000)
     column_name = CQLUtils.type_to_db_column_name(value_type)
+    db_value = to_db_friendly_type(value)
 
     # TODO: :reception_timestamp_submillis is just a place holder right now
     insert_value = %{
@@ -143,7 +144,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
       "path" => path,
       "reception_timestamp" => timestamp,
       "reception_timestamp_submillis" => reception_timestamp_submillis,
-      column_name => value
+      column_name => db_value
     }
 
     insert_opts = [
@@ -173,6 +174,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     timestamp = div(reception_timestamp, 10000)
     reception_timestamp_submillis = rem(reception_timestamp, 10000)
     column_name = CQLUtils.type_to_db_column_name(value_type)
+    db_value = to_db_friendly_type(value)
 
     # TODO: use received value_timestamp when needed
     # TODO: :reception_timestamp_submillis is just a place holder right now
@@ -184,7 +186,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
       "value_timestamp" => value_timestamp,
       "reception_timestamp" => timestamp,
       "reception_timestamp_submillis" => reception_timestamp_submillis,
-      column_name => value
+      column_name => db_value
     }
 
     insert_opts = [


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
DUP crashes when writing individual-aggregated binaryblobs (or arrays thereof) due to the fact that binaryblobs are decoded as `%Cyanide.Binary{}` structs.
Handle `%Cyanide.Binary{}` structs when writing individual values, just as we do when we handle object values.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #1187 

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

