### PR TITLE
fix: make `unset_property` work

### DIFF
--- a/apps/astarte_appengine_api/coveralls.json
+++ b/apps/astarte_appengine_api/coveralls.json
@@ -1,0 +1,7 @@
+{
+    "skip_files": [
+        "test",
+        "deps",
+        "_build"
+    ]
+}

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/fallback_controller.ex
@@ -205,6 +205,13 @@ defmodule Astarte.AppEngine.APIWeb.FallbackController do
     |> render(:"422_unexpected_object_key")
   end
 
+  def call(conn, {:error, :unset_not_allowed}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(Astarte.AppEngine.APIWeb.ErrorView)
+    |> render(:"422_unset_not_allowed")
+  end
+
   # This is called when no JWT token is present
   def auth_error(conn, {:unauthenticated, reason}, _opts) do
     _ =

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/views/error_view.ex
@@ -82,6 +82,10 @@ defmodule Astarte.AppEngine.APIWeb.ErrorView do
     %{errors: %{detail: "Alias already in use"}}
   end
 
+  def render("422_unset_not_allowed.json", _assigns) do
+    %{errors: %{detail: "Unset not allowed"}}
+  end
+
   def render("422_alias_tag_not_found.json", _assigns) do
     %{errors: %{detail: "Alias tag not found"}}
   end

--- a/apps/astarte_appengine_api/test/support/cases/device.ex
+++ b/apps/astarte_appengine_api/test/support/cases/device.ex
@@ -154,6 +154,10 @@ defmodule Astarte.Cases.Device do
     other_interfaces = list_of(InterfaceGenerator.interface()) |> Enum.at(0)
     properties_device = list_of(properties(:device), min_length: 1) |> Enum.at(0)
     properties_server = list_of(properties(:server), min_length: 1) |> Enum.at(0)
+
+    properties_server_allow_unset =
+      list_of(properties(:server, true), min_length: 1) |> Enum.at(0)
+
     fallible_interfaces = list_of(fallible(:server), min_length: 1) |> Enum.at(0)
     individual_downsampable = list_of(individual_downsampable(), min_length: 1) |> Enum.at(0)
     object_downsampable = list_of(object_downsampable(), min_length: 1) |> Enum.at(0)
@@ -169,7 +173,8 @@ defmodule Astarte.Cases.Device do
         properties_server,
         fallible_interfaces,
         individual_downsampable,
-        object_downsampable
+        object_downsampable,
+        properties_server_allow_unset
       ]
       |> Enum.concat()
 
@@ -214,7 +219,11 @@ defmodule Astarte.Cases.Device do
     )
   end
 
-  defp properties(ownership) do
-    InterfaceGenerator.interface(ownership: ownership, type: :properties)
+  defp properties(ownership, allow_unset \\ nil) do
+    InterfaceGenerator.interface(
+      ownership: ownership,
+      type: :properties,
+      allow_unset: allow_unset
+    )
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -94,18 +94,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
         device_id,
         %InterfaceDescriptor{storage_type: :multi_interface_individual_properties_dbtable} =
           interface_descriptor,
-        mapping,
+        %Mapping{allow_unset: true} = mapping,
         path,
         nil,
         _value_timestamp,
         _reception_timestamp,
         opts
       ) do
-    if mapping.allow_unset == false do
-      Logger.warning("Tried to unset value on allow_unset=false mapping.")
-      # TODO: should we handle this situation?
-    end
-
     %InterfaceDescriptor{storage: storage, interface_id: interface_id} = interface_descriptor
     %Mapping{endpoint_id: endpoint_id} = mapping
     keyspace = Realm.keyspace_name(realm)
@@ -114,6 +109,27 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
       remove_property_row(keyspace, storage, device_id, interface_id, endpoint_id, path, opts)
 
     :ok
+  end
+
+  def insert_value_into_db(
+        realm,
+        device_id,
+        %InterfaceDescriptor{storage_type: :multi_interface_individual_properties_dbtable} =
+          _interface_descriptor,
+        _mapping,
+        _path,
+        nil,
+        _value_timestamp,
+        _reception_timestamp,
+        _opts
+      ) do
+    _ =
+      Logger.warning(
+        "Device #{inspect(device_id)} in realm #{realm} tried to unset an unsettable property.",
+        tag: :unset_not_allowed
+      )
+
+    {:error, :unset_not_allowed}
   end
 
   def insert_value_into_db(

--- a/apps/astarte_data_updater_plant/test/support/database_test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/support/database_test_helper.exs
@@ -152,7 +152,7 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
     """,
     """
       INSERT INTO #{Realm.keyspace_name(@test_realm)}.endpoints (interface_id, endpoint_id, allow_unset, endpoint, expiry, interface_major_version, interface_minor_version, interface_name, interface_type, reliability, retention, value_type) VALUES
-        (798b93a5-842e-bbad-2e4d-d20306838051, 801e1035-5fdf-7069-8e6e-3fd2792699ab, False, '/weekSchedule/%{day}/start', 0, 0, 3, 'com.test.LCDMonitor', 1, 1, 1, 5);
+        (798b93a5-842e-bbad-2e4d-d20306838051, 801e1035-5fdf-7069-8e6e-3fd2792699ab, True, '/weekSchedule/%{day}/start', 0, 0, 3, 'com.test.LCDMonitor', 1, 1, 1, 5);
     """,
     """
       INSERT INTO #{Realm.keyspace_name(@test_realm)}.endpoints (interface_id, endpoint_id, allow_unset, endpoint, expiry, interface_major_version, interface_minor_version, interface_name, interface_type, reliability, retention, value_type) VALUES


### PR DESCRIPTION
Astarte documentation reports an optional field of properties interfaces called `allow_unset`.This field should allow or forbid for interface value unset.
Up to now this field was not checked, and interfaces with `allow_unset: false` or `allow_unset: nil` were able to unset such properties.

This PR introduces such checks both in server owned interfaces (trough appengine) and in device owned interfaces (trough data updater plant).

Tests in both services are also added/edited accordingly:
- In appengine a deletion property is checked:  when unsetting properties with `allow_uset: true` the API should return `204` (no content) as HTML code. Instead, when `allow_unset` is `false` the server should answer with a `400` status code (bad request)
- In DUP the old _happy path_ test is updated to allow to unset the property of the `com.test.LCDMonitor` test interface