### PR TITLE
test(RM API): Expand and refactor trigger policy testing

### DIFF
--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/trigger_policy_view.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/views/trigger_policy_view.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2022 SECO Mind Srl
+# Copyright 2022 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,10 +27,6 @@ defmodule Astarte.RealmManagement.APIWeb.TriggerPolicyView do
 
   def render("show.json", %{policy: policy}) do
     %{data: render_one(policy, TriggerPolicyView, "policy.json")}
-  end
-
-  def render("already_installed_policy.json", _assigns) do
-    %{errors: %{detail: "Policy already exists"}}
   end
 
   def render("policy.json", %{trigger_policy: policy}) do

--- a/apps/astarte_realm_management_api/test/support/helpers/astarte_realm_management_mock.ex
+++ b/apps/astarte_realm_management_api/test/support/helpers/astarte_realm_management_mock.ex
@@ -225,7 +225,7 @@ defmodule Astarte.RealmManagement.API.Helpers.RPCMock do
        ) do
     case DB.delete_trigger_policy(realm_name, name) do
       :ok ->
-        generic_ok()
+        generic_ok(true)
         |> ok_wrap()
 
       {:error, reason} ->


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

- Improve testing coverage for realm management api, by removing unused trigger policy view as it is actually handled by `trigger_policy_already_present` and not `already_installed_policy`
- Fix extension mistake in `trigger_policy_controller_test.ex` file as it was not being executed since it was named with `.ex` extension instead of `.exs`
- Add property based testing for trigger policies
- Refactor context tests to test functions in isolation
- Update `execute_rpc` function to properly support synchronous calls

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No
