### PR TITLE
test(RM): test realm and jwt functionalities in RM

### DIFF
--- a/apps/astarte_realm_management/test/astarte_realm_management/jwt_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/jwt_test.exs
@@ -1,0 +1,45 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.RealmManagement.JwtTest do
+  alias Astarte.RealmManagement.Engine
+
+  use Astarte.RealmManagement.DataCase, async: true
+  use ExUnitProperties
+
+  describe "Test JWT PEM" do
+    @describetag :jwt
+    setup %{realm: realm} do
+      {:ok, jwt} = Engine.get_jwt_public_key_pem(realm)
+      %{jwt: jwt}
+    end
+
+    test "is correctly updated and fetched", %{realm: realm, jwt: old_jwt} do
+      new_jwt =
+        :ascii
+        |> StreamData.string()
+        |> StreamData.filter(&(&1 != old_jwt))
+        |> Enum.at(0)
+
+      :ok = Engine.update_jwt_public_key_pem(realm, new_jwt)
+      assert {:ok, ^new_jwt} = Engine.get_jwt_public_key_pem(realm)
+    end
+  end
+end

--- a/apps/astarte_realm_management/test/astarte_realm_management/realm_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/realm_test.exs
@@ -1,0 +1,44 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.RealmManagement.RealmTest do
+  alias Astarte.Test.Helpers.Database
+  alias Astarte.RealmManagement.Engine
+
+  use Astarte.RealmManagement.DataCase, async: true
+  use ExUnitProperties
+
+  describe "Test Realm" do
+    @describetag :realm
+    property "Fetches device_registration limit correctly", %{realm: realm} do
+      check all(limit <- integer(1..256)) do
+        Database.insert_device_registration_limit!(realm, limit)
+        assert {:ok, ^limit} = Engine.get_device_registration_limit(realm)
+      end
+    end
+
+    property "retrieve datasteam_maximum_storage_retention correctly", %{realm: realm} do
+      check all(retention <- integer(1..256)) do
+        Database.set_datastream_maximum_storage_retention(realm, retention)
+        assert {:ok, ^retention} = Engine.get_datastream_maximum_storage_retention(realm)
+      end
+    end
+  end
+end

--- a/apps/astarte_realm_management/test/support/helpers/database.ex
+++ b/apps/astarte_realm_management/test/support/helpers/database.ex
@@ -17,6 +17,8 @@
 #
 
 defmodule Astarte.Test.Helpers.Database do
+  alias Astarte.Core.Realm
+  alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Repo
   alias Astarte.DataAccess.Realms.Realm
 
@@ -256,6 +258,28 @@ defmodule Astarte.Test.Helpers.Database do
     execute!(astarte_keyspace, @drop_keyspace)
 
     :ok
+  end
+
+  def insert_device_registration_limit!(realm, limit) do
+    keyspace = Realm.astarte_keyspace_name()
+
+    %Realm{
+      realm_name: realm,
+      device_registration_limit: limit
+    }
+    |> Repo.insert!(prefix: keyspace)
+  end
+
+  def set_datastream_maximum_storage_retention(realm, value) do
+    keyspace = Realm.keyspace_name(realm)
+
+    %{
+      group: "realm_config",
+      key: "datastream_maximum_storage_retention",
+      value: value,
+      value_type: :integer
+    }
+    |> KvStore.insert(prefix: keyspace)
   end
 
   def insert_public_key!(realm_name) do


### PR DESCRIPTION
Based on #1211 

Adds property based testing for realm and jwt functionalities in Realm management:
- RM shoud be able to retrieve and update the `JWT PEM` certificate
- RM should be able to retrieve the `device_registration_limit` and `datastream_maximum_storage_retention` of a realm