### PR TITLE
test(DUP): Add missing raised error test for `reload_datastream_maximum_storage_retention_on_expiry/2

### DIFF
--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/time_based_actions_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/time_based_actions_test.exs
@@ -867,6 +867,33 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActionsTest do
       assert new_state.datastream_maximum_storage_retention == nil
       assert new_state.last_datastream_maximum_retention_refresh == @timestamp_us_x_10
     end
+
+    test "does not update datastream_maximum_storage_retention if fetch returns :error",
+         %{
+           realm_name: realm,
+           device_id: device_id,
+           encoded_device_id: encoded_device_id
+         } do
+      # Insert initial device state
+      state = setup_device_state(realm, device_id, encoded_device_id, [])
+
+      # Simulate error scenario: update the state to use a nonexistent realm
+      nonexistent_realm = "nonexistentrealm#{System.unique_integer([:positive])}"
+      state = %{state | realm: nonexistent_realm}
+
+      new_state =
+        TimeBasedActions.reload_datastream_maximum_storage_retention_on_expiry(
+          state,
+          @timestamp2_us_x_10
+        )
+
+      # State should remain unchanged
+      assert new_state.last_datastream_maximum_retention_refresh ==
+               state.last_datastream_maximum_retention_refresh
+
+      assert new_state.datastream_maximum_storage_retention ==
+               state.datastream_maximum_storage_retention
+    end
   end
 
   defp setup_device_state(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Added missing test case to ensure proper behavior when `reload_datastream_maximum_storage_retention_on_expiry/2` encounters an error. Previously, the underlying repo functions did not properly handle such errors. After recent updates, this test confirms that the state remains unchanged when an error occurs.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
