### PR TITLE
chore(HK API): Remove unused `realm_exists?` function

### DIFF
--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2023 SECO Mind Srl
+# Copyright 2017 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
     Call,
     CreateRealm,
     DeleteRealm,
-    DoesRealmExist,
-    DoesRealmExistReply,
     GenericErrorReply,
     GenericOkReply,
     GetHealth,
@@ -154,14 +152,6 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
     |> extract_reply()
   end
 
-  def realm_exists?(realm_name) do
-    %DoesRealmExist{realm: realm_name}
-    |> encode_call(:does_realm_exist)
-    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
-    |> decode_reply()
-    |> extract_reply()
-  end
-
   defp encode_call(call, callname) do
     %Call{call: {callname, call}}
     |> Call.encode()
@@ -170,10 +160,6 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
   defp decode_reply({:ok, encoded_reply}) when is_binary(encoded_reply) do
     %Reply{reply: reply} = Reply.decode(encoded_reply)
     reply
-  end
-
-  defp extract_reply({:does_realm_exist_reply, %DoesRealmExistReply{exists: exists}}) do
-    exists
   end
 
   defp extract_reply({:get_realms_list_reply, %GetRealmsListReply{realms_names: realms_list}}) do

--- a/apps/astarte_housekeeping_api/test/support/helpers/astarte_housekeeping_mock.ex
+++ b/apps/astarte_housekeeping_api/test/support/helpers/astarte_housekeeping_mock.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2025 SECO Mind Srl
+# Copyright 2017 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,8 +21,6 @@ defmodule Astarte.Housekeeping.Mock do
     Call,
     CreateRealm,
     DeleteRealm,
-    DoesRealmExist,
-    DoesRealmExistReply,
     GenericErrorReply,
     GenericOkReply,
     GetRealm,
@@ -150,14 +148,6 @@ defmodule Astarte.Housekeeping.Mock do
 
     %GenericOkReply{async_operation: async}
     |> encode_reply(:generic_ok_reply)
-    |> ok_wrap
-  end
-
-  defp execute_rpc({:does_realm_exist, %DoesRealmExist{realm: realm}}) do
-    exists = Astarte.Housekeeping.Mock.DB.realm_exists?(realm)
-
-    %DoesRealmExistReply{exists: exists}
-    |> encode_reply(:does_realm_exist_reply)
     |> ok_wrap
   end
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

The `realm_exists?` function is not used anywhere in the codebase and has been removed to reduce clutter and improve maintainability. This change has no effect on functionality and is purely a cleanup.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

