### PR TITLE
test(RM API): Fix test flakiness by ensure JWT public key is set

### DIFF
--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/device_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/device_controller_test.exs
@@ -28,6 +28,7 @@ defmodule Astarte.RealmManagement.APIWeb.DeviceControllerTest do
 
   setup %{conn: conn} do
     DB.create_device(@realm, @device_id)
+    DB.put_jwt_public_key_pem(@realm, JWTTestHelper.public_key_pem())
     token = JWTTestHelper.gen_jwt_all_access_token()
 
     conn =


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Add a call to `DB.put_jwt_public_key_pem/2` in the test `setup` block to explicitly register the JWT public key for the test realm. Previously, the absence of a public key caused `:jose_jwk.from_pem/1` to raise a `FunctionClauseError` due to receiving `nil`. This happened because `VerifyHeader.get_secret/1` attempted to fetch the public key but found none, leading to failing controller tests involving authenticated requests.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No


