### PR TITLE
ci: move back to flags

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,63 +4,67 @@ codecov:
 coverage:
   range: 60..80
   round: down
-  precision: 1
   status:
-    patch: off
     project:
       default:
         threshold: 1%
         branches:
           - "!master"
+        flags:
+          - astarte_appengine_api
+          - astarte_data_updater_plant
+          - astarte_housekeeping
+          - astarte_housekeeping_api
+          - astarte_pairing
+          - astarte_pairing_api
+          - astarte_realm_management
+          - astarte_realm_management_api
+          - astarte_trigger_engine
 
 ignore:
   - "apps/*/test"
 
 comment:
-  layout: "header, diff, files, components"
+  layout: "header, diff, files, flags"
   require_changes: yes
 
-component_management:
+flag_management:
   default_rules:
+    carryforward: true
     statuses:
       - type: project
         target: auto
+        threshold: 1%
         branches:
           - "!master"
-  individual_components:
-    - component_id:  astarte_appengine_api
-      name: AppEngine API
-      paths:
-        - "apps/astarte_appengine_api/"
-    - component_id:  astarte_data_updater_plant
-      name: Data Updater Plant
-      paths:
-        - "apps/astarte_data_updater_plant/"
-    - component_id: astarte_housekeeping
-      name: Housekeeping
-      paths:
-        - "apps/astarte_housekeeping/"
-    - component_id: astarte_housekeeping_api
-      name: Housekeeping API
-      paths:
-        - "apps/astarte_housekeeping_api/"
-    - component_id: astarte_pairing
-      name: Pairing
-      paths:
-        - "apps/astarte_pairing/"
-    - component_id: astarte_pairing_api
-      name: Pairing API
-      paths:
-        - "apps/astarte_pairing_api/"
-    - component_id: astarte_realm_management
-      name: Realm Management
-      paths:
-        - "apps/astarte_realm_management/"
-    - component_id: astarte_realm_management_api
-      name: Realm Management API
-      paths:
-        - "apps/astarte_realm_management_api/"
-    - component_id: astarte_trigger_engine
-      name: Trigger Engine
-      paths:
-        - "apps/astarte_trigger_engine/"
+      - type: patch
+        target: 90%
+
+flags:
+  astarte_appengine_api:
+    paths:
+      - apps/astarte_appengine_api
+  astarte_data_updater_plant:
+    paths:
+      - apps/astarte_data_updater_plant
+  astarte_housekeeping:
+    paths:
+      - apps/astarte_housekeeping
+  astarte_housekeeping_api:
+    paths:
+      - apps/astarte_housekeeping_api
+  astarte_pairing:
+    paths:
+      - apps/astarte_pairing
+  astarte_pairing_api:
+    paths:
+      - apps/astarte_pairing_api
+  astarte_realm_management:
+    paths:
+      - apps/astarte_realm_management
+  astarte_realm_management_api:
+    paths:
+      - apps/astarte_realm_management_api
+  astarte_trigger_engine:
+    paths:
+      - apps/astarte_trigger_engine

--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -152,3 +152,4 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
         directory: ./apps/${{ inputs.app }}/coverage_results
+        flags: ${{ inputs.app }}


### PR DESCRIPTION
At some point while trying to understand codecov I seem to have read the documentation correctly; stating

![Screenshot From 2025-05-29 16-21-46](https://github.com/user-attachments/assets/507ad36f-f096-4e52-b54f-418ffde3ed98)

Then dyslexia came in, and I moved everything to components

Now I'm here to make amend of my errors, taking everything back and reinserting flags in our CI, this should give us more consistent and understandable feedback on
- project coverage, computed according to the combined coverage of all astarte services coverage
- service coverage, computed with `mix coveralls`
- patch coverage