### PR TITLE
refactor(DUP): move time-based actions away from impl.ex and test them separately

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/interface.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/interface.ex
@@ -406,22 +406,4 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Interface do
         data_triggers: updated_triggers
     }
   end
-
-  def purge_expired_interfaces(state, timestamp) do
-    expired =
-      Enum.take_while(state.interfaces_by_expiry, fn {expiry, _interface} ->
-        expiry <= timestamp
-      end)
-
-    new_interfaces_by_expiry = Enum.drop(state.interfaces_by_expiry, length(expired))
-
-    interfaces_to_drop_list =
-      for {_exp, iface} <- expired do
-        iface
-      end
-
-    state
-    |> forget_interfaces(interfaces_to_drop_list)
-    |> Map.put(:interfaces_by_expiry, new_interfaces_by_expiry)
-  end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -1705,7 +1705,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     state
     |> Map.put(:last_seen_message, timestamp)
     |> TimeBasedActions.reload_groups_on_expiry(timestamp)
-    |> Core.Interface.purge_expired_interfaces(timestamp)
+    |> TimeBasedActions.purge_expired_interfaces(timestamp)
     |> reload_device_triggers_on_expiry(timestamp)
     |> reload_device_deletion_status_on_expiry(timestamp)
     |> reload_datastream_maximum_storage_retention_on_expiry(timestamp)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/time_based_actions.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/time_based_actions.ex
