### PR TITLE
HK remove helper files from test coverage

### DIFF
--- a/apps/astarte_housekeeping/coveralls.json
+++ b/apps/astarte_housekeeping/coveralls.json
@@ -8,7 +8,11 @@
 
   "custom_stop_words": [
   ],
-
+  "skip_files": [
+    "test/helpers",
+    "test/support",
+    "lib/astarte_housekeeping/release_tasks.ex"
+  ],
   "coverage_options": {
     "treat_no_relevant_lines_as_covered": true,
     "output_dir": "cover/"


### PR DESCRIPTION
remove helper files from test coverage
remove also release_task because it's only a wrapper for queries and migrator