### PR TITLE
forward port from `release-1.2`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -28,6 +28,7 @@ comment:
   layout: "header, diff, files, flags"
   require_changes: yes
 
+
 flag_management:
   default_rules:
     carryforward: true
@@ -42,29 +43,38 @@ flag_management:
 
 flags:
   astarte_appengine_api:
+    carryforward: true
     paths:
       - apps/astarte_appengine_api
   astarte_data_updater_plant:
+    carryforward: true
     paths:
       - apps/astarte_data_updater_plant
   astarte_housekeeping:
+    carryforward: true
     paths:
       - apps/astarte_housekeeping
   astarte_housekeeping_api:
+    carryforward: true
     paths:
       - apps/astarte_housekeeping_api
   astarte_pairing:
+    carryforward: true
     paths:
       - apps/astarte_pairing
   astarte_pairing_api:
+    carryforward: true
     paths:
       - apps/astarte_pairing_api
   astarte_realm_management:
+    carryforward: true
     paths:
       - apps/astarte_realm_management
   astarte_realm_management_api:
+    carryforward: true
     paths:
       - apps/astarte_realm_management_api
   astarte_trigger_engine:
+    carryforward: true
     paths:
       - apps/astarte_trigger_engine

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,63 +4,67 @@ codecov:
 coverage:
   range: 60..80
   round: down
-  precision: 1
   status:
-    patch: off
     project:
       default:
         threshold: 1%
         branches:
           - "!master"
+        flags:
+          - astarte_appengine_api
+          - astarte_data_updater_plant
+          - astarte_housekeeping
+          - astarte_housekeeping_api
+          - astarte_pairing
+          - astarte_pairing_api
+          - astarte_realm_management
+          - astarte_realm_management_api
+          - astarte_trigger_engine
 
 ignore:
   - "apps/*/test"
 
 comment:
-  layout: "header, diff, files, components"
+  layout: "header, diff, files, flags"
   require_changes: yes
 
-component_management:
+flag_management:
   default_rules:
+    carryforward: true
     statuses:
       - type: project
         target: auto
+        threshold: 1%
         branches:
           - "!master"
-  individual_components:
-    - component_id:  astarte_appengine_api
-      name: AppEngine API
-      paths:
-        - apps/astarte_appengine_api
-    - component_id:  astarte_data_updater_plant
-      name: Data Updater Plant
-      paths:
-        - apps/astarte_data_updater_plant
-    - component_id: astarte_housekeeping
-      name: Housekeeping
-      paths:
-        - apps/astarte_housekeeping
-    - component_id: astarte_housekeeping_api
-      name: Housekeeping API
-      paths:
-        - apps/astarte_housekeeping_api
-    - component_id: astarte_pairing
-      name: Pairing
-      paths:
-        - apps/astarte_pairing
-    - component_id: astarte_pairing_api
-      name: Pairing API
-      paths:
-        - apps/astarte_pairing_api
-    - component_id: astarte_realm_management
-      name: Realm Management
-      paths:
-        - apps/astarte_realm_management
-    - component_id: astarte_realm_management_api
-      name: Realm Management API
-      paths:
-        - apps/astarte_realm_management_api
-    - component_id: astarte_trigger_engine
-      name: Trigger Engine
-      paths:
-        - apps/astarte_trigger_engine
+      - type: patch
+        target: 90%
+
+flags:
+  astarte_appengine_api:
+    paths:
+      - apps/astarte_appengine_api
+  astarte_data_updater_plant:
+    paths:
+      - apps/astarte_data_updater_plant
+  astarte_housekeeping:
+    paths:
+      - apps/astarte_housekeeping
+  astarte_housekeeping_api:
+    paths:
+      - apps/astarte_housekeeping_api
+  astarte_pairing:
+    paths:
+      - apps/astarte_pairing
+  astarte_pairing_api:
+    paths:
+      - apps/astarte_pairing_api
+  astarte_realm_management:
+    paths:
+      - apps/astarte_realm_management
+  astarte_realm_management_api:
+    paths:
+      - apps/astarte_realm_management_api
+  astarte_trigger_engine:
+    paths:
+      - apps/astarte_trigger_engine

--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -146,7 +146,7 @@ jobs:
       if: |
           matrix.database == 'scylladb/scylla:5.2.2' &&
           ${{ github.repository }} == astarte-platform/astarte
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Moves CI codecov configuration to use flags and a flag based coverage approach
Port forwards recent CI changes, namely PRs #1302 and #1298 