### PR TITLE
fix(RM): avoid crashing on interface list

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -741,7 +741,10 @@ defmodule Astarte.RealmManagement.Queries do
 
     consistency = Consistency.domain_model(:read)
 
-    Repo.fetch_all(query, prefix: keyspace, consistency: consistency)
+    with result when is_list(result) <-
+           Repo.fetch_all(query, prefix: keyspace, consistency: consistency) do
+      {:ok, result}
+    end
   end
 
   def has_interface_simple_triggers?(realm_name, object_id) do

--- a/apps/astarte_realm_management/test/astarte_realm_management/interfaces_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/interfaces_test.exs
@@ -75,7 +75,7 @@ defmodule Astarte.RealmManagement.InterfacesTest do
         assert {:error, :forbidden} =
                  Engine.delete_interface(realm, interface.name, interface.major_version)
 
-        interfaces = Engine.get_interfaces_list(realm)
+        {:ok, interfaces} = Engine.get_interfaces_list(realm)
         assert interface.name in interfaces
       end
     end
@@ -88,7 +88,7 @@ defmodule Astarte.RealmManagement.InterfacesTest do
         _ = Engine.install_interface(realm, json_interface)
 
         assert :ok = Engine.delete_interface(realm, interface.name, interface.major_version)
-        interfaces = Engine.get_interfaces_list(realm)
+        {:ok, interfaces} = Engine.get_interfaces_list(realm)
         refute interface.name in interfaces
       end
     end


### PR DESCRIPTION
Fixes the usage of an old behavior of `Repo.fetch_all` causing a crash each time a user requested the listing of all available interfaces.