### PR TITLE
test: use capture_log

### DIFF
--- a/apps/astarte_appengine_api/test/test_helper.exs
+++ b/apps/astarte_appengine_api/test/test_helper.exs
@@ -1,3 +1,3 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)
 
 Code.require_file("support/database_test_helper.exs", __DIR__)

--- a/apps/astarte_data_updater_plant/test/test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/test_helper.exs
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-ExUnit.start()
+ExUnit.start(capture_log: true)
 
 Code.require_file("support/database_test_helper.exs", __DIR__)
 Code.require_file("support/amqp_test_helper.exs", __DIR__)

--- a/apps/astarte_housekeeping/test/test_helper.exs
+++ b/apps/astarte_housekeeping/test/test_helper.exs
@@ -1,3 +1,3 @@
 Mimic.copy(Xandra)
 Mimic.copy(Xandra.Cluster)
-ExUnit.start()
+ExUnit.start(capture_log: true)

--- a/apps/astarte_housekeeping_api/test/test_helper.exs
+++ b/apps/astarte_housekeeping_api/test/test_helper.exs
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-ExUnit.start()
+ExUnit.start(capture_log: true)

--- a/apps/astarte_pairing/test/test_helper.exs
+++ b/apps/astarte_pairing/test/test_helper.exs
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-ExUnit.start()
+ExUnit.start(capture_log: true)
 
 {:ok, files} = File.ls("./test/support")
 

--- a/apps/astarte_pairing_api/test/test_helper.exs
+++ b/apps/astarte_pairing_api/test/test_helper.exs
@@ -16,4 +16,4 @@
 # limitations under the License.
 #
 
-ExUnit.start()
+ExUnit.start(capture_log: true)

--- a/apps/astarte_realm_management/test/test_helper.exs
+++ b/apps/astarte_realm_management/test/test_helper.exs
@@ -16,6 +16,5 @@
 # limitations under the License.
 #
 
-ExUnit.start()
-
 Mimic.copy(Astarte.DataAccess.Config)
+ExUnit.start(capture_log: true)

--- a/apps/astarte_realm_management_api/test/test_helper.exs
+++ b/apps/astarte_realm_management_api/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start()
+ExUnit.start(capture_log: true)

--- a/apps/astarte_trigger_engine/test/test_helper.exs
+++ b/apps/astarte_trigger_engine/test/test_helper.exs
@@ -20,4 +20,4 @@ Mimic.copy(AMQP.Basic)
 Mimic.copy(Astarte.DataAccess.Config)
 Mimic.copy(HTTPoison)
 
-ExUnit.start()
+ExUnit.start(capture_log: true)


### PR DESCRIPTION
this reduces cluttering during tests in a substantial way, while still showing logs in case of a failed test (and in an organized way).

unfortunately this won't remove _all_ logs, as the logs from the `application.ex` starting will still be shown as not part of the exunit processes.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
--

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [X] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
