### PR TITLE
test(appengine): add `populate_interface` function

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -189,13 +189,14 @@ defmodule Astarte.AppEngine.API.Device do
     end
   end
 
-  defp update_individual_interface_values(
-         realm_name,
-         device_id,
-         interface_descriptor,
-         path,
-         raw_value
-       ) do
+  @doc false
+  def update_individual_interface_values(
+        realm_name,
+        device_id,
+        interface_descriptor,
+        path,
+        raw_value
+      ) do
     with {:ok, [endpoint_id]} <- get_endpoint_ids(interface_descriptor.automaton, path),
          mapping =
            Queries.retrieve_mapping(realm_name, interface_descriptor.interface_id, endpoint_id),
@@ -361,13 +362,14 @@ defmodule Astarte.AppEngine.API.Device do
     end
   end
 
-  defp update_object_interface_values(
-         realm_name,
-         device_id,
-         interface_descriptor,
-         path,
-         raw_value
-       ) do
+  @doc false
+  def update_object_interface_values(
+        realm_name,
+        device_id,
+        interface_descriptor,
+        path,
+        raw_value
+      ) do
     now = DateTime.utc_now()
 
     with {:ok, mappings} <-

--- a/apps/astarte_appengine_api/test/support/cases/device.ex
+++ b/apps/astarte_appengine_api/test/support/cases/device.ex
@@ -19,10 +19,19 @@
 defmodule Astarte.Cases.Device do
   alias Astarte.Core.Generators.Device, as: DeviceGenerator
   alias Astarte.Core.Generators.Interface, as: InterfaceGenerator
+  alias Astarte.DataAccess.Interface
+
   use ExUnit.CaseTemplate
   use ExUnitProperties
 
   import Astarte.Helpers.Device
+  import Astarte.InterfaceUpdateGenerators
+
+  using do
+    quote do
+      import unquote(__MODULE__)
+    end
+  end
 
   setup_all %{realm_name: realm_name} do
     interfaces = interfaces_for_update()
@@ -32,6 +41,73 @@ defmodule Astarte.Cases.Device do
     Enum.each(interfaces, &insert_interface_cleanly(realm_name, &1))
 
     %{interfaces: interfaces, device: device}
+  end
+
+  def populate_interfaces(context) do
+    %{realm_name: realm_name, interfaces: interfaces, device: device} = context
+
+    random_interfaces =
+      Enum.group_by(interfaces, fn interface ->
+        {interface.type, interface.ownership, interface.aggregation}
+      end)
+      |> Map.new(fn {key, values} -> {key, Enum.random(values)} end)
+
+    individual_datastream_device =
+      Map.fetch!(random_interfaces, {:datastream, :device, :individual})
+
+    individual_datastream_server =
+      Map.fetch!(random_interfaces, {:datastream, :server, :individual})
+
+    object_datastream_device = Map.fetch!(random_interfaces, {:datastream, :device, :object})
+    object_datastream_server = Map.fetch!(random_interfaces, {:datastream, :server, :object})
+
+    individual_properties_device =
+      Map.fetch!(random_interfaces, {:properties, :device, :individual})
+
+    individual_properties_server =
+      Map.fetch!(random_interfaces, {:properties, :server, :individual})
+
+    interfaces_with_data =
+      [
+        individual_datastream_device,
+        individual_datastream_server,
+        object_datastream_device,
+        object_datastream_server,
+        individual_properties_device,
+        individual_properties_server
+      ]
+
+    registered_paths =
+      for interface <- interfaces_with_data, into: %{} do
+        inserted_paths = populate(realm_name, device.device_id, interface)
+        interface_key = {interface.name, interface.major_version}
+
+        {interface_key, inserted_paths}
+      end
+
+    %{
+      registered_paths: registered_paths,
+      interfaces_with_data: interfaces_with_data,
+      individual_datastream_device_interface: individual_datastream_device,
+      individual_datastream_server_interface: individual_datastream_server,
+      object_datastream_device_interface: object_datastream_device,
+      object_datastream_server_interface: object_datastream_server,
+      individual_properties_device_interface: individual_properties_device,
+      individual_properties_server_interface: individual_properties_server
+    }
+  end
+
+  defp populate(realm_name, device_id, interface) do
+    {:ok, descriptor} =
+      Interface.fetch_interface_descriptor(realm_name, interface.name, interface.major_version)
+
+    values =
+      list_of(valid_mapping_update_for(interface), length: 100..10_000)
+      |> Enum.at(0)
+
+    insert_values(realm_name, device_id, descriptor, values)
+
+    MapSet.new(values, & &1.path)
   end
 
   defp interfaces_for_update do

--- a/apps/astarte_appengine_api/test/test_helper.exs
+++ b/apps/astarte_appengine_api/test/test_helper.exs
@@ -1,4 +1,5 @@
 Mimic.copy(Astarte.DataAccess.Config)
 Mimic.copy(Astarte.AppEngine.API.Device)
+Mimic.copy(DateTime)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
this adds a function to the Device case which is used to pre-populate the database with random data for a random interface of each type

the chosen interfaces are then exposed in the context so they can be accessed by tests to verify the data.

to use this function, add `setup_all :populate_interfaces` in a module which `use`s `Cases.Device`

update values functions from Device had to be made public to avoid duplicating the code, as the pre-existing public interface would only allow server owned values to be inserted

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
