### PR TITLE
ci: individually carryforward

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -28,6 +28,7 @@ comment:
   layout: "header, diff, files, flags"
   require_changes: yes
 
+
 flag_management:
   default_rules:
     carryforward: true
@@ -42,29 +43,38 @@ flag_management:
 
 flags:
   astarte_appengine_api:
+    carryforward: true
     paths:
       - apps/astarte_appengine_api
   astarte_data_updater_plant:
+    carryforward: true
     paths:
       - apps/astarte_data_updater_plant
   astarte_housekeeping:
+    carryforward: true
     paths:
       - apps/astarte_housekeeping
   astarte_housekeeping_api:
+    carryforward: true
     paths:
       - apps/astarte_housekeeping_api
   astarte_pairing:
+    carryforward: true
     paths:
       - apps/astarte_pairing
   astarte_pairing_api:
+    carryforward: true
     paths:
       - apps/astarte_pairing_api
   astarte_realm_management:
+    carryforward: true
     paths:
       - apps/astarte_realm_management
   astarte_realm_management_api:
+    carryforward: true
     paths:
       - apps/astarte_realm_management_api
   astarte_trigger_engine:
+    carryforward: true
     paths:
       - apps/astarte_trigger_engine

--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -146,7 +146,7 @@ jobs:
       if: |
           matrix.database == 'scylladb/scylla:5.2.2' &&
           ${{ github.repository }} == astarte-platform/astarte
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
- sets individual carryforward for flags
- updates codecov ci action to version `v5`

PRs should report the following informations:
- total poroject coverage
- patch coverage
- service coverage
![Screenshot From 2025-05-30 17-01-19](https://github.com/user-attachments/assets/f5ec3ca6-0c45-4d73-932c-4050344c6b1c)
