### PR TITLE
test(RM): test device deletion

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -933,8 +933,7 @@ defmodule Astarte.RealmManagement.Engine do
     with {:ok, decoded_device_id} <-
            Astarte.Core.Device.decode_device_id(device_id, allow_extended_id: true),
          {:ok, true} <- check_device_exists(realm_name, decoded_device_id),
-         {:ok, %Xandra.Void{}} <-
-           insert_device_into_deletion_in_progress(realm_name, decoded_device_id) do
+         :ok <- insert_device_into_deletion_in_progress(realm_name, decoded_device_id) do
       _ = Logger.info("Added device #{device_id} to deletion in progress")
       :ok
     end

--- a/apps/astarte_realm_management/test/astarte_realm_management/device_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/device_test.exs
@@ -1,0 +1,119 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.RealmManagement.DeviceTest do
+  @moduledoc """
+  Test for the `Device` section of the RealmManagement Engine
+  """
+  alias Astarte.RealmManagement.Queries
+  alias Astarte.RealmManagement.Engine
+  alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.RealmManagement.Repo
+  alias Astarte.DataAccess.Device.DeletionInProgress
+  alias Astarte.DataAccess.Devices.Device
+  alias Astarte.RealmManagement.DatabaseTestHelper
+
+  use Astarte.RealmManagement.DataCase, async: true
+  use ExUnitProperties
+
+  describe "Test device" do
+    @describetag :devices
+    property "gets put in deletion in progress on deletion request", %{realm: realm} do
+      check all(device_id <- Astarte.Core.Generators.Device.id()) do
+        keyspace = Realm.keyspace_name(realm)
+
+        %Device{
+          device_id: device_id
+        }
+        |> Repo.insert!(prefix: keyspace)
+
+        encoded_device_id = Astarte.Core.Device.encode_device_id(device_id)
+        :ok = Engine.delete_device(realm, encoded_device_id)
+
+        [deletion] = Repo.all(DeletionInProgress, prefix: keyspace)
+        _ = Repo.delete!(deletion)
+
+        assert device_id == deletion.device_id
+        refute DeletionInProgress.all_ack?(deletion)
+      end
+    end
+
+    property "is not queued for deletion if there are no acks", %{realm: realm} do
+      check all(device_id <- Astarte.Core.Generators.Device.id()) do
+        keyspace = Realm.keyspace_name(realm)
+
+        %Device{
+          device_id: device_id
+        }
+        |> Repo.insert!(prefix: keyspace)
+
+        encoded_device_id = Astarte.Core.Device.encode_device_id(device_id)
+        :ok = Engine.delete_device(realm, encoded_device_id)
+
+        assert [] = Queries.retrieve_devices_to_delete!(realm)
+
+        %DeletionInProgress{
+          device_id: device_id,
+          dup_end_ack: false,
+          vmq_ack: false,
+          dup_start_ack: false
+        }
+        |> Repo.delete!(prefix: keyspace)
+      end
+    end
+
+    property "is queued for deletion with all acks", %{realm: realm} do
+      check all(device <- Astarte.Core.Generators.Device.device(interfaces: [])) do
+        keyspace = Realm.keyspace_name(realm)
+
+        %Device{
+          device_id: device.device_id
+        }
+        |> Repo.insert!(prefix: keyspace)
+
+        %DeletionInProgress{
+          device_id: device.device_id,
+          vmq_ack: true,
+          dup_end_ack: true,
+          dup_start_ack: true
+        }
+        |> Repo.insert!(prefix: keyspace)
+
+        assert [deletion] = Queries.retrieve_devices_to_delete!(realm)
+        _ = Repo.delete!(deletion)
+
+        device_id = device.device_id
+
+        assert %DeletionInProgress{
+                 device_id: ^device_id,
+                 vmq_ack: true,
+                 dup_end_ack: true,
+                 dup_start_ack: true
+               } = deletion
+      end
+    end
+
+    property "does not delete a non existing device", %{realm: realm} do
+      check all(encoded_device_id <- Astarte.Core.Generators.Device.encoded_id()) do
+        assert {:error, :device_not_found} = Engine.delete_device(realm, encoded_device_id)
+      end
+    end
+  end
+end

--- a/apps/astarte_realm_management/test/astarte_realm_management/interfaces_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/interfaces_test.exs
@@ -33,7 +33,7 @@ defmodule Astarte.RealmManagement.InterfacesTest do
       check all(interface <- Astarte.Core.Generators.Interface.interface()) do
         json_interface = Jason.encode!(interface)
 
-        _ = Engine.install_interface(realm, json_interface)
+        :ok = Engine.install_interface(realm, json_interface)
 
         {:ok, fetched_interface} =
           Queries.fetch_interface(realm, interface.name, interface.major_version)
@@ -58,7 +58,7 @@ defmodule Astarte.RealmManagement.InterfacesTest do
 
         assert MapSet.equal?(fetched_mappings, interface_mappings)
 
-        _ = Engine.delete_interface(realm, interface.name, interface.major_version)
+        _ = Queries.delete_interface(realm, interface.name, interface.major_version)
       end
     end
 

--- a/apps/astarte_realm_management/test/support/helpers/database.ex
+++ b/apps/astarte_realm_management/test/support/helpers/database.ex
@@ -214,6 +214,16 @@ defmodule Astarte.Test.Helpers.Database do
   )
   """
 
+  @create_deletion_in_progress_table """
+  CREATE TABLE :keyspace.deletion_in_progress (
+      device_id uuid,
+      vmq_ack boolean,
+      dup_start_ack boolean,
+      dup_end_ack boolean,
+      PRIMARY KEY ((device_id))
+    )
+  """
+
   @insert_public_key """
     INSERT INTO :keyspace.kv_store (group, key, value)
     VALUES ('auth', 'jwt_public_key_pem', varcharAsBlob(:pem));
@@ -238,6 +248,7 @@ defmodule Astarte.Test.Helpers.Database do
     execute!(realm_keyspace, @create_individual_properties_table)
     execute!(realm_keyspace, @create_individual_datastreams_table)
     execute!(realm_keyspace, @create_interfaces_table)
+    execute!(realm_keyspace, @create_deletion_in_progress_table)
 
     astarte_keyspace = Realm.astarte_keyspace_name()
     execute!(astarte_keyspace, @create_keyspace)


### PR DESCRIPTION
Tests device deletion in Realm Management `Engine` module with property based testing. The actual deletion is carried out by another module (`DeviceRemover`) hence here the only thing to test is that RM correctly puts a new entry in the `deletion_in_progress` table in the DB, so that the device remover can then query the database and handle the deletion asyncronously (with DUP). Tests of that module will appear in another PR.