### PR TITLE
test(AE): test for optional `keep_milliseconds` parameter

### DIFF
--- a/apps/astarte_appengine_api/test/test_helper.exs
+++ b/apps/astarte_appengine_api/test/test_helper.exs
@@ -1,4 +1,5 @@
 Mimic.copy(Astarte.DataAccess.Config)
 Mimic.copy(Astarte.AppEngine.API.Device)
+Mimic.copy(DateTime)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
Adds tests for interface update and retrieval with optional `keep_milliseconds` parameter
