### PR TITLE
refactor(DUP): better (and more testable) error handling

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -33,31 +33,29 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   require Logger
 
   def handle_data(state, interface, path, payload, message_id, timestamp) do
-    with :ok <- validate_interface(interface),
-         :ok <- validate_path(path),
-         {:ok, interface_descriptor, state} <-
-           state.interfaces
-           |> Map.get(interface)
-           |> Core.Interface.maybe_handle_cache_miss(interface, state),
-         :ok <- can_write_on_interface?(interface_descriptor.ownership),
-         {:ok, mapping} <-
-           Core.Interface.resolve_path(path, interface_descriptor, state.mappings),
-         {value, value_timestamp, _metadata} <-
-           PayloadsDecoder.decode_bson_payload(payload, timestamp),
-         :ok <-
-           Core.Interface.extract_expected_types(
-             path,
-             interface_descriptor,
-             mapping,
-             state.mappings
-           )
-           |> validate_value_type(value) do
+    context = %{
+      state: state,
+      interface: interface,
+      path: path,
+      payload: payload,
+      message_id: message_id,
+      timestamp: timestamp
+    }
+
+    with :ok <- validate_interface(context),
+         :ok <- validate_path(context),
+         {:ok, interface_descriptor, context} <- maybe_handle_cache_miss(context),
+         :ok <- can_write_on_interface?(context, interface_descriptor.ownership),
+         {:ok, mapping} <- resolve_path(context, interface_descriptor),
+         {value, value_timestamp, _metadata} <- decode_bson_payload(context),
+         :ok <- validate_value_type(context, interface_descriptor, mapping, value) do
       interface_id = interface_descriptor.interface_id
 
       endpoint_id = mapping.endpoint_id
       db_retention_policy = mapping.database_retention_policy
       db_ttl = mapping.database_retention_ttl
       device_id_string = Device.encode_device_id(state.device_id)
+      state = context.state
 
       maybe_explicit_value_timestamp =
         if mapping.explicit_timestamp,
@@ -270,319 +268,74 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
 
           update_stats(state, interface, interface_descriptor.major_version, path, payload)
       end
-    else
-      {:error, :cannot_write_on_server_owned_interface} ->
-        Logger.warning(
-          "Tried to write on server owned interface: #{interface} on " <>
-            "path: #{path}, base64-encoded payload: #{inspect(Base.encode64(payload))}, timestamp: #{inspect(timestamp)}.",
-          tag: "write_on_server_owned_interface"
-        )
+    end
+  end
 
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
+  defp maybe_handle_cache_miss(context) do
+    %{interface: interface, state: state} = context
 
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
+    cache_miss =
+      state.interfaces
+      |> Map.get(interface)
+      |> Core.Interface.maybe_handle_cache_miss(interface, state)
 
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "write_on_server_owned_interface",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :invalid_interface} ->
-        Logger.warning("Received invalid interface: #{inspect(interface)}.",
-          tag: "invalid_interface"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "invalid_interface",
-          error_metadata,
-          timestamp
-        )
-
-        # We dont't update stats on an invalid interface
-        state
-
-      {:error, :invalid_path} ->
-        Logger.warning("Received invalid path: #{inspect(path)}.", tag: "invalid_path")
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "invalid_path",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :mapping_not_found} ->
-        Logger.warning("Mapping not found for #{interface}#{path}. Maybe outdated introspection?",
-          tag: "mapping_not_found"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "mapping_not_found",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
+    case cache_miss do
       {:error, :interface_loading_failed} ->
-        Logger.warning("Cannot load interface: #{interface}.", tag: "interface_loading_failed")
-        # TODO: think about additional actions since the problem
-        # could be a missing interface in the DB
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
+        error = %{
+          message: "Cannot load interface: #{interface}.",
+          logger_metadata: [tag: "interface_loading_failed"],
+          error_name: "interface_loading_failed"
         }
 
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "interface_loading_failed",
-          error_metadata,
-          timestamp
-        )
+        Core.Error.handle_error(context, error)
 
-        update_stats(state, interface, nil, path, payload)
+      {:ok, descriptor, state} ->
+        new_context = Map.put(context, :state, state)
+        {:ok, descriptor, new_context}
+    end
+  end
+
+  defp resolve_path(context, interface_descriptor) do
+    %{interface: interface, path: path, state: state} = context
+    mappings = Core.Interface.resolve_path(path, interface_descriptor, state.mappings)
+
+    case mappings do
+      {:error, :mapping_not_found} ->
+        error = %{
+          message: "Mapping not found for #{interface}#{path}. Maybe outdated introspection?",
+          logger_metadata: [tag: "mapping_not_found"],
+          error_name: "mapping_not_found"
+        }
+
+        Core.Error.handle_error(context, error)
 
       {:guessed, _guessed_endpoints} ->
