### PR TITLE
Hk new migrator tests 

### DIFF
--- a/apps/astarte_housekeeping/priv/migrations/astarte/0001_drop_astarte_schema_table.sql
+++ b/apps/astarte_housekeeping/priv/migrations/astarte/0001_drop_astarte_schema_table.sql
@@ -1,1 +1,1 @@
-DROP TABLE astarte_schema;
+DROP TABLE if exists astarte_schema;

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
@@ -20,32 +20,110 @@ defmodule Astarte.Housekeeping.MigratorTest do
   use ExUnit.Case
 
   alias Astarte.Housekeeping.Migrator
+  alias Astarte.Housekeeping.Engine
+  alias Astarte.Housekeeping.Queries
+  alias Astarte.Housekeeping.Helpers.Database
+  use Mimic
 
-  # This test ensures that we're not skipping versions when creating a new astarte migration
-  test "latest astarte schema version is consistent with migrations" do
-    astarte_migrations_path =
-      Application.app_dir(:astarte_housekeeping, Path.join(["priv", "migrations", "astarte"]))
+  describe "run migrations, " do
+    setup do
+      on_exit(fn ->
+        Database.destroy_test_astarte_keyspace!(:xandra)
+      end)
 
-    # We don't specify the .sql extension so we also check if there are migrations with the wrong extension
-    astarte_migrations_count =
-      Path.join([astarte_migrations_path, "*"])
-      |> Path.wildcard()
-      |> Enum.count()
+      Queries.initialize_database()
+      Database.edit_with_outdated_column_for_astarte_realms_table!(:xandra)
+      :ok
+    end
 
-    assert Migrator.latest_astarte_schema_version() == astarte_migrations_count
+    test "returns ok with complete db" do
+      assert :ok = Migrator.run_astarte_keyspace_migrations()
+    end
+
+    test "returns ok with incomplete db (missing kv_store table)" do
+      Database.destroy_astarte_kv_store_table!(:xandra)
+
+      assert :ok = Migrator.run_astarte_keyspace_migrations()
+    end
+
+    test "returns error due do xandra problem" do
+      Xandra |> stub(:execute, fn _, _, _, _ -> {:error, %Xandra.Error{}} end)
+
+      assert {:error, :database_error} = Migrator.run_astarte_keyspace_migrations()
+    end
+
+    test "returns error due do xandra connection problem" do
+      Xandra |> stub(:execute, fn _, _, _, _ -> {:error, %Xandra.ConnectionError{}} end)
+
+      assert {:error, :database_connection_error} = Migrator.run_astarte_keyspace_migrations()
+    end
   end
 
-  # This test ensures that we're not skipping versions when creating a new realm migration
-  test "latest realm schema version is consistent with migrations" do
-    realm_migrations_path =
-      Application.app_dir(:astarte_housekeeping, Path.join(["priv", "migrations", "realm"]))
+  describe "run realms migrations, " do
+    setup do
+      realm_name = Astarte.Core.Generators.Realm.realm_name() |> Enum.at(0)
 
-    # We don't specify the .sql extension so we also check if there are migrations with the wrong extension
-    realm_migrations_count =
-      Path.join([realm_migrations_path, "*.sql"])
-      |> Path.wildcard()
-      |> Enum.count()
+      on_exit(fn ->
+        Database.destroy_test_astarte_keyspace!(:xandra)
+        Database.destroy_test_keyspace!(:xandra, realm_name)
+      end)
 
