### PR TITLE
fix(dup): use safe_fetch_one in queries

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -510,7 +510,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
       |> select([device], fragment("TTL(?)", device.connected))
       |> put_query_prefix(keyspace_name)
 
-    case Repo.fetch_one(query, consistency: Consistency.device_info(:read)) do
+    case Repo.safe_fetch_one(query, consistency: Consistency.device_info(:read)) do
       {:ok, n} ->
         {:ok, n}
 
@@ -568,7 +568,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
 
     consistency = Consistency.device_info(:read)
 
-    with {:ok, minors} <- Repo.fetch_one(query, consistency: consistency) do
+    with {:ok, minors} <- Repo.safe_fetch_one(query, consistency: consistency) do
       {:ok, minors}
     end
   end
@@ -584,7 +584,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
 
     consistency = Consistency.device_info(:read)
 
-    with {:ok, groups} <- Repo.fetch_one(query, consistency: consistency) do
+    with {:ok, groups} <- Repo.safe_fetch_one(query, consistency: consistency) do
       {:ok, Map.keys(groups)}
     end
   end
@@ -721,7 +721,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
       |> where(device_id: ^device_id)
       |> put_query_prefix(keyspace_name)
 
-    case Repo.fetch_one(query, consistency: Consistency.device_info(:read)) do
+    case Repo.safe_fetch_one(query, consistency: Consistency.device_info(:read)) do
       {:ok, _} -> {:ok, true}
       {:error, :not_found} -> {:ok, false}
       {:error, reason} -> {:error, reason}


### PR DESCRIPTION
restore the behavior pre-1283 of having all du/queries queries be safe

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [X] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