@@ -1,0 +1,34 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataUpdaterPlant.TimeBasedActions do
+  alias Astarte.DataUpdaterPlant.DataUpdater.Queries
+
+  @groups_lifespan_decimicroseconds 60 * 10 * 1000 * 10000
+
+  def reload_groups_on_expiry(state, timestamp) do
+    if state.last_groups_refresh + @groups_lifespan_decimicroseconds <= timestamp do
+      # TODO this could be a bang!
+      {:ok, groups} = Queries.get_device_groups(state.realm, state.device_id)
+
+      %{state | last_groups_refresh: timestamp, groups: groups}
+    else
+      state
+    end
+  end
+end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/time_based_actions_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/time_based_actions_test.exs
@@ -1,0 +1,179 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataUpdaterPlant.TimeBasedActionsTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.Core.Device
+  alias Astarte.DataUpdaterPlant.DataUpdater
+  alias Astarte.DataUpdaterPlant.TimeBasedActions
+  alias Astarte.Helpers.Database
+
+  @timestamp_us_x_10 Database.make_timestamp("2025-05-14T14:00:32+00:00")
+  @timestamp2_us_x_10 Database.make_timestamp("2025-05-14T14:10:32+00:00")
+
+  setup_all do
+    realm = "autotestrealm#{System.unique_integer([:positive])}"
+    Database.setup!(realm)
+    on_exit(fn -> Database.teardown!(realm) end)
+    {:ok, realm: realm}
+  end
+
+  setup %{realm: realm} do
+    device_id = Database.random_device_id()
+    encoded_device_id = Device.encode_device_id(device_id)
+    {:ok, device_id: device_id, encoded_device_id: encoded_device_id, realm: realm}
+  end
+
+  describe "reload_groups_on_expiry/2" do
+    test "refreshes groups when expired but groups are unchanged", %{
+      realm: realm,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      insert_opts = [groups: ["group1"]]
+      state = setup_device_state(realm, device_id, encoded_device_id, insert_opts)
+
+      assert state.groups == ["group1"]
+      assert state.last_groups_refresh == @timestamp_us_x_10
+
+      # Simulate expiration and refresh
+      new_state = TimeBasedActions.reload_groups_on_expiry(state, @timestamp2_us_x_10)
+
+      assert new_state.groups == ["group1"]
+      assert new_state.last_groups_refresh == @timestamp2_us_x_10
+    end
+
+    test "refreshes groups when expired and database groups have changed", %{
+      realm: realm,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      insert_opts = [groups: ["group1"]]
+      state = setup_device_state(realm, device_id, encoded_device_id, insert_opts)
+
+      assert state.groups == ["group1"]
+      assert state.last_groups_refresh == @timestamp_us_x_10
+
+      # Update groups in the database, simulate expiration and refresh
+      Database.update_device(device_id, realm, groups: ["group1", "group2"])
+      new_state = TimeBasedActions.reload_groups_on_expiry(state, @timestamp2_us_x_10)
+
+      assert new_state.groups == ["group1", "group2"]
+      assert new_state.last_groups_refresh == @timestamp2_us_x_10
+    end
+
+    test "refreshes groups with multiple updates in database", %{
+      realm: realm,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      insert_opts = [groups: ["group1"]]
+      state = setup_device_state(realm, device_id, encoded_device_id, insert_opts)
+
+      assert state.groups == ["group1"]
+      assert state.last_groups_refresh == @timestamp_us_x_10
+
+      # Update groups in the database, simulate expiration and refresh
+      Database.update_device(device_id, realm, groups: ["group2", "group3"])
+      new_state = TimeBasedActions.reload_groups_on_expiry(state, @timestamp2_us_x_10)
+
+      assert new_state.groups == ["group2", "group3"]
+      assert new_state.last_groups_refresh == @timestamp2_us_x_10
+    end
+
+    test "refreshes groups to empty when database groups are removed", %{
+      realm: realm,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      insert_opts = [groups: ["group1"]]
+      state = setup_device_state(realm, device_id, encoded_device_id, insert_opts)
+
+      assert state.groups == ["group1"]
+      assert state.last_groups_refresh == @timestamp_us_x_10
+
+      # Remove groups in the database, simulate expiration and refresh
+      Database.update_device(device_id, realm, groups: [])
+      new_state = TimeBasedActions.reload_groups_on_expiry(state, @timestamp2_us_x_10)
+
+      assert new_state.groups == []
+      assert new_state.last_groups_refresh == @timestamp2_us_x_10
+    end
+
+    test "does not refresh groups when not expired", %{
+      realm: realm,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      insert_opts = [groups: ["group1"]]
+      state = setup_device_state(realm, device_id, encoded_device_id, insert_opts)
+
+      assert state.groups == ["group1"]
+      assert state.last_groups_refresh == @timestamp_us_x_10
+
+      # Simulate no expiration
+      timestamp2_us_x_10 = Database.make_timestamp("2025-05-14T14:05:32+00:00")
+      new_state = TimeBasedActions.reload_groups_on_expiry(state, timestamp2_us_x_10)
+
+      assert new_state.groups == state.groups
+      assert new_state.last_groups_refresh == state.last_groups_refresh
+    end
+
+    test "does not refresh groups when timestamp equals last refresh", %{
+      realm: realm,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      insert_opts = [groups: ["group1"]]
+      state = setup_device_state(realm, device_id, encoded_device_id, insert_opts)
+
+      # Use the same timestamp, should not refresh
+      new_state = TimeBasedActions.reload_groups_on_expiry(state, @timestamp_us_x_10)
+
+      assert new_state.groups == state.groups
+      assert new_state.last_groups_refresh == state.last_groups_refresh
+    end
+  end
+
+  defp setup_device_state(
+         realm,
+         device_id,
+         encoded_device_id,
+         insert_opts,
+         timestamp \\ @timestamp_us_x_10
+       ) do
+    Database.insert_device(device_id, realm, insert_opts)
+
+    DataUpdater.handle_connection(
+      realm,
+      encoded_device_id,
+      "10.0.0.1",
+      Database.gen_tracking_id(),
+      timestamp
+    )
+
+    DataUpdater.dump_state(realm, encoded_device_id)
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Currently, `impl.ex` contains the `execute_time_based_actions/2` function which collects logic for refreshing device state. It is not tested. Therefore, the following functions should be moved to a different module, and each one tested in isolation:
- `reload_groups_on_expiry/2`
- `purge_expired_interfaces/2`
- `reload_device_triggers_on_expiry/2`
- `reload_device_deletion_status_on_expiry/2`
- `reload_datastream_maximum_storage_retention_on_expiry/2`



##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

