### PR TITLE
test(RM API): Expand and refactor trigger actions testing 

### DIFF
--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/trigger.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/trigger.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018-2020 Ispirata Srl
+# Copyright 2018 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -43,7 +43,12 @@ defmodule Astarte.RealmManagement.API.Triggers.Trigger do
     |> validate_required([:name])
     |> validate_length(:policy, max: 128)
     |> validate_format(:policy, policy_name_regex())
-    |> cast_embed(:amqp_action, required: false, with: {AMQPAction, :changeset, [opts]})
+    |> cast_embed(:amqp_action,
+      required: false,
+      with: fn amqp_action, params ->
+        AMQPAction.changeset(amqp_action, params, opts)
+      end
+    )
     |> cast_embed(:http_action, required: false)
     |> cast_embed(:simple_triggers, required: true)
     |> normalize()

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/action_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/action_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2023 SECO Mind Srl
+# Copyright 2023 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,11 @@
 
 defmodule Astarte.RealmManagement.API.Triggers.ActionTest do
   use ExUnit.Case
+
+  @moduletag :trigger_actions
+
   alias Astarte.RealmManagement.API.Triggers.Action
+  alias Astarte.RealmManagement.API.Triggers.Trigger
 
   describe "well-formed HTTP action is correctly encoded" do
     test "when headers are set" do
@@ -117,5 +121,14 @@ defmodule Astarte.RealmManagement.API.Triggers.ActionTest do
                }
              }
     end
+  end
+
+  test "does nothing with unknown action fields" do
+    action = %{foo: "bar"}
+    input = %{name: "test", policy: "ok", action: action}
+
+    updated = Trigger.move_action(input)
+    refute Map.has_key?(updated, :amqp_action)
+    refute Map.has_key?(updated, :http_action)
   end
 end

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/http_action_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/http_action_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2020 Ispirata Srl
+# Copyright 2020 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,7 +18,11 @@
 
 defmodule Astarte.RealmManagement.API.Triggers.HttpActionTest do
   use ExUnit.Case
+
+  @moduletag :trigger_actions
+
   alias Astarte.RealmManagement.API.Triggers.HttpAction
+  alias Astarte.RealmManagement.API.Triggers.Trigger
   alias Ecto.Changeset
 
   test "HttpAction is invalid when both http_post_url and http_url are set" do
@@ -226,5 +230,41 @@ defmodule Astarte.RealmManagement.API.Triggers.HttpActionTest do
               http_method: "get",
               ignore_ssl_errors: true
             }} = out
+  end
+
+  test "headers over the max size are rejected" do
+    value = String.duplicate("a", 2048)
+    headers = Enum.into(1..40, %{}, &{Integer.to_string(&1), value})
+
+    input = %{
+      "http_url" => "http://example.com/",
+      "http_method" => "put",
+      "http_static_headers" => headers
+    }
+
+    changeset = HttpAction.changeset(%HttpAction{}, input)
+
+    refute changeset.valid?
+
+    assert {"headers total size must be lower than 8192", _} =
+             Keyword.get(changeset.errors, :http_static_headers)
+  end
+
+  test "recognizes atom keys for HTTP POST action" do
+    action = %{http_post_url: "https://example.com"}
+    input = %{name: "test", policy: "ok", action: action}
+
+    updated = Trigger.move_action(input)
+    assert Map.has_key?(updated, :http_action)
+    assert updated[:http_action] == action
+  end
+
+  test "recognizes atom keys for HTTP action" do
+    action = %{http_url: "https://example.com"}
+    input = %{name: "test", policy: "ok", action: action}
+
+    updated = Trigger.move_action(input)
+    assert Map.has_key?(updated, :http_action)
+    assert updated[:http_action] == action
   end
 end

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/trigger_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/triggers/trigger_test.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2020 Ispirata Srl
+# Copyright 2020 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@
 
 defmodule Astarte.RealmManagement.API.Triggers.TriggerTest do
   use ExUnit.Case
+
+  @moduletag :trigger_actions
+
   alias Astarte.Core.Triggers.SimpleTriggerConfig
   alias Astarte.RealmManagement.API.Triggers.Trigger
-  alias Astarte.RealmManagement.API.Triggers.AMQPAction
-  alias Astarte.RealmManagement.API.Triggers.HttpAction
   alias Astarte.RealmManagement.API.Triggers.Action
   alias Ecto.Changeset
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

- Replaced the deprecated MFA (`{Module, :function, args}`) in the `:with` option of `cast_embed/3` for the `:amqp_action` field with an anonymous function, as recommended by Ecto 3.12.5.
- Fix extension mistake in `amqp_action_test.ex` file as it was not being executed since it was named with `.ex` extension instead of `.exs`
- Add amqp and http header size tests, with default and custom error messages
- Add tests for recognizing atom keys not just string keys
- Remove unused aliases
- Add module tags

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

