### PR TITLE
fix(ae): properly declare needed exchanges

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -119,13 +119,6 @@ jobs:
     - name: Check formatting
       working-directory: ./apps/${{ inputs.app }}
       run: mix format --check-formatted
-    - name: Setup Events Exchange
-      if: inputs.app == 'astarte_appengine_api'
-      run: |
-        wget http://guest:guest@localhost:15672/cli/rabbitmqadmin -O rabbitmqadmin
-        chmod +x ./rabbitmqadmin
-        ./rabbitmqadmin declare exchange name=astarte_events type=direct
-        rm rabbitmqadmin
     - name: Compile
       working-directory: ./apps/${{ inputs.app }}
       run: mix compile --warning-as-errors --force

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/amqp_client.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/amqp_client.ex
@@ -148,6 +148,8 @@ defmodule Astarte.AppEngine.API.Rooms.AMQPClient do
          :ok <- Basic.qos(chan, prefetch_count: @prefetch_count),
          :ok <-
            Exchange.declare(chan, Config.rooms_events_routing_key!(), :direct, durable: true),
+         :ok <-
+           Exchange.declare(chan, Config.events_exchange_name!(), :direct, durable: true),
          {:ok, _queue} <- Queue.declare(chan, Config.rooms_events_queue_name!(), durable: true),
          :ok <-
            Queue.bind(


### PR DESCRIPTION
AMQPClient needs an exchange `events_exchange_name` to be declared, otherwise the queue binding fails and the whole application fails to start.

this was mitigated in CI with a custom exchange declaration and in production by having DUP or TE declare this exchange for AE before it could start successfully.

while for queues it's documented (eg [here](https://www.rabbitmq.com/tutorials/amqp-concepts#queues)) that "The declaration will have no effect if the queue does already exist and its attributes are the same as those in the declaration", this appears to be never explicitly stated to also be the case for exchanges.

however, in astarte we're already declaring this exchange twice:
- once in [trigger engine](https://github.com/astarte-platform/astarte/blob/d5ed3c0a6c1af3b620a436ae506462c756537f6d/apps/astarte_trigger_engine/lib/astarte_trigger_engine/amqp_consumer/amqp_message_consumer.ex#L171)
- once in [data updater plant](https://github.com/astarte-platform/astarte/blob/d5ed3c0a6c1af3b620a436ae506462c756537f6d/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_events_producer.ex#L120)

if it has not caused us problems thus far, it should also work as expected declaring it a third time

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->


#### Special notes for your reviewer:

Pr tested by manually starting hk+ae before other services.
AE was able to become healthy after the astarte keyspace was created by hk.

after that, the remaining services were started and a test with astarte in 5 minutes was performed, and everything seemed to be working correctly

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