-    assert Migrator.latest_realm_schema_version() == realm_migrations_count
+      Queries.initialize_database()
+      :ok = Engine.create_realm(realm_name, "test1publickey", 1, 1, 1, [])
+      Database.edit_with_outdated_column_for_astarte_realms_table!(:xandra)
+      :ok
+    end
+
+    test "returns ok with complete db" do
+      assert :ok = Migrator.run_realms_migrations()
+    end
+
+    test "returns ok with incomplete db (missing kv_store table)" do
+      Database.destroy_astarte_kv_store_table!(:xandra)
+
+      assert :ok = Migrator.run_realms_migrations()
+    end
+
+    test "returns error due do xandra problem" do
+      Xandra |> stub(:execute, fn _, _, _, _ -> {:error, %Xandra.Error{}} end)
+
+      assert {:error, :database_error} = Migrator.run_realms_migrations()
+    end
+
+    test "returns error due do xandra connection problem" do
+      Xandra |> stub(:execute, fn _, _, _, _ -> {:error, %Xandra.ConnectionError{}} end)
+
+      assert {:error, :database_connection_error} = Migrator.run_realms_migrations()
+    end
+  end
+
+  describe "latest schema version is consistent with migrations, " do
+    # This test ensures that we're not skipping versions when creating a new astarte migration
+    test "for astarte" do
+      astarte_migrations_path =
+        Application.app_dir(:astarte_housekeeping, Path.join(["priv", "migrations", "astarte"]))
+
+      # We don't specify the .sql extension so we also check if there are migrations with the wrong extension
+      astarte_migrations_count =
+        Path.join([astarte_migrations_path, "*"])
+        |> Path.wildcard()
+        |> Enum.count()
+
+      assert Migrator.latest_astarte_schema_version() == astarte_migrations_count
+    end
+
+    # This test ensures that we're not skipping versions when creating a new realm migration
+    test "for realms" do
+      realm_migrations_path =
+        Application.app_dir(:astarte_housekeeping, Path.join(["priv", "migrations", "realm"]))
+
+      # We don't specify the .sql extension so we also check if there are migrations with the wrong extension
+      realm_migrations_count =
+        Path.join([realm_migrations_path, "*.sql"])
+        |> Path.wildcard()
+        |> Enum.count()
+
+      assert Migrator.latest_realm_schema_version() == realm_migrations_count
+    end
   end
 end

--- a/apps/astarte_housekeeping/test/helpers/db_test_helper.ex
+++ b/apps/astarte_housekeeping/test/helpers/db_test_helper.ex
@@ -359,6 +359,12 @@ defmodule Astarte.Housekeeping.Helpers.Database do
     PRIMARY KEY (realm_name)
   );
   """
+  @add_replication_factor_column_for_realms_table """
+  ALTER TABLE :keyspace.realms ADD replication_factor varchar;
+  """
+  @drop_device_registration_limit_column_for_realms_table """
+  ALTER TABLE :keyspace.realms DROP device_registration_limit;
+  """
 
   @create_kv_store """
   CREATE TABLE :keyspace.kv_store (
@@ -368,6 +374,9 @@ defmodule Astarte.Housekeeping.Helpers.Database do
 
     PRIMARY KEY ((group), key)
   )
+  """
+  @drop_kv_store """
+  DROP TABLE if exists :keyspace.kv_store
   """
 
   @create_names_table """
@@ -573,6 +582,52 @@ defmodule Astarte.Housekeeping.Helpers.Database do
   def destroy_test_astarte_keyspace!(cluster) do
     keyspace = Realm.astarte_keyspace_name()
     Xandra.Cluster.execute!(cluster, String.replace(@drop_keyspace, ":keyspace", keyspace))
+  end
+
+  def destroy_kv_store_table!(cluster, keyspace) do
+    keyspace = Realm.keyspace_name(keyspace)
+    Xandra.Cluster.execute!(cluster, String.replace(@drop_keyspace, ":keyspace", keyspace))
+  end
+
+  def destroy_astarte_kv_store_table!(cluster) do
+    keyspace = Realm.astarte_keyspace_name()
+    Xandra.Cluster.execute!(cluster, String.replace(@drop_kv_store, ":keyspace", keyspace))
+  end
+
+  def edit_with_outdated_column_for_realms_table!(cluster, keyspace) do
+    keyspace = Realm.keyspace_name(keyspace)
+
+    Xandra.Cluster.execute!(
+      cluster,
+      String.replace(@add_replication_factor_column_for_realms_table, ":keyspace", keyspace)
+    )
+
+    Xandra.Cluster.execute!(
+      cluster,
+      String.replace(
+        @drop_device_registration_limit_column_for_realms_table,
+        ":keyspace",
+        keyspace
+      )
+    )
+  end
+
+  def edit_with_outdated_column_for_astarte_realms_table!(cluster) do
+    keyspace = Realm.astarte_keyspace_name()
+
+    Xandra.Cluster.execute!(
+      cluster,
+      String.replace(@add_replication_factor_column_for_realms_table, ":keyspace", keyspace)
+    )
+
+    Xandra.Cluster.execute!(
+      cluster,
+      String.replace(
+        @drop_device_registration_limit_column_for_realms_table,
+        ":keyspace",
+        keyspace
+      )
+    )
   end
 
   ###


### PR DESCRIPTION
Rationalize and expand migrator test
Edit test helper with new functions (83.7% coverage for the file)
Edit existing migration file to ensure process does not crash on unexpected db version