### PR TITLE
fix: update CI to use pull_request_target event

### DIFF
--- a/.github/workflows/pr-size-based-label.yaml
+++ b/.github/workflows/pr-size-based-label.yaml
@@ -1,8 +1,6 @@
 name: PR Size Bot
 
-on:
-  pull_request:
-    types: [opened, synchronize]
+on: pull_request_target
 
 jobs:
   pr-size-labeler:


### PR DESCRIPTION
With the `pull_request` event trigger the CI used to label the PR based on the size was running but not applying the label.
After looking at similar issues, the solution seems to switch to `pull_request_target` event trigger.

See https://github.com/actions/labeler/issues/399#issuecomment-1357785473

