### PR TITLE
refactor(te): amqp_message_consumer's core extraction for units

### DIFF
--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_message_consumer/impl.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_message_consumer/impl.ex
@@ -1,0 +1,104 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.TriggerEngine.AMQPConsumer.AMQPMessageConsumer.Impl do
+  alias AMQP.Channel
+  alias AMQP.Basic
+  alias Astarte.TriggerEngine.Config
+  alias Astarte.Core.Triggers.Policy, as: PolicyStruct
+  alias ExRabbitPool.Consumer
+
+  require Logger
+
+  @adapter Config.amqp_adapter!()
+
+  @type delivery_params() :: %{
+          realm_name: String.t(),
+          policy: PolicyStruct.t(),
+          channel: Channel.t(),
+          payload: Basic.payload(),
+          meta: Consumer.meta()
+        }
+
+  @doc """
+    Gets a connection worker out of the connection pool, if there is one available
+    takes a channel out of it channel pool, if there is one available
+    subscribe itself as a consumer process.
+  """
+  @spec connect(String.t(), PolicyStruct.t()) ::
+          {:ok, Channel.t(), reference()} | {:error, reason :: term()}
+  def connect(realm_name, policy) do
+    conn = ExRabbitPool.get_connection_worker(:events_consumer_pool)
+
+    with {:ok, channel} <- ExRabbitPool.checkout_channel(conn) do
+      try_to_connect(realm_name, policy, channel)
+    end
+  end
+
+  defp try_to_connect(realm_name, policy, channel) do
+    %{pid: channel_pid} = channel
+
+    exchange_name = Config.events_exchange_name!()
+    queue_name = generate_queue_name(realm_name, policy.name)
+    routing_key = generate_routing_key(realm_name, policy.name)
+
+    with :ok <- @adapter.qos(channel, prefetch_count: Config.amqp_consumer_prefetch_count!()),
+         :ok <- @adapter.declare_exchange(channel, exchange_name, type: :direct, durable: true),
+         {:ok, _queue} <- @adapter.declare_queue(channel, queue_name, durable: true),
+         :ok <-
+           @adapter.queue_bind(
+             channel,
+             queue_name,
+             exchange_name,
+             routing_key: routing_key,
+             arguments: [{"x-queue-mode", :longstr, "lazy"} | generate_policy_x_args(policy)]
+           ),
+         {:ok, _consumer_tag} <- @adapter.consume(channel, queue_name, self(), []) do
+      ref = Process.monitor(channel_pid)
+
+      _ =
+        Logger.debug(
+          "Queue #{queue_name} on exchange #{exchange_name} declared, bound with routing key #{routing_key}",
+          tag: "queue_bound"
+        )
+
+      {:ok, channel, ref}
+    end
+  end
+
+  defp generate_policy_x_args(%PolicyStruct{
+         maximum_capacity: max_capacity,
+         event_ttl: event_ttl
+       }) do
+    []
+    |> put_x_arg_if(max_capacity != nil, fn -> {"x-max-length", :signedint, max_capacity} end)
+    # AMQP message TTLs are in milliseconds!
+    |> put_x_arg_if(event_ttl != nil, fn -> {"x-message-ttl", :signedint, event_ttl * 1_000} end)
+  end
+
+  defp put_x_arg_if(list, true, x_arg_fun), do: [x_arg_fun.() | list]
+  defp put_x_arg_if(list, false, _x_arg_fun), do: list
+
+  defp generate_queue_name(realm, policy) do
+    "#{realm}_#{policy}_queue"
+  end
+
+  defp generate_routing_key(realm, policy) do
+    "#{realm}_#{policy}"
+  end
+end

--- a/apps/astarte_trigger_engine/test/amqp_consumer/amqp_message_consumer_test.exs
+++ b/apps/astarte_trigger_engine/test/amqp_consumer/amqp_message_consumer_test.exs
@@ -1,0 +1,32 @@
+defmodule Astarte.TriggerEngine.AMQPConsumer.AMQPMessageConsumerTest do
+  use Astarte.Cases.FakeRabbitPool, async: true
+  use Astarte.Cases.Policy
+  use Mimic
+
+  alias Astarte.TriggerEngine.AMQPConsumer.AMQPMessageConsumer.Impl
+  alias AMQP.Channel
+
+  import Astarte.Helpers.AMQPMessageConsumer
+
+  describe "connect/2" do
+    @tag :unit
+    test "connects to the channel with a valid realm name and policy", args do
+      %{realm_name: realm_name, policy: policy} = args
+
+      assert {:ok, channel, monitor} = Impl.connect(realm_name, policy)
+      assert %Channel{} = channel
+      assert is_reference(monitor)
+    end
+
+    @tag :unit
+    test "monitors the channel process", args do
+      %{realm_name: realm_name, policy: policy} = args
+
+      {:ok, channel, monitor} = Impl.connect(realm_name, policy)
+      %{pid: pid} = channel
+      kill_channel(channel)
+
+      assert_receive {:DOWN, ^monitor, :process, ^pid, _reason}
+    end
+  end
+end

--- a/apps/astarte_trigger_engine/test/support/cases/fake_rabbit_pool.ex
+++ b/apps/astarte_trigger_engine/test/support/cases/fake_rabbit_pool.ex
@@ -1,0 +1,48 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Cases.FakeRabbitPool do
+  use ExUnit.CaseTemplate
+  use Mimic
+
+  alias AMQP.Channel
+
+  setup do
+    connection = dummy_process()
+    channel_process = dummy_process()
+
+    channel = %Channel{conn: connection, pid: channel_process}
+
+    ExRabbitPool
+    |> stub(:get_connection_worker, fn :events_consumer_pool -> connection end)
+    |> stub(:checkout_channel, fn ^connection -> {:ok, channel} end)
+
+    ExRabbitPool.RabbitMQ
+    |> stub_with(ExRabbitPool.FakeRabbitMQ)
+
+    :ok
+  end
+
+  defp dummy_process do
+    spawn(fn ->
+      receive do
+        :ok -> :ok
+      end
+    end)
+  end
+end

--- a/apps/astarte_trigger_engine/test/support/helpers/amqp_message_consumer.ex
+++ b/apps/astarte_trigger_engine/test/support/helpers/amqp_message_consumer.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 - 2025 SECO Mind Srl
+# Copyright 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,10 +16,8 @@
 # limitations under the License.
 #
 
-Mimic.copy(AMQP.Basic)
-Mimic.copy(Astarte.DataAccess.Config)
-Mimic.copy(ExRabbitPool)
-Mimic.copy(ExRabbitPool.RabbitMQ)
-Mimic.copy(HTTPoison)
-
-ExUnit.start(capture_log: true)
+defmodule Astarte.Helpers.AMQPMessageConsumer do
+  def kill_channel(channel) do
+    Process.exit(channel.pid, :kill)
+  end
+end


### PR DESCRIPTION
adds unit tests for amqp_message_consumer.

mimic has been used for RabbitMQ because, although it provides a behavior, this would make existing processes fail crash for unset expectations, when we only really want to use `FakeRabbitMQ` in a subset of the tests

depends on #1215

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
