### PR TITLE
DUP: fix expiry check and add tests

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/cache.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/cache.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2018 Ispirata Srl
+# Copyright 2018 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -58,24 +58,22 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Cache do
 
   def fetch({_size, map}, key) do
     with {:ok, {value, expiry}} <- Map.fetch(map, key) do
-      if is_expired?(expiry) do
-        {:ok, value}
-      else
+      if expired?(expiry) do
         :error
+      else
+        {:ok, value}
       end
     end
   end
 
   def has_key?({_size, map}, key) do
-    with {:ok, {_value, expiry}} <- Map.fetch(map, key) do
-      not is_expired?(expiry)
-    else
-      :error ->
-        false
+    case Map.fetch(map, key) do
+      {:ok, {_value, expiry}} -> not expired?(expiry)
+      :error -> false
     end
   end
 
-  defp is_expired?(expiry) do
-    expiry == nil or expiry > System.system_time(:second)
+  defp expired?(expiry) do
+    expiry != nil and expiry <= System.system_time(:second)
   end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/cache_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/cache_test.exs
@@ -1,0 +1,195 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.CacheTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+  import Mimic
+
+  alias Astarte.DataUpdaterPlant.DataUpdater.Cache
+
+  setup :verify_on_exit!
+
+  describe "put/4 and get/3" do
+    property "stores and retrieves the value for any key and value" do
+      check all(
+              key <- term(),
+              value <- term(),
+              size <- positive_integer(),
+              ttl <- one_of([nil, integer()])
+            ) do
+        cache = Cache.new(size)
+        cache = Cache.put(cache, key, value, ttl)
+
+        if is_integer(ttl) and ttl <= 0 do
+          assert Cache.get(cache, key) == nil
+        else
+          assert Cache.get(cache, key) == value
+        end
+      end
+    end
+
+    test "overwrites an existing key with a new value" do
+      cache = Cache.new(2)
+      cache = Cache.put(cache, :foo, 1, nil)
+      cache = Cache.put(cache, :foo, 2, nil)
+      assert Cache.get(cache, :foo) == 2
+    end
+
+    test "evicts a random key when cache exceeds capacity" do
+      cache = Cache.new(2)
+      cache = Cache.put(cache, :a, 1, nil)
+      cache = Cache.put(cache, :b, 2, nil)
+      cache = Cache.put(cache, :c, 3, nil)
+      assert {2, map} = cache
+      assert map_size(map) == 2
+    end
+
+    test "stores value with TTL and expires after TTL" do
+      now = System.system_time(:second)
+      System |> expect(:system_time, fn :second -> now end)
+
+      cache = Cache.new(1)
+      cache = Cache.put(cache, :foo, :bar, 1)
+
+      # Simulate time after TTL
+      System |> expect(:system_time, fn :second -> now + 2 end)
+      assert Cache.get(cache, :foo) == nil
+    end
+
+    test "returns nil for missing keys" do
+      cache = Cache.new(1)
+      assert Cache.get(cache, :foo) == nil
+    end
+
+    test "returns default value for missing key" do
+      cache = Cache.new(1)
+      assert Cache.get(cache, :missing, :default) == :default
+    end
+
+    test "expired key is not returned but remains in map" do
+      now = System.system_time(:second)
+      System |> expect(:system_time, fn :second -> now end)
+
+      cache = Cache.new(1)
+      cache = Cache.put(cache, :foo, :bar, 1)
+
+      # Simulate time after TTL
+      System |> expect(:system_time, fn :second -> now + 2 end)
+      assert Cache.get(cache, :foo, :default) == :default
+    end
+  end
+
+  describe "fetch/2" do
+    property "stores and retrieves the value for any key and value" do
+      check all(
+              key <- term(),
+              value <- term(),
+              size <- positive_integer(),
+              ttl <- one_of([nil, integer()])
+            ) do
+        cache = Cache.new(size)
+        cache = Cache.put(cache, key, value, ttl)
+
+        if is_integer(ttl) and ttl <= 0 do
+          assert Cache.fetch(cache, key) == :error
+        else
+          assert Cache.fetch(cache, key) == {:ok, value}
+        end
+      end
+    end
+
+    test "returns value for present and non-expired key" do
+      cache = Cache.new(1)
+      cache = Cache.put(cache, :foo, :bar, nil)
+      assert Cache.fetch(cache, :foo) == {:ok, :bar}
+    end
+
+    test "returns :error for missing key" do
+      cache = Cache.new(1)
+      assert Cache.fetch(cache, :missing) == :error
+    end
+
+    test "expired key is not returned but remains in map" do
+      # Set up the initial time for put
+      now = System.system_time(:second)
+      System |> expect(:system_time, fn :second -> now end)
+
+      cache = Cache.new(1)
+      cache = Cache.put(cache, :foo, :bar, 1)
+
+      # Move time forward to simulate expiration
+      System |> expect(:system_time, fn :second -> now + 2 end)
+
+      assert Cache.fetch(cache, :foo) == :error
+    end
+  end
+
+  describe "has_key?/2" do
+    property "returns true if key is present and not expired, false otherwise" do
+      check all(
+              key <- term(),
+              value <- term(),
+              size <- positive_integer(),
+              ttl <- one_of([nil, integer()])
+            ) do
+        cache = Cache.new(size)
+        cache = Cache.put(cache, key, value, ttl)
+
+        result = Cache.has_key?(cache, key)
+
+        cond do
+          is_integer(ttl) and ttl <= 0 ->
+            assert result == false
+
+          true ->
+            assert result == true
+        end
+      end
+    end
+
+    test "returns true for present and non-expired key with no TTL" do
+      cache = Cache.new(1)
+      cache = Cache.put(cache, :foo, :bar, nil)
+      assert Cache.has_key?(cache, :foo) == true
+    end
+
+    test "returns true for present and non-expired key with positive TTL" do
+      cache = Cache.new(1)
+      cache = Cache.put(cache, :foo, :bar, 1)
+      assert Cache.has_key?(cache, :foo) == true
+    end
+
+    test "returns false for present but expired key" do
+      now = System.system_time(:second)
+      System |> expect(:system_time, fn :second -> now end)
+
+      cache = Cache.new(1)
+      cache = Cache.put(cache, :foo, :bar, 1)
+
+      # Simulate time after TTL
+      System |> expect(:system_time, fn :second -> now + 2 end)
+      assert Cache.has_key?(cache, :foo) == false
+    end
+
+    test "returns false for missing key" do
+      cache = Cache.new(1)
+      assert Cache.has_key?(cache, :missing) == false
+    end
+  end
+end

--- a/apps/astarte_data_updater_plant/test/test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/test_helper.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 Ispirata Srl
+# Copyright 2017 - 2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,5 +17,6 @@
 #
 
 Mimic.copy(Astarte.DataAccess.Config)
+Mimic.copy(System)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
- Fix the expiry logic in `fetch/2` and `has_key?/2` by introducing a clearly named `expired?/1` predicate. This reverses the previous logic, making the intent explicit and avoiding double negatives

- Add complete test suite for the `Cache.ex` module, which previously lacked any test coverage.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No