### PR TITLE
test(te): fix health check

### DIFF
--- a/apps/astarte_trigger_engine/test/astarte_trigger_engine_web_test.exs
+++ b/apps/astarte_trigger_engine/test/astarte_trigger_engine_web_test.exs
@@ -25,9 +25,7 @@ defmodule Astarte.TriggerEngineWebTest do
   test "/health returns ok if astarte is working correctly" do
     conn = get("/health")
 
-    # FIXME: remove commented out assertion when health check works again
-    _ = conn
-    # assert conn.status == 200
+    assert conn.status == 200
   end
 
   test "/metrics return prometheus metrics" do

--- a/apps/astarte_trigger_engine/test/support/helpers/database.ex
+++ b/apps/astarte_trigger_engine/test/support/helpers/database.ex
@@ -34,6 +34,7 @@ defmodule Astarte.Helpers.Database do
   @create_realms_table """
   CREATE TABLE :keyspace.realms (
     realm_name varchar,
+    device_registration_limit bigint,
 
     PRIMARY KEY (realm_name)
   );  


### PR DESCRIPTION
add `device_registration_limit` realm field to the database schema so that the query for the health check doesn't crash

this field was actually introduced in astarte 1.2 but not documented

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [X] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
