### PR TITLE
ci: remove flags config

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -31,36 +31,36 @@ component_management:
     - component_id:  astarte_appengine_api
       name: AppEngine API
       paths:
-        - apps/astarte_appengine_api
+        - "apps/astarte_appengine_api/"
     - component_id:  astarte_data_updater_plant
       name: Data Updater Plant
       paths:
-        - apps/astarte_data_updater_plant
+        - "apps/astarte_data_updater_plant/"
     - component_id: astarte_housekeeping
       name: Housekeeping
       paths:
-        - apps/astarte_housekeeping
+        - "apps/astarte_housekeeping/"
     - component_id: astarte_housekeeping_api
       name: Housekeeping API
       paths:
-        - apps/astarte_housekeeping_api
+        - "apps/astarte_housekeeping_api/"
     - component_id: astarte_pairing
       name: Pairing
       paths:
-        - apps/astarte_pairing
+        - "apps/astarte_pairing/"
     - component_id: astarte_pairing_api
       name: Pairing API
       paths:
-        - apps/astarte_pairing_api
+        - "apps/astarte_pairing_api/"
     - component_id: astarte_realm_management
       name: Realm Management
       paths:
-        - apps/astarte_realm_management
+        - "apps/astarte_realm_management/"
     - component_id: astarte_realm_management_api
       name: Realm Management API
       paths:
-        - apps/astarte_realm_management_api
+        - "apps/astarte_realm_management_api/"
     - component_id: astarte_trigger_engine
       name: Trigger Engine
       paths:
-        - apps/astarte_trigger_engine
+        - "apps/astarte_trigger_engine/"

--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -152,4 +152,3 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
         directory: ./apps/${{ inputs.app }}/coverage_results
-        flags: ${{ inputs.app }}


### PR DESCRIPTION
CI configuration was never meant to use flags but codecov somehow misundertood us (the _somehow_ has a name and an address, and are mine)

This removes flags when uploading and should force codecov to read components configuration

Also changes path definition to better fit codecov example

- codecov components docs: https://docs.codecov.com/docs/components
- codecov example: https://github.com/codecov/example-components
