### PR TITLE
ci: remove old files

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,4 +1,0 @@
-coverage:
-  status:
-    project: off
-    patch: off


### PR DESCRIPTION
Old `codecov.yaml` file took precedence in codecov report generation and did not contain all the components definitions and new rules, this commit removes that file and uses the new `codecov.yml` file convention

For context: https://docs.codecov.com/docs/components
