### PR TITLE
test(appengine): add downsampling to interface value options gen

### DIFF
--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_v2_reading_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_v2_reading_test.exs
@@ -125,7 +125,7 @@ defmodule Astarte.AppEngine.API.Device.DeviceV2ReadingTest do
               lower_limit <- optional(timestamp_at_least(timings.initial_time)),
               to <- optional(timestamp_at_most(timings.last_time)),
               params = [{since_or_after, lower_limit}, to: to],
-              opts <- interface_values_options(params) do
+              opts <- interface_values_options(params, interface) do
       result =
         Device.get_interface_values!(
           realm_name,

--- a/apps/astarte_appengine_api/test/support/helpers/database.ex
+++ b/apps/astarte_appengine_api/test/support/helpers/database.ex
@@ -143,11 +143,6 @@ defmodule Astarte.Helpers.Database do
   );
   """
 
-  @insert_pubkey_pem """
-    INSERT INTO #{Realm.keyspace_name(@test_realm)}.kv_store (group, key, value)
-    VALUES ('auth', 'jwt_public_key_pem', varcharAsBlob(:pem));
-  """
-
   @create_interfaces_table """
       CREATE TABLE #{Realm.keyspace_name(@test_realm)}.interfaces (
         name ascii,

--- a/apps/astarte_appengine_api/test/support/helpers/database_v2.ex
+++ b/apps/astarte_appengine_api/test/support/helpers/database_v2.ex
@@ -18,7 +18,6 @@
 
 defmodule Astarte.Helpers.DatabaseV2 do
   alias Astarte.Core.Realm
-  alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Repo
   alias Astarte.DataAccess.Realms.Realm
 

--- a/apps/astarte_appengine_api/test/support/interface_values_retrieveal_generators.ex
+++ b/apps/astarte_appengine_api/test/support/interface_values_retrieveal_generators.ex
@@ -10,7 +10,7 @@ defmodule Astarte.InterfaceValuesRetrievealGenerators do
     params gen all since <- nil,
                    since_after <- nil,
                    to <- nil,
-                   limit <- optional(integer(0..1000)),
+                   limit <- optional(integer(1..1000)),
                    downsample_key <- nil,
                    downsample_to <- downsample_to(interface, downsample_key),
                    retrieve_metadata <- optional(boolean()),

--- a/apps/astarte_appengine_api/test/support/interface_values_retrieveal_generators.ex
+++ b/apps/astarte_appengine_api/test/support/interface_values_retrieveal_generators.ex
@@ -5,14 +5,14 @@ defmodule Astarte.InterfaceValuesRetrievealGenerators do
   Generate valid Astarte.AppEngine.API.Device.InterfaceValuesOptions.
   For the nature of 
   """
-  def interface_values_options(params \\ []) do
+  def interface_values_options(params \\ [], interface \\ nil) do
     # TODO: generate valid since, since_after, to values
     params gen all since <- nil,
                    since_after <- nil,
                    to <- nil,
                    limit <- optional(integer(0..1000)),
-                   downsample_to <- nil,
                    downsample_key <- nil,
+                   downsample_to <- downsample_to(interface, downsample_key),
                    retrieve_metadata <- optional(boolean()),
                    allow_bigintegers <- optional(boolean()),
                    allow_safe_bigintegers <- optional(boolean()),
@@ -39,4 +39,16 @@ defmodule Astarte.InterfaceValuesRetrievealGenerators do
 
   defp optional(gen), do: one_of([nil, gen])
   defp format, do: member_of(["structured", "table", "disjoint_tables"])
+  defp downsample_to, do: optional(integer(3..100))
+  defp downsample_to(nil = _interface, _), do: nil
+
+  defp downsample_to(interface, _downsample_key) when interface.aggregation == :individual do
+    if Astarte.Helpers.Device.downsampable?(interface), do: downsample_to()
+  end
+
+  defp downsample_to(interface, nil = _downsample_key) when interface.aggregation == :object,
+    do: nil
+
+  defp downsample_to(interface, _downsample_key) when interface.aggregation == :object,
+    do: downsample_to()
 end


### PR DESCRIPTION
allows downsampling options if:
- an individual interface is downsampable
- an object interface's downsample keys are overridden from params

the final step would be allowing all downsampable object interfaces
without overrides from params, but currently this would mean checking
that an object key does not contain any `nil` value.

this would become easier to implement if we implemented nil handling
in exlttb

remove warnings by dropping unused alias and module attribute

~~depends on #1271~~

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [X] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