-        Logger.warning("Mapping guessed for #{interface}#{path}. Maybe outdated introspection?",
-          tag: "ambiguous_path"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
+        error = %{
+          message: "Mapping guessed for #{interface}#{path}. Maybe outdated introspection?",
+          logger_metadata: [tag: "ambiguous_path"],
+          error_name: "ambiguous_path"
         }
 
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "ambiguous_path",
-          error_metadata,
-          timestamp
-        )
+        Core.Error.handle_error(context, error)
 
-        update_stats(state, interface, nil, path, payload)
+      ok ->
+        ok
+    end
+  end
 
-      {:error, :undecodable_bson_payload} ->
-        Logger.warning(
+  defp decode_bson_payload(context) do
+    %{payload: payload, timestamp: timestamp, interface: interface, path: path} = context
+    decoding = PayloadsDecoder.decode_bson_payload(payload, timestamp)
+
+    with {:error, :undecodable_bson_payload} <- decoding do
+      error = %{
+        message:
           "Invalid BSON base64-encoded payload: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
-          tag: "undecodable_bson_payload"
-        )
+        logger_metadata: [tag: "undecodable_bson_payload"],
+        error_name: "undecodable_bson_payload"
+      }
 
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "undecodable_bson_payload",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :unexpected_value_type} ->
-        Logger.warning(
-          "Received invalid value: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
-          tag: "unexpected_value_type"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "unexpected_value_type",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :value_size_exceeded} ->
-        Logger.warning(
-          "Received huge base64-encoded payload: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
-          tag: "value_size_exceeded"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "value_size_exceeded",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :unexpected_object_key} ->
-        base64_payload = Base.encode64(payload)
-
-        Logger.warning(
-          "Received object with unexpected key, object base64 is: #{base64_payload} sent to #{interface}#{path}.",
-          tag: "unexpected_object_key"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "unexpected_object_key",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
+      Core.Error.handle_error(context, error)
     end
   end
 
@@ -605,29 +358,108 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
     now_secs + ttl + 3600 < expiry_secs
   end
 
-  defp validate_interface(interface) do
-    if String.valid?(interface),
-      do: :ok,
-      else: {:error, :invalid_interface}
-  end
-
-  defp validate_path(path) do
-    cond do
-      # Make sure the path is a valid unicode string
-      not String.valid?(path) ->
-        {:error, :invalid_path}
-
-      # TODO: this is a temporary fix to work around a bug in EndpointsAutomaton.resolve_path/2
-      String.contains?(path, "//") ->
-        {:error, :invalid_path}
-
-      true ->
-        :ok
+  defp validate_interface(%{interface: interface} = context) do
+    case String.valid?(interface) do
+      true -> :ok
+      false -> invalid_interface_error(context)
     end
   end
 
-  defp can_write_on_interface?(:device), do: :ok
-  defp can_write_on_interface?(:server), do: {:error, :cannot_write_on_server_owned_interface}
+  defp invalid_interface_error(%{interface: interface} = context) do
+    error = %{
+      message: "Received invalid interface: #{inspect(interface)}.",
+      logger_metadata: [tag: "invalid_interface"],
+      error_name: "invalid_interface"
+    }
+
+    Core.Error.handle_error(context, error, update_stats: false)
+  end
+
+  defp validate_path(%{path: path} = context),
+    do: valid_path_or_error(context, String.valid?(path), String.contains?(path, "//"))
+
+  defp valid_path_or_error(_context, true, false), do: :ok
+
+  defp valid_path_or_error(%{path: path} = context, _, _) do
+    error = %{
+      message: "Received invalid path: #{inspect(path)}.",
+      logger_metadata: [tag: "invalid_path"],
+      error_name: "invalid_path"
+    }
+
+    Core.Error.handle_error(context, error)
+  end
+
+  defp can_write_on_interface?(_context, :device), do: :ok
+
+  defp can_write_on_interface?(context, :server) do
+    %{interface: interface, path: path, payload: payload, timestamp: timestamp} = context
+
+    message =
+      "Tried to write on server owned interface: #{interface} on " <>
+        "path: #{path}, base64-encoded payload: #{inspect(Base.encode64(payload))}, timestamp: #{inspect(timestamp)}."
+
+    tag = "write_on_server_owned_interface"
+
+    error_name = "write_on_server_owned_interface"
+
+    error = %{
+      message: message,
+      logger_metadata: [tag: tag],
+      error_name: error_name
+    }
+
+    Core.Error.handle_error(context, error)
+  end
+
+  defp validate_value_type(context, interface_descriptor, mapping, value) do
+    %{interface: interface, path: path, payload: payload, state: state} = context
+
+    expected_types =
+      Core.Interface.extract_expected_types(
+        path,
+        interface_descriptor,
+        mapping,
+        state.mappings
+      )
+
+    validation = validate_value_type(expected_types, value)
+
+    case validation do
+      {:error, :unexpected_value_type} ->
+        error = %{
+          message:
+            "Received invalid value: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
+          logger_metadata: [tag: "unexpected_value_type"],
+          error_name: "unexpected_value_type"
+        }
+
+        Core.Error.handle_error(context, error)
+
+      {:error, :unexpected_object_key} ->
+        error = %{
+          message:
+            "Received object with unexpected key, object base64 is: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
+          logger_metadata: [tag: "unexpected_value_type"],
+          error_name: "unexpected_value_type"
+        }
+
+        Core.Error.handle_error(context, error)
+
+      {:error, :value_size_exceeded} ->
+        error = %{
+          message:
+            "Received huge base64-encoded payload: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
+          logger_metadata: [tag: "value_size_exceeded"],
+          error_name: "value_size_exceeded"
+        }
+
+        Core.Error.handle_error(context, error)
+
+      ok ->
+        ok
+    end
+  end
 
   # TODO: We need tests for this function
   def validate_value_type(expected_type, %DateTime{} = value) do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -279,7 +279,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "write_on_server_owned_interface"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -310,7 +310,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "invalid_interface"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -339,7 +339,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
 
       {:error, :invalid_path} ->
         Logger.warning("Received invalid path: #{inspect(path)}.", tag: "invalid_path")
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -365,7 +365,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "mapping_not_found"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -390,7 +390,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
         Logger.warning("Cannot load interface: #{interface}.", tag: "interface_loading_failed")
         # TODO: think about additional actions since the problem
         # could be a missing interface in the DB
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -421,7 +421,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "ambiguous_path"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -453,7 +453,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "undecodable_bson_payload"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -485,7 +485,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "unexpected_value_type"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -517,7 +517,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "value_size_exceeded"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -551,7 +551,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "unexpected_object_key"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_trigger.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_trigger.ex
@@ -22,9 +22,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataTrigger do
   @moduledoc """
 
   """
+  alias Astarte.DataUpdaterPlant.TriggersHandler
   alias Astarte.Core.Mapping.EndpointsAutomaton
   alias Astarte.Core.InterfaceDescriptor
   alias Astarte.Core.Triggers.DataTrigger
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
 
   def data_trigger_to_key(state, data_trigger, event_type) do
     %DataTrigger{
@@ -52,13 +54,86 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataTrigger do
     {event_type, interface_id, endpoint}
   end
 
-  defp replace_empty_token(token) do
-    case token do
-      "" ->
-        "%{}"
+  def execute_incoming_data_triggers(
+        state,
+        device,
+        interface,
+        interface_id,
+        path,
+        endpoint_id,
+        payload,
+        value,
+        timestamp
+      ) do
+    realm = state.realm
 
-      not_empty ->
-        not_empty
-    end
+    # any interface triggers
+    Core.Interface.get_on_data_triggers(state, :on_incoming_data, :any_interface, :any_endpoint)
+    |> Enum.each(fn trigger ->
+      target_with_policy_list = get_target_with_policy_list(state, trigger)
+
+      TriggersHandler.incoming_data(
+        target_with_policy_list,
+        realm,
+        device,
+        interface,
+        path,
+        payload,
+        timestamp
+      )
+    end)
+
+    # any endpoint triggers
+    Core.Interface.get_on_data_triggers(state, :on_incoming_data, interface_id, :any_endpoint)
+    |> Enum.each(fn trigger ->
+      target_with_policy_list = get_target_with_policy_list(state, trigger)
+
+      TriggersHandler.incoming_data(
+        target_with_policy_list,
+        realm,
+        device,
+        interface,
+        path,
+        payload,
+        timestamp
+      )
+    end)
+
+    # incoming data triggers
+    Core.Interface.get_on_data_triggers(
+      state,
+      :on_incoming_data,
+      interface_id,
+      endpoint_id,
+      path,
+      value
+    )
+    |> Enum.each(fn trigger ->
+      target_with_policy_list = get_target_with_policy_list(state, trigger)
+
+      TriggersHandler.incoming_data(
+        target_with_policy_list,
+        realm,
+        device,
+        interface,
+        path,
+        payload,
+        timestamp
+      )
+    end)
+
+    :ok
+  end
+
+  defp replace_empty_token(""), do: "%{}"
+  defp replace_empty_token(non_empty), do: non_empty
+
+  defp get_target_with_policy_list(state, trigger) do
+    trigger.trigger_targets
+    |> Enum.map(fn target ->
+      parent_target_id = Map.get(state.trigger_id_to_policy_name, target.parent_trigger_id)
+
+      {target, parent_target_id}
+    end)
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/error.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/error.ex
@@ -1,0 +1,121 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Error do
+  @moduledoc """
+  Part of the `DataUpdater` `Core` modules
+
+  This module is responsble for providing utilities to handle errors during the handling of messages
+  """
+  alias Astarte.DataUpdaterPlant.MessageTracker
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
+
+  require Logger
+
+  @doc """
+  Handles errors arising when handling data from a device. It needs a context,
+  a map in the shape:
+
+  %{
+    state: DataUpdater.State.t(),
+    interface: Astarte.Core.Interface.t(),
+    message_id: binary(),
+    path: String.t(),
+    timestamp: DateTime.t(),
+    payload: binary()
+  }
+
+  and returns the updated state after asking for a clean session
+
+  the `error` should consist of a map with
+
+  %{
+    message: String.t(),
+    tag: String.t(),
+    error_name: String.t(),
+  }
+
+  The first two for the logging and the latter to execute device error triggers.
+  The optional `update_stats` parameter switches the update of stats when the
+  telemetry has been executed.
+
+  An optional option keyword list can be supplied, to specify the handle_error behavior:
+  - update_stats: updates message stats in the %State{}
+  - ask_clean_session: forcefully disconnects the device and creates a clean session
+  - execute_error_triggers: execute device error triggers
+  """
+  def handle_error(context, error, opts \\ []) do
+    %{
+      state: state,
+      interface: interface,
+      message_id: message_id,
+      path: path,
+      timestamp: timestamp,
+      payload: payload
+    } = context
+
+    %{
+      message: message,
+      logger_metadata: logger_metadata,
+      error_name: error_name
+    } = error
+
+    update_stats = Keyword.get(opts, :update_stats, true)
+    ask_clean_session = Keyword.get(opts, :ask_clean_session, true)
+    execute_error_triggers = Keyword.get(opts, :execute_error_triggers, true)
+
+    Logger.warning(message, logger_metadata)
+
+    {:ok, state} =
+      case ask_clean_session do
+        true -> Core.Device.ask_clean_session(state, timestamp)
+        false -> {:ok, state}
+      end
+
+    MessageTracker.discard(state.message_tracker, message_id)
+
+    :telemetry.execute(
+      [:astarte, :data_updater_plant, :data_updater, :discarded_message],
+      %{},
+      %{realm: state.realm}
+    )
+
+    base64_payload = Base.encode64(payload)
+
+    error_metadata = %{
+      "interface" => inspect(interface),
+      "path" => inspect(path),
+      "base64_payload" => base64_payload
+    }
+
+    if execute_error_triggers,
+      do:
+        Core.Trigger.execute_device_error_triggers(
+          state,
+          error_name,
+          error_metadata,
+          timestamp
+        )
+
+    if update_stats,
+      do: Core.DataHandler.update_stats(state, interface, nil, path, payload),
+      else: state
+  end
+end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/interface.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/interface.ex
@@ -219,6 +219,42 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Interface do
     end
   end
 
+  def get_value_change_triggers(state, interface_id, endpoint_id, path, value) do
+    value_change_triggers =
+      get_on_data_triggers(state, :on_value_change, interface_id, endpoint_id, path, value)
+
+    value_change_applied_triggers =
+      get_on_data_triggers(
+        state,
+        :on_value_change_applied,
+        interface_id,
+        endpoint_id,
+        path,
+        value
+      )
+
+    path_created_triggers =
+      get_on_data_triggers(state, :on_path_created, interface_id, endpoint_id, path, value)
+
+    path_removed_triggers =
+      get_on_data_triggers(state, :on_path_removed, interface_id, endpoint_id, path)
+
+    all_empty? =
+      [value_change_triggers, value_change_applied_triggers, path_created_triggers]
+      |> Enum.all?(&Enum.empty?/1)
+
+    triggers_tuple = {
+      value_change_triggers,
+      value_change_applied_triggers,
+      path_created_triggers,
+      path_removed_triggers
+    }
+
+    if all_empty?,
+      do: {:no_value_change_triggers, nil},
+      else: {:ok, triggers_tuple}
+  end
+
   defp path_matches?([], []) do
     true
   end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/time_based_actions.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/time_based_actions.ex
@@ -20,7 +20,6 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActions do
   alias Astarte.Core.Device
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.Utils, as: SimpleTriggersProtobufUtils
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
-  alias Astarte.DataUpdaterPlant.DataUpdater.Impl
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
@@ -152,7 +151,7 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActions do
       encoded_device_id = Device.encode_device_id(device_id)
 
       :ok = force_device_deletion_from_broker(realm, encoded_device_id)
-      new_state = Impl.set_device_disconnected(state, timestamp)
+      new_state = Core.Device.set_device_disconnected(state, timestamp)
 
       Logger.info("Stop handling data from device in deletion, device_id #{encoded_device_id}")
 

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/device_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/device_test.exs
@@ -1,0 +1,92 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DeviceTest do
+  use Astarte.Cases.Data, async: true
+  use Astarte.Cases.Device
+  use Mimic
+
+  import Astarte.Helpers.DataUpdater
+
+  alias Astarte.DataUpdaterPlant.DataUpdater
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
+  alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
+  alias Astarte.DataAccess.Devices.Device, as: DatabaseDevice
+  alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.DataAccess.Repo
+  alias Astarte.Helpers.Database
+
+  @timestamp_us_x_10 Database.make_timestamp("2025-05-14T14:00:32+00:00")
+
+  setup_all %{realm_name: realm_name, device: device} do
+    setup_data_updater(realm_name, device.encoded_id)
+    state = DataUpdater.dump_state(realm_name, device.encoded_id)
+
+    %{state: state}
+  end
+
+  describe "ask_clean_session/2" do
+    test "disconnects device and clears cache on successful disconnect", %{
+      realm_name: realm_name,
+      state: state
+    } do
+      # Successfully disconnected
+      Mimic.expect(VMQPlugin, :disconnect, fn _client_id, _discard_state -> :ok end)
+
+      {:ok, new_state} = Core.Device.ask_clean_session(state, @timestamp_us_x_10)
+
+      assert read_device_empty_cache(realm_name, state.device_id) == true
+      assert new_state.connected == false
+    end
+
+    test "clears cache and marks device disconnected if already disconnected", %{
+      realm_name: realm_name,
+      state: state
+    } do
+      # Not found means it was already disconnected, succeed anyway
+      Mimic.expect(VMQPlugin, :disconnect, fn _client_id, _discard_state ->
+        {:error, :not_found}
+      end)
+
+      {:ok, new_state} = Core.Device.ask_clean_session(state, @timestamp_us_x_10)
+
+      assert read_device_empty_cache(realm_name, state.device_id) == true
+      assert new_state.connected == false
+    end
+
+    test "returns error and clears cache on disconnect failure", %{
+      realm_name: realm_name,
+      state: state
+    } do
+      # Some other error, return it
+      Mimic.expect(VMQPlugin, :disconnect, fn _client_id, _discard_state ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, :clean_session_failed} =
+               Core.Device.ask_clean_session(state, @timestamp_us_x_10)
+
+      assert read_device_empty_cache(realm_name, state.device_id) == true
+    end
+  end
+
+  defp read_device_empty_cache(realm_name, device_id) do
+    Repo.get!(DatabaseDevice, device_id, prefix: Realm.keyspace_name(realm_name))
+    |> Map.fetch!(:pending_empty_cache)
+  end
+end

--- a/apps/astarte_data_updater_plant/test/test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/test_helper.exs
@@ -19,6 +19,7 @@
 Mimic.copy(Astarte.DataAccess.Config)
 Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Server)
 Mimic.copy(Astarte.DataUpdaterPlant.RPC.Server.Core)
+Mimic.copy(Astarte.DataUpdaterPlant.RPC.VMQPlugin)
 Mimic.copy(System)
 Mimic.copy(Xandra)
 Mimic.copy(Astarte.DataAccess.Health.Health)


### PR DESCRIPTION
Based on #1315 ~and #1313~
Up to now errors were handled in `handle_data/5` directly, with little to no testability

This refactors the code by
- providing error handling function testable separately
- move error handling where errors happen instead of the `else` branch of `handle_data/5`
- provide a general framework for message context and errors in data handling
