### PR TITLE
fix(dup): avoid applying `astarte_instance_id` twice

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/deletion_scheduler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/deletion_scheduler.ex
@@ -29,7 +29,6 @@ defmodule Astarte.DataUpdater.DeletionScheduler do
   alias Astarte.DataUpdaterPlant.DataUpdater
   alias Astarte.DataUpdaterPlant.Config
   alias Astarte.Core.Device
-  alias Astarte.Core.CQLUtils
 
   require Logger
 
@@ -70,10 +69,8 @@ defmodule Astarte.DataUpdater.DeletionScheduler do
     realms = Queries.retrieve_realms!()
 
     for %{"realm_name" => realm_name} <- realms,
-        keyspace_name =
-          CQLUtils.realm_name_to_keyspace_name(realm_name, Config.astarte_instance_id!()),
         %{"device_id" => device_id} <-
-          Queries.retrieve_devices_waiting_to_start_deletion!(keyspace_name),
+          Queries.retrieve_devices_waiting_to_start_deletion!(realm_name),
         encoded_device_id = Device.encode_device_id(device_id),
         should_handle_data_from_device?(realm_name, encoded_device_id) do
       _ =

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -171,10 +171,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   def handle_internal(%State{discard_messages: true} = state, "/f", _, message_id, _) do
-    keyspace_name =
-      CQLUtils.realm_name_to_keyspace_name(state.realm, Config.astarte_instance_id!())
-
-    :ok = Queries.ack_end_device_deletion(keyspace_name, state.device_id)
+    :ok = Queries.ack_end_device_deletion(state.realm, state.device_id)
     _ = Logger.info("End device deletion acked.", tag: "device_delete_ack")
     MessageTracker.ack_delivery(state.message_tracker, message_id)
     {:stop, state}

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -867,9 +867,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
   end
 
   def check_device_deletion_in_progress(realm_name, device_id) do
+    keyspace_name = Realm.keyspace_name(realm_name)
+
     Xandra.Cluster.run(
       :xandra,
-      &do_check_device_deletion_in_progress(&1, realm_name, device_id)
+      &do_check_device_deletion_in_progress(&1, keyspace_name, device_id)
     )
   end
 
@@ -925,9 +927,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
   end
 
   def retrieve_devices_waiting_to_start_deletion!(realm_name) do
+    keyspace_name = Realm.keyspace_name(realm_name)
+
     Xandra.Cluster.run(
       :xandra,
-      &do_retrieve_devices_waiting_to_start_deletion!(&1, realm_name)
+      &do_retrieve_devices_waiting_to_start_deletion!(&1, keyspace_name)
     )
   end
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/time_based_actions.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/time_based_actions.ex
@@ -17,10 +17,8 @@
 #
 
 defmodule Astarte.DataUpdaterPlant.TimeBasedActions do
-  alias Astarte.Core.CQLUtils
   alias Astarte.Core.Device
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.Utils, as: SimpleTriggersProtobufUtils
-  alias Astarte.DataUpdaterPlant.Config
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
   alias Astarte.DataUpdaterPlant.DataUpdater.Impl
   alias Astarte.DataUpdaterPlant.DataUpdater.State
@@ -140,10 +138,7 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActions do
       Logger.info("Stop handling data from device in deletion, device_id #{encoded_device_id}")
 
       # It's ok to repeat that, as we always write ⊤
-      keyspace_name =
-        CQLUtils.realm_name_to_keyspace_name(realm, Config.astarte_instance_id!())
-
-      Queries.ack_start_device_deletion(keyspace_name, device_id)
+      Queries.ack_start_device_deletion(realm, device_id)
 
       %State{new_state | discard_messages: true}
     else
@@ -152,10 +147,7 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActions do
   end
 
   defp should_start_device_deletion?(realm_name, device_id) do
-    keyspace_name =
-      CQLUtils.realm_name_to_keyspace_name(realm_name, Config.astarte_instance_id!())
-
-    case Queries.check_device_deletion_in_progress(keyspace_name, device_id) do
+    case Queries.check_device_deletion_in_progress(realm_name, device_id) do
       {:ok, true} ->
         true
 

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/time_based_actions_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/time_based_actions_test.exs
@@ -761,7 +761,7 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActionsTest do
       state = setup_device_state(realm, device_id, encoded_device_id, [])
 
       # Simulate error scenario: update the state to use the nonexistent realm
-      nonexistent_realm = "nonexistent_realm_#{System.unique_integer([:positive])}"
+      nonexistent_realm = "nonexistentrealm#{System.unique_integer([:positive])}"
       state = %{state | realm: nonexistent_realm}
 
       # Verify state behavior: only timestamp is updated, no deletion triggered


### PR DESCRIPTION
Standardize the format of having only the `Queries` module know about `keyspace_name` and `astarte_instance_id`

fixes two instances in which this was applied BOTH in application code and in the queries module

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
