### PR TITLE
Chore: forward porionting `release-1.1` into `release-1.2`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,63 +4,67 @@ codecov:
 coverage:
   range: 60..80
   round: down
-  precision: 1
   status:
-    patch: off
     project:
       default:
         threshold: 1%
         branches:
           - "!master"
+        flags:
+          - astarte_appengine_api
+          - astarte_data_updater_plant
+          - astarte_housekeeping
+          - astarte_housekeeping_api
+          - astarte_pairing
+          - astarte_pairing_api
+          - astarte_realm_management
+          - astarte_realm_management_api
+          - astarte_trigger_engine
 
 ignore:
   - "apps/*/test"
 
 comment:
-  layout: "header, diff, files, components"
+  layout: "header, diff, files, flags"
   require_changes: yes
 
-component_management:
+flag_management:
   default_rules:
+    carryforward: true
     statuses:
       - type: project
         target: auto
+        threshold: 1%
         branches:
           - "!master"
-  individual_components:
-    - component_id:  astarte_appengine_api
-      name: AppEngine API
-      paths:
-        - apps/astarte_appengine_api
-    - component_id:  astarte_data_updater_plant
-      name: Data Updater Plant
-      paths:
-        - apps/astarte_data_updater_plant
-    - component_id: astarte_housekeeping
-      name: Housekeeping
-      paths:
-        - apps/astarte_housekeeping
-    - component_id: astarte_housekeeping_api
-      name: Housekeeping API
-      paths:
-        - apps/astarte_housekeeping_api
-    - component_id: astarte_pairing
-      name: Pairing
-      paths:
-        - apps/astarte_pairing
-    - component_id: astarte_pairing_api
-      name: Pairing API
-      paths:
-        - apps/astarte_pairing_api
-    - component_id: astarte_realm_management
-      name: Realm Management
-      paths:
-        - apps/astarte_realm_management
-    - component_id: astarte_realm_management_api
-      name: Realm Management API
-      paths:
-        - apps/astarte_realm_management_api
-    - component_id: astarte_trigger_engine
-      name: Trigger Engine
-      paths:
-        - apps/astarte_trigger_engine
+      - type: patch
+        target: 90%
+
+flags:
+  astarte_appengine_api:
+    paths:
+      - apps/astarte_appengine_api
+  astarte_data_updater_plant:
+    paths:
+      - apps/astarte_data_updater_plant
+  astarte_housekeeping:
+    paths:
+      - apps/astarte_housekeeping
+  astarte_housekeeping_api:
+    paths:
+      - apps/astarte_housekeeping_api
+  astarte_pairing:
+    paths:
+      - apps/astarte_pairing
+  astarte_pairing_api:
+    paths:
+      - apps/astarte_pairing_api
+  astarte_realm_management:
+    paths:
+      - apps/astarte_realm_management
+  astarte_realm_management_api:
+    paths:
+      - apps/astarte_realm_management_api
+  astarte_trigger_engine:
+    paths:
+      - apps/astarte_trigger_engine


### PR DESCRIPTION
Codecov example uses `flags` for components, this seems deprecated as our setup
is currently reporting flag configuration instead of components configuration.

Moreover paths configuration of components is made more similar to examples,
validator passes as before.

Signed-off-by: Luca Zaninotto <luca.zaninotto@secomind.com><!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
