### PR TITLE
refactor(DUP): make `handle_data` comprehensible

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -20,7 +20,6 @@
 
 defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   alias Astarte.Core.Mapping.ValueType
-  alias Astarte.DataUpdaterPlant.DataUpdater.Impl
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.DataUpdaterPlant.DataUpdater.CachedPath
   alias Astarte.DataUpdaterPlant.DataUpdater.Cache
@@ -279,7 +278,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "write_on_server_owned_interface"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -310,7 +309,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "invalid_interface"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -339,7 +338,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
 
       {:error, :invalid_path} ->
         Logger.warning("Received invalid path: #{inspect(path)}.", tag: "invalid_path")
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -370,7 +369,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "mapping_not_found"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -400,7 +399,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
         Logger.warning("Cannot load interface: #{interface}.", tag: "interface_loading_failed")
         # TODO: think about additional actions since the problem
         # could be a missing interface in the DB
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -431,7 +430,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "ambiguous_path"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -463,7 +462,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "undecodable_bson_payload"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -495,7 +494,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "unexpected_value_type"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -527,7 +526,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "value_size_exceeded"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -561,7 +560,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           tag: "unexpected_object_key"
         )
 
-        {:ok, state} = Impl.ask_clean_session(state, timestamp)
+        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(state.message_tracker, message_id)
 
         :telemetry.execute(

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -19,6 +19,8 @@
 #
 
 defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.Error
+  alias Astarte.Core.InterfaceDescriptor
   alias Astarte.Core.Mapping.ValueType
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.DataUpdaterPlant.DataUpdater.CachedPath
@@ -48,209 +50,265 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
          :ok <- can_write_on_interface?(context, interface_descriptor.ownership),
          {:ok, mapping} <- resolve_path(context, interface_descriptor),
          {value, value_timestamp, _metadata} <- decode_bson_payload(context),
-         :ok <- maybe_validate_value_type(context, interface_descriptor, mapping, value) do
-      interface_id = interface_descriptor.interface_id
-
-      endpoint_id = mapping.endpoint_id
-      db_retention_policy = mapping.database_retention_policy
-      db_ttl = mapping.database_retention_ttl
-      device_id_string = Device.encode_device_id(state.device_id)
+         :ok <- maybe_validate_value_type(context, interface_descriptor, mapping, value),
+         :ok <- can_set_to_value(context, interface_descriptor, mapping, value, value_timestamp) do
+      execute_incoming_data_triggers(
+        context,
+        interface_descriptor,
+        mapping,
+        value,
+        value_timestamp
+      )
 
       maybe_explicit_value_timestamp =
         if mapping.explicit_timestamp,
           do: value_timestamp,
           else: div(timestamp, 10000)
 
-      Core.DataTrigger.execute_incoming_data_triggers(
-        state,
-        device_id_string,
-        interface_descriptor.name,
-        interface_id,
-        path,
-        endpoint_id,
-        payload,
-        value,
-        maybe_explicit_value_timestamp
-      )
+      context = Map.put(context, :explicit_value_timestamp, maybe_explicit_value_timestamp)
 
-      {has_change_triggers, change_triggers} =
-        Core.Interface.get_value_change_triggers(state, interface_id, endpoint_id, path, value)
-
-      has_change_triggers = has_change_triggers == :ok
+      maybe_change_triggers =
+        Core.Interface.get_value_change_triggers(
+          state,
+          interface_descriptor.interface_id,
+          mapping.endpoint_id,
+          path,
+          value
+        )
 
       previous_value =
-        with true <- has_change_triggers,
-             {:ok, property_value} <-
-               Data.fetch_property(
-                 state.realm,
-                 state.device_id,
-                 interface_descriptor,
-                 mapping,
-                 path
-               ) do
-          property_value
-        end
+        get_previous_value(context, interface_descriptor, mapping, maybe_change_triggers)
 
-      with true <- has_change_triggers do
-        :ok =
-          Core.Trigger.execute_pre_change_triggers(
-            change_triggers,
-            state.realm,
-            device_id_string,
-            interface_descriptor.name,
-            path,
-            previous_value,
-            value,
-            maybe_explicit_value_timestamp,
-            state.trigger_id_to_policy_name
-          )
-      end
+      context = Map.put(context, :previous_value, previous_value)
+
+      :ok =
+        maybe_execute_pre_change_triggers(
+          context,
+          interface_descriptor,
+          value,
+          maybe_change_triggers
+        )
 
       realm_max_ttl = state.datastream_maximum_storage_retention
 
-      db_max_ttl = max_ttl(db_retention_policy, realm_max_ttl, db_ttl)
+      db_max_ttl =
+        max_ttl(mapping.database_retention_policy, realm_max_ttl, mapping.database_retention_ttl)
 
-      cond do
-        interface_descriptor.type == :datastream and value != nil ->
-          :ok =
-            cond do
-              Cache.has_key?(state.paths_cache, {interface, path}) ->
-                :ok
+      context = Map.put(context, :db_max_ttl, db_max_ttl)
 
-              is_still_valid?(
-                # TODO this is now a bang!
-                Queries.fetch_path_expiry(
-                  state.realm,
-                  state.device_id,
-                  interface_descriptor,
-                  mapping,
-                  path
-                ),
-                db_max_ttl
-              ) ->
-                :ok
+      # Here value cannot be nil, otherwise `can_set_to_value/5` would have not
+      # been :ok
+      if interface_descriptor.type == :datastream,
+        do: maybe_insert_path(context, interface_descriptor, mapping)
 
-              true ->
-                Queries.insert_path_into_db(
-                  state.realm,
-                  state.device_id,
-                  interface_descriptor,
-                  mapping,
-                  path,
-                  maybe_explicit_value_timestamp,
-                  timestamp,
-                  ttl: path_ttl(db_max_ttl)
-                )
-            end
-
-        interface_descriptor.type == :datastream ->
-          Logger.warning("Tried to unset a datastream.", tag: "unset_on_datastream")
-          MessageTracker.discard(state.message_tracker, message_id)
-
-          :telemetry.execute(
-            [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-            %{},
-            %{realm: state.realm}
-          )
-
-          base64_payload = Base.encode64(payload)
-
-          error_metadata = %{
-            "interface" => inspect(interface),
-            "path" => inspect(path),
-            "base64_payload" => base64_payload
-          }
-
-          Core.Trigger.execute_device_error_triggers(
-            state,
-            "unset_on_datastream",
-            error_metadata,
-            timestamp
-          )
-
-          raise "Unsupported"
-
-        true ->
-          :ok
-      end
-
-      # TODO: handle insert failures here
-      insert_result =
-        Queries.insert_value_into_db(
-          state.realm,
-          state.device_id,
-          interface_descriptor,
-          mapping,
-          path,
-          value,
-          maybe_explicit_value_timestamp,
-          timestamp,
-          ttl: db_max_ttl
-        )
-
-      case insert_result do
-        {:error, :unset_not_allowed} ->
-          Logger.warning("Tried to unset a property with `allow_unset`=false.",
-            tag: "unset_not_allowed"
-          )
-
-          MessageTracker.discard(state.message_tracker, message_id)
-
-          :telemetry.execute(
-            [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-            %{},
-            %{realm: state.realm}
-          )
-
-          base64_payload = Base.encode64(payload)
-
-          error_metadata = %{
-            "interface" => inspect(interface),
-            "path" => inspect(path),
-            "base64_payload" => base64_payload
-          }
-
-          Core.Trigger.execute_device_error_triggers(
-            state,
-            "unset_not_allowed",
-            error_metadata,
-            timestamp
-          )
-
-        :ok ->
-          with true <- has_change_triggers do
-            :ok =
-              Core.Trigger.execute_post_change_triggers(
-                change_triggers,
-                state.realm,
-                device_id_string,
-                interface_descriptor.name,
-                path,
-                previous_value,
-                value,
-                maybe_explicit_value_timestamp,
-                state.trigger_id_to_policy_name
-              )
-          end
-
-          ttl = db_max_ttl
-          paths_cache = Cache.put(state.paths_cache, {interface, path}, %CachedPath{}, ttl)
-          state = %{state | paths_cache: paths_cache}
-
-          MessageTracker.ack_delivery(state.message_tracker, message_id)
-
-          :telemetry.execute(
-            [:astarte, :data_updater_plant, :data_updater, :processed_message],
-            %{},
-            %{
-              realm: state.realm,
-              interface_type: interface_descriptor.type
-            }
-          )
-
-          update_stats(state, interface, interface_descriptor.major_version, path, payload)
-      end
+      Queries.insert_value_into_db(
+        state.realm,
+        state.device_id,
+        interface_descriptor,
+        mapping,
+        path,
+        value,
+        maybe_explicit_value_timestamp,
+        timestamp,
+        ttl: db_max_ttl
+      )
+      |> handle_result(context, maybe_change_triggers, interface_descriptor, value)
     end
+  end
+
+  defp maybe_execute_pre_change_triggers(
+         context,
+         interface_descriptor,
+         value,
+         {:ok, change_triggers}
+       ) do
+    %{
+      state: state,
+      path: path,
+      previous_value: previous_value,
+      explicit_value_timestamp: explicit_value_timestamp
+    } = context
+
+    Core.Trigger.execute_pre_change_triggers(
+      change_triggers,
+      state.realm,
+      Device.encode_device_id(state.device_id),
+      interface_descriptor.name,
+      path,
+      previous_value,
+      value,
+      explicit_value_timestamp,
+      state.trigger_id_to_policy_name
+    )
+  end
+
+  defp maybe_execute_pre_change_triggers(_, _, _, _), do: :ok
+
+  defp maybe_execute_post_change_triggers(
+         context,
+         interface_descriptor,
+         value,
+         {:ok, change_triggers}
+       ) do
+    %{
+      state: state,
+      path: path,
+      previous_value: previous_value,
+      explicit_value_timestamp: explicit_value_timestamp
+    } = context
+
+    Core.Trigger.execute_post_change_triggers(
+      change_triggers,
+      state.realm,
+      Device.encode_device_id(state.device_id),
+      interface_descriptor.name,
+      path,
+      previous_value,
+      value,
+      explicit_value_timestamp,
+      state.trigger_id_to_policy_name
+    )
+  end
+
+  defp maybe_execute_post_change_triggers(_, _, _, _), do: :ok
+
+  defp get_previous_value(context, interface_descriptor, mapping, {:ok, _change_triggers}) do
+    %{state: state, path: path} = context
+
+    case Data.fetch_property(state.realm, state.device_id, interface_descriptor, mapping, path) do
+      {:ok, property_value} -> property_value
+      _ -> nil
+    end
+  end
+
+  defp get_previous_value(_, _, _, _), do: nil
+
+  defp handle_result({:error, :unset_not_allowed}, context, _, _, _) do
+    error = %{
+      message: "Tried to unset a property with `allow_unset`=false.",
+      tag: "unset_not_allowed",
+      error_name: "unset_not_allowed",
+      update_stats: false
+    }
+
+    # with `unset_not_allowed` we do not want to update the stats
+    Error.handle_error(context, error)
+  end
+
+  defp handle_result(:ok, context, maybe_change_triggers, interface_descriptor, value) do
+    %{
+      state: state,
+      path: path,
+      payload: payload,
+      interface: interface,
+      message_id: message_id,
+      db_max_ttl: db_max_ttl
+    } = context
+
+    maybe_execute_post_change_triggers(
+      context,
+      interface_descriptor,
+      value,
+      maybe_change_triggers
+    )
+
+    paths_cache = Cache.put(state.paths_cache, {interface, path}, %CachedPath{}, db_max_ttl)
+    state = %{state | paths_cache: paths_cache}
+
+    MessageTracker.ack_delivery(state.message_tracker, message_id)
+
+    :telemetry.execute(
+      [:astarte, :data_updater_plant, :data_updater, :processed_message],
+      %{},
+      %{
+        realm: state.realm,
+        interface_type: interface_descriptor.type
+      }
+    )
+
+    update_stats(state, interface, interface_descriptor.major_version, path, payload)
+  end
+
+  defp maybe_insert_path(context, interface_descriptor, mapping) do
+    %{
+      state: state,
+      interface: interface,
+      path: path,
+      timestamp: timestamp,
+      explicit_value_timestamp: explicit_value_timestamp,
+      db_max_ttl: db_max_ttl
+    } = context
+
+    with false <- Cache.has_key?(state.paths_cache, {interface, path}),
+         false <-
+           Queries.fetch_path_expiry(
+             state.realm,
+             state.device_id,
+             interface_descriptor,
+             mapping,
+             path
+           )
+           |> is_still_valid?(db_max_ttl) do
+      Queries.insert_path_into_db(
+        state.realm,
+        state.device_id,
+        interface_descriptor,
+        mapping,
+        path,
+        explicit_value_timestamp,
+        timestamp,
+        ttl: path_ttl(db_max_ttl)
+      )
+    end
+  end
+
+  defp can_set_to_value(
+         context,
+         %InterfaceDescriptor{type: :datastream} = interface_descriptor,
+         mapping,
+         nil,
+         value_timestamp
+       ) do
+    # We still want to execute incoming data triggers
+    execute_incoming_data_triggers(context, interface_descriptor, mapping, nil, value_timestamp)
+
+    error = %{
+      message: "Tried to unset a datastream.",
+      tag: "unset_on_datastream",
+      error_name: "unset_on_datastream"
+    }
+
+    Error.handle_error(context, error)
+  end
+
+  defp can_set_to_value(_context, _descriptor, _mapping, _value, _value_timestamp), do: :ok
+
+  defp execute_incoming_data_triggers(
+         context,
+         interface_descriptor,
+         mapping,
+         value,
+         value_timestamp
+       ) do
+    %{state: state, path: path, payload: payload} = context
+    interface_id = interface_descriptor.interface_id
+
+    maybe_explicit_value_timestamp =
+      if mapping.explicit_timestamp,
+        do: value_timestamp,
+        else: div(context.timestamp, 10000)
+
+    Core.DataTrigger.execute_incoming_data_triggers(
+      state,
+      Device.encode_device_id(state.device_id),
+      interface_descriptor.name,
+      interface_id,
+      path,
+      mapping.endpoint_id,
+      payload,
+      value,
+      maybe_explicit_value_timestamp
+    )
   end
 
   defp maybe_handle_cache_miss(context) do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -65,7 +65,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           do: value_timestamp,
           else: div(timestamp, 10000)
 
-      Impl.execute_incoming_data_triggers(
+      Core.DataTrigger.execute_incoming_data_triggers(
         state,
         device_id_string,
         interface_descriptor.name,
@@ -78,7 +78,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
       )
 
       {has_change_triggers, change_triggers} =
-        Impl.get_value_change_triggers(state, interface_id, endpoint_id, path, value)
+        Core.Interface.get_value_change_triggers(state, interface_id, endpoint_id, path, value)
 
       previous_value =
         with {:has_change_triggers, :ok} <- {:has_change_triggers, has_change_triggers},
@@ -101,7 +101,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
 
       if has_change_triggers == :ok do
         :ok =
-          Impl.execute_pre_change_triggers(
+          Core.Trigger.execute_pre_change_triggers(
             change_triggers,
             state.realm,
             device_id_string,
@@ -182,7 +182,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
             "base64_payload" => base64_payload
           }
 
-          Impl.execute_device_error_triggers(
+          Core.Trigger.execute_device_error_triggers(
             state,
             "unset_on_datastream",
             error_metadata,
@@ -231,7 +231,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
             "base64_payload" => base64_payload
           }
 
-          Impl.execute_device_error_triggers(
+          Core.Trigger.execute_device_error_triggers(
             state,
             "unset_not_allowed",
             error_metadata,
@@ -241,7 +241,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
         :ok ->
           if has_change_triggers == :ok do
             :ok =
-              Impl.execute_post_change_triggers(
+              Core.Trigger.execute_post_change_triggers(
                 change_triggers,
                 state.realm,
                 device_id_string,
@@ -296,7 +296,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           state,
           "write_on_server_owned_interface",
           error_metadata,
@@ -327,7 +327,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           state,
           "invalid_interface",
           error_metadata,
@@ -356,7 +356,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(state, "invalid_path", error_metadata, timestamp)
+        Core.Trigger.execute_device_error_triggers(
+          state,
+          "invalid_path",
+          error_metadata,
+          timestamp
+        )
 
         update_stats(state, interface, nil, path, payload)
 
@@ -382,7 +387,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(state, "mapping_not_found", error_metadata, timestamp)
+        Core.Trigger.execute_device_error_triggers(
+          state,
+          "mapping_not_found",
+          error_metadata,
+          timestamp
+        )
 
         update_stats(state, interface, nil, path, payload)
 
@@ -407,7 +417,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           state,
           "interface_loading_failed",
           error_metadata,
@@ -438,7 +448,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           state,
           "ambiguous_path",
           error_metadata,
@@ -470,7 +480,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           state,
           "undecodable_bson_payload",
           error_metadata,
@@ -502,7 +512,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           state,
           "unexpected_value_type",
           error_metadata,
@@ -534,7 +544,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           state,
           "value_size_exceeded",
           error_metadata,
@@ -566,7 +576,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           "base64_payload" => base64_payload
         }
 
-        Impl.execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           state,
           "unexpected_object_key",
           error_metadata,

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -33,25 +33,22 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   require Logger
 
   def handle_data(state, interface, path, payload, message_id, timestamp) do
-    with :ok <- validate_interface(interface),
-         :ok <- validate_path(path),
-         {:ok, interface_descriptor, state} <-
-           state.interfaces
-           |> Map.get(interface)
-           |> Core.Interface.maybe_handle_cache_miss(interface, state),
-         :ok <- can_write_on_interface?(interface_descriptor.ownership),
-         {:ok, mapping} <-
-           Core.Interface.resolve_path(path, interface_descriptor, state.mappings),
-         {value, value_timestamp, _metadata} <-
-           PayloadsDecoder.decode_bson_payload(payload, timestamp),
-         :ok <-
-           Core.Interface.extract_expected_types(
-             path,
-             interface_descriptor,
-             mapping,
-             state.mappings
-           )
-           |> validate_value_type(value) do
+    context = %{
+      state: state,
+      interface: interface,
+      path: path,
+      payload: payload,
+      message_id: message_id,
+      timestamp: timestamp
+    }
+
+    with :ok <- validate_interface(context),
+         :ok <- validate_path(context),
+         {:ok, interface_descriptor, state, context} <- maybe_handle_cache_miss(context),
+         :ok <- can_write_on_interface?(context, interface_descriptor.ownership),
+         {:ok, mapping} <- resolve_path(context, interface_descriptor),
+         {value, value_timestamp, _metadata} <- decode_bson_payload(context),
+         :ok <- maybe_validate_value_type(context, interface_descriptor, mapping, value) do
       interface_id = interface_descriptor.interface_id
 
       endpoint_id = mapping.endpoint_id
@@ -253,319 +250,74 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
 
           update_stats(state, interface, interface_descriptor.major_version, path, payload)
       end
-    else
-      {:error, :cannot_write_on_server_owned_interface} ->
-        Logger.warning(
-          "Tried to write on server owned interface: #{interface} on " <>
-            "path: #{path}, base64-encoded payload: #{inspect(Base.encode64(payload))}, timestamp: #{inspect(timestamp)}.",
-          tag: "write_on_server_owned_interface"
-        )
+    end
+  end
 
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
+  defp maybe_handle_cache_miss(context) do
+    %{interface: interface, state: state} = context
 
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
+    cache_miss =
+      state.interfaces
+      |> Map.get(interface)
+      |> Core.Interface.maybe_handle_cache_miss(interface, state)
 
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "write_on_server_owned_interface",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :invalid_interface} ->
-        Logger.warning("Received invalid interface: #{inspect(interface)}.",
-          tag: "invalid_interface"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "invalid_interface",
-          error_metadata,
-          timestamp
-        )
-
-        # We dont't update stats on an invalid interface
-        state
-
-      {:error, :invalid_path} ->
-        Logger.warning("Received invalid path: #{inspect(path)}.", tag: "invalid_path")
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "invalid_path",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :mapping_not_found} ->
-        Logger.warning("Mapping not found for #{interface}#{path}. Maybe outdated introspection?",
-          tag: "mapping_not_found"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "mapping_not_found",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
+    case cache_miss do
       {:error, :interface_loading_failed} ->
-        Logger.warning("Cannot load interface: #{interface}.", tag: "interface_loading_failed")
-        # TODO: think about additional actions since the problem
-        # could be a missing interface in the DB
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
+        error = %{
+          message: "Cannot load interface: #{interface}.",
+          tag: "interface_loading_failed",
+          error_name: "interface_loading_failed"
         }
 
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "interface_loading_failed",
-          error_metadata,
-          timestamp
-        )
+        Core.Error.handle_error(context, error)
 
-        update_stats(state, interface, nil, path, payload)
+      {:ok, descriptor, state} ->
+        new_context = Map.put(context, :state, state)
+        {:ok, descriptor, state, new_context}
+    end
+  end
+
+  defp resolve_path(context, interface_descriptor) do
+    %{interface: interface, path: path, state: state} = context
+    mappings = Core.Interface.resolve_path(path, interface_descriptor, state.mappings)
+
+    case mappings do
+      {:error, :mapping_not_found} ->
+        error = %{
+          message: "Mapping not found for #{interface}#{path}. Maybe outdated introspection?",
+          tag: "mapping_not_found",
+          error_name: "mapping_not_found"
+        }
+
+        Core.Error.handle_error(context, error)
 
       {:guessed, _guessed_endpoints} ->
-        Logger.warning("Mapping guessed for #{interface}#{path}. Maybe outdated introspection?",
-          tag: "ambiguous_path"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
+        error = %{
+          message: "Mapping guessed for #{interface}#{path}. Maybe outdated introspection?",
+          tag: "ambiguous_path",
+          error_name: "ambiguous_path"
         }
 
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "ambiguous_path",
-          error_metadata,
-          timestamp
-        )
+        Core.Error.handle_error(context, error)
 
-        update_stats(state, interface, nil, path, payload)
+      ok ->
+        ok
+    end
+  end
 
-      {:error, :undecodable_bson_payload} ->
-        Logger.warning(
+  defp decode_bson_payload(context) do
+    %{payload: payload, timestamp: timestamp, interface: interface, path: path} = context
+    decoding = PayloadsDecoder.decode_bson_payload(payload, timestamp)
+
+    with {:error, :undecodable_bson_payload} <- decoding do
+      error = %{
+        message:
           "Invalid BSON base64-encoded payload: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
-          tag: "undecodable_bson_payload"
-        )
+        tag: "undecodable_bson_payload",
+        error_name: "undecodable_bson_payload"
+      }
 
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "undecodable_bson_payload",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :unexpected_value_type} ->
-        Logger.warning(
-          "Received invalid value: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
-          tag: "unexpected_value_type"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "unexpected_value_type",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :value_size_exceeded} ->
-        Logger.warning(
-          "Received huge base64-encoded payload: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
-          tag: "value_size_exceeded"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        base64_payload = Base.encode64(payload)
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "value_size_exceeded",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
-
-      {:error, :unexpected_object_key} ->
-        base64_payload = Base.encode64(payload)
-
-        Logger.warning(
-          "Received object with unexpected key, object base64 is: #{base64_payload} sent to #{interface}#{path}.",
-          tag: "unexpected_object_key"
-        )
-
-        {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
-        MessageTracker.discard(state.message_tracker, message_id)
-
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :data_updater, :discarded_message],
-          %{},
-          %{realm: state.realm}
-        )
-
-        error_metadata = %{
-          "interface" => inspect(interface),
-          "path" => inspect(path),
-          "base64_payload" => base64_payload
-        }
-
-        Core.Trigger.execute_device_error_triggers(
-          state,
-          "unexpected_object_key",
-          error_metadata,
-          timestamp
-        )
-
-        update_stats(state, interface, nil, path, payload)
+      Core.Error.handle_error(context, error)
     end
   end
 
@@ -588,29 +340,107 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
     now_secs + ttl + 3600 < expiry_secs
   end
 
-  defp validate_interface(interface) do
-    if String.valid?(interface),
-      do: :ok,
-      else: {:error, :invalid_interface}
+  defp validate_interface(%{interface: interface} = context),
+    do: valid_interface_or_error(context, String.valid?(interface))
+
+  defp valid_interface_or_error(_context, true), do: :ok
+
+  defp valid_interface_or_error(%{interface: interface} = context, false) do
+    error = %{
+      message: "Received invalid interface: #{inspect(interface)}.",
+      tag: "invalid_interface",
+      error_name: "invalid_interface",
+      update_stats: false
+    }
+
+    Core.Error.handle_error(context, error)
   end
 
-  defp validate_path(path) do
-    cond do
-      # Make sure the path is a valid unicode string
-      not String.valid?(path) ->
-        {:error, :invalid_path}
+  defp validate_path(%{path: path} = context),
+    do: valid_path_or_error(context, String.valid?(path), String.contains?(path, "//"))
 
-      # TODO: this is a temporary fix to work around a bug in EndpointsAutomaton.resolve_path/2
-      String.contains?(path, "//") ->
-        {:error, :invalid_path}
+  defp valid_path_or_error(_context, true, false), do: :ok
 
-      true ->
-        :ok
+  defp valid_path_or_error(%{path: path} = context, _, _) do
+    error = %{
+      message: "Received invalid path: #{inspect(path)}.",
+      tag: "invalid_path",
+      error_name: "invalid_path"
+    }
+
+    Core.Error.handle_error(context, error)
+  end
+
+  defp can_write_on_interface?(_context, :device), do: :ok
+
+  defp can_write_on_interface?(context, :server) do
+    %{interface: interface, path: path, payload: payload, timestamp: timestamp} = context
+
+    message =
+      "Tried to write on server owned interface: #{interface} on " <>
+        "path: #{path}, base64-encoded payload: #{inspect(Base.encode64(payload))}, timestamp: #{inspect(timestamp)}."
+
+    tag = "write_on_server_owned_interface"
+
+    error_name = "write_on_server_owned_interface"
+
+    error = %{
+      message: message,
+      tag: tag,
+      error_name: error_name
+    }
+
+    Core.Error.handle_error(context, error)
+  end
+
+  defp maybe_validate_value_type(context, interface_descriptor, mapping, value) do
+    %{interface: interface, path: path, payload: payload, state: state} = context
+
+    expected_types =
+      Core.Interface.extract_expected_types(
+        path,
+        interface_descriptor,
+        mapping,
+        state.mappings
+      )
+
+    validation = validate_value_type(expected_types, value)
+
+    case validation do
+      {:error, :unexpected_value_type} ->
+        error = %{
+          message:
+            "Received invalid value: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
+          tag: "unexpected_value_type",
+          error_name: "unexpected_value_type"
+        }
+
+        Core.Error.handle_error(context, error)
+
+      {:error, :unexpected_object_key} ->
+        error = %{
+          message:
+            "Received object with unexpected key, object base64 is: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
+          tag: "unexpected_value_type",
+          error_name: "unexpected_value_type"
+        }
+
+        Core.Error.handle_error(context, error)
+
+      {:error, :value_size_exceeded} ->
+        error = %{
+          message:
+            "Received huge base64-encoded payload: #{inspect(Base.encode64(payload))} sent to #{interface}#{path}.",
+          tag: "value_size_exceeded",
+          error_name: "value_size_exceeded"
+        }
+
+        Core.Error.handle_error(context, error)
+
+      ok ->
+        ok
     end
   end
-
-  defp can_write_on_interface?(:device), do: :ok
-  defp can_write_on_interface?(:server), do: {:error, :cannot_write_on_server_owned_interface}
 
   # TODO: We need tests for this function
   def validate_value_type(expected_type, %DateTime{} = value) do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -79,8 +79,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
       {has_change_triggers, change_triggers} =
         Core.Interface.get_value_change_triggers(state, interface_id, endpoint_id, path, value)
 
+      has_change_triggers = has_change_triggers == :ok
+
       previous_value =
-        with {:has_change_triggers, :ok} <- {:has_change_triggers, has_change_triggers},
+        with true <- has_change_triggers,
              {:ok, property_value} <-
                Data.fetch_property(
                  state.realm,
@@ -90,15 +92,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
                  path
                ) do
           property_value
-        else
-          {:has_change_triggers, _not_ok} ->
-            nil
-
-          {:error, :property_not_set} ->
-            nil
         end
 
-      if has_change_triggers == :ok do
+      with true <- has_change_triggers do
         :ok =
           Core.Trigger.execute_pre_change_triggers(
             change_triggers,
@@ -115,20 +111,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
 
       realm_max_ttl = state.datastream_maximum_storage_retention
 
-      db_max_ttl =
-        cond do
-          db_retention_policy == :use_ttl and is_integer(realm_max_ttl) ->
-            min(db_ttl, realm_max_ttl)
-
-          db_retention_policy == :use_ttl ->
-            db_ttl
-
-          is_integer(realm_max_ttl) ->
-            realm_max_ttl
-
-          true ->
-            nil
-        end
+      db_max_ttl = max_ttl(db_retention_policy, realm_max_ttl, db_ttl)
 
       cond do
         interface_descriptor.type == :datastream and value != nil ->
@@ -238,7 +221,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
           )
 
         :ok ->
-          if has_change_triggers == :ok do
+          with true <- has_change_triggers do
             :ok =
               Core.Trigger.execute_post_change_triggers(
                 change_triggers,
@@ -684,7 +667,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
     end
   end
 
-  defp update_stats(state, interface, major, path, payload) do
+  def update_stats(state, interface, major, path, payload) do
     exchanged_bytes = byte_size(payload) + byte_size(interface) + byte_size(path)
 
     :telemetry.execute(
@@ -743,4 +726,14 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
         interface_exchanged_msgs: updated_interface_exchanged_msgs
     }
   end
+
+  defp max_ttl(:use_ttl, realm_max_ttl, db_ttl) when is_integer(realm_max_ttl),
+    do: min(db_ttl, realm_max_ttl)
+
+  defp max_ttl(:use_ttl, _, db_ttl), do: db_ttl
+
+  defp max_ttl(_db_retention_policy, realm_max_ttl, _db_ttl) when is_integer(realm_max_ttl),
+    do: realm_max_ttl
+
+  defp max_ttl(_, _, _), do: nil
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -437,8 +437,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
 
         Core.Error.handle_error(context, error)
 
-      ok ->
-        ok
+      :ok ->
+        :ok
     end
   end
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_trigger.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_trigger.ex
@@ -22,9 +22,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataTrigger do
   @moduledoc """
 
   """
+  alias Astarte.DataUpdaterPlant.TriggersHandler
   alias Astarte.Core.Mapping.EndpointsAutomaton
   alias Astarte.Core.InterfaceDescriptor
   alias Astarte.Core.Triggers.DataTrigger
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
 
   def data_trigger_to_key(state, data_trigger, event_type) do
     %DataTrigger{
@@ -52,13 +54,86 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataTrigger do
     {event_type, interface_id, endpoint}
   end
 
-  defp replace_empty_token(token) do
-    case token do
-      "" ->
-        "%{}"
+  def execute_incoming_data_triggers(
+        state,
+        device,
+        interface,
+        interface_id,
+        path,
+        endpoint_id,
+        payload,
+        value,
+        timestamp
+      ) do
+    realm = state.realm
 
-      not_empty ->
-        not_empty
-    end
+    # any interface triggers
+    Core.Interface.get_on_data_triggers(state, :on_incoming_data, :any_interface, :any_endpoint)
+    |> Enum.each(fn trigger ->
+      target_with_policy_list = get_target_with_policy_list(state, trigger)
+
+      TriggersHandler.incoming_data(
+        target_with_policy_list,
+        realm,
+        device,
+        interface,
+        path,
+        payload,
+        timestamp
+      )
+    end)
+
+    # any endpoint triggers
+    Core.Interface.get_on_data_triggers(state, :on_incoming_data, interface_id, :any_endpoint)
+    |> Enum.each(fn trigger ->
+      target_with_policy_list = get_target_with_policy_list(state, trigger)
+
+      TriggersHandler.incoming_data(
+        target_with_policy_list,
+        realm,
+        device,
+        interface,
+        path,
+        payload,
+        timestamp
+      )
+    end)
+
+    # incoming data triggers
+    Core.Interface.get_on_data_triggers(
+      state,
+      :on_incoming_data,
+      interface_id,
+      endpoint_id,
+      path,
+      value
+    )
+    |> Enum.each(fn trigger ->
+      target_with_policy_list = get_target_with_policy_list(state, trigger)
+
+      TriggersHandler.incoming_data(
+        target_with_policy_list,
+        realm,
+        device,
+        interface,
+        path,
+        payload,
+        timestamp
+      )
+    end)
+
+    :ok
+  end
+
+  defp replace_empty_token(""), do: "%{}"
+  defp replace_empty_token(non_empty), do: non_empty
+
+  defp get_target_with_policy_list(state, trigger) do
+    trigger.trigger_targets
+    |> Enum.map(fn target ->
+      parent_target_id = Map.get(state.trigger_id_to_policy_name, target.parent_trigger_id)
+
+      {target, parent_target_id}
+    end)
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/device.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/device.ex
@@ -25,10 +25,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Device do
   This module contains functions and utilities to process devices.
   """
   alias Astarte.DataUpdaterPlant.TimeBasedActions
+  alias Astarte.Core.Device
   alias Astarte.DataUpdaterPlant.Config
   alias Astarte.DataUpdaterPlant.MessageTracker
   alias Astarte.DataUpdaterPlant.DataUpdater.Cache
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
+  alias Astarte.DataUpdaterPlant.DataUpdater.State
+  alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
   alias Astarte.Core.CQLUtils
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.DataUpdaterPlant.TriggersHandler
@@ -260,5 +263,95 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Device do
         total_received_msgs: new_state.total_received_msgs + 1,
         total_received_bytes: new_state.total_received_bytes + byte_size(payload)
     }
+  end
+
+  def ask_clean_session(state, timestamp) do
+    Logger.warning("Disconnecting client and asking clean session.")
+    %State{realm: realm, device_id: device_id} = state
+
+    encoded_device_id = Device.encode_device_id(device_id)
+
+    with :ok <- Queries.set_pending_empty_cache(realm, device_id, true),
+         :ok <- force_disconnection(realm, encoded_device_id) do
+      new_state = set_device_disconnected(state, timestamp)
+
+      Logger.info("Successfully forced device disconnection.", tag: "forced_device_disconnection")
+
+      :telemetry.execute(
+        [:astarte, :data_updater_plant, :data_updater, :clean_session_request],
+        %{},
+        %{realm: new_state.realm}
+      )
+
+      {:ok, new_state}
+    else
+      {:error, reason} ->
+        Logger.warning("Disconnect failed due to error: #{inspect(reason)}")
+        # TODO: die gracefully here
+        {:error, :clean_session_failed}
+    end
+  end
+
+  @doc """
+  Sets a device as disconnected, this does not foce device disconnection, but
+  rather informs other astarte components that a device has been disconnected.
+  """
+  def set_device_disconnected(state, timestamp) do
+    timestamp_ms = div(timestamp, 10_000)
+
+    Queries.set_device_disconnected!(
+      state.realm,
+      state.device_id,
+      DateTime.from_unix!(timestamp_ms, :millisecond),
+      state.total_received_msgs,
+      state.total_received_bytes,
+      state.interface_exchanged_msgs,
+      state.interface_exchanged_bytes
+    )
+
+    maybe_execute_device_disconnected_trigger(state, timestamp_ms)
+
+    %{state | connected: false}
+  end
+
+  defp maybe_execute_device_disconnected_trigger(%State{connected: false}, _), do: :ok
+
+  defp maybe_execute_device_disconnected_trigger(state, timestamp_ms) do
+    trigger_target_with_policy_list =
+      Map.get(state.device_triggers, :on_device_disconnection, [])
+      |> Enum.map(fn target ->
+        {target, Map.get(state.trigger_id_to_policy_name, target.parent_trigger_id)}
+      end)
+
+    device_id_string = Device.encode_device_id(state.device_id)
+
+    TriggersHandler.device_disconnected(
+      trigger_target_with_policy_list,
+      state.realm,
+      device_id_string,
+      timestamp_ms
+    )
+
+    :telemetry.execute(
+      [:astarte, :data_updater_plant, :data_updater, :device_disconnection],
+      %{},
+      %{realm: state.realm}
+    )
+  end
+
+  defp force_disconnection(realm, encoded_device_id) do
+    case VMQPlugin.disconnect("#{realm}/#{encoded_device_id}", true) do
+      # Successfully disconnected
+      :ok ->
+        :ok
+
+      # Not found means it was already disconnected, succeed anyway
+      {:error, :not_found} ->
+        :ok
+
+      # Some other error, return it
+      {:error, reason} ->
+        {:error, reason}
+    end
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/error.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/error.ex
@@ -1,0 +1,108 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Error do
+  @moduledoc """
+  Part of the `DataUpdater` `Core` modules
+
+  This module is responsble for providing utilities to handle errors during the handling of messages
+  """
+  alias Astarte.DataUpdaterPlant.MessageTracker
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
+
+  require Logger
+
+  @doc """
+  Handles errors arising when handling data from a device. It needs a context,
+  a map in the shape:
+
+  %{
+    state: DataUpdater.State.t(),
+    interface: Astarte.Core.Interface.t(),
+    message_id: binary(),
+    path: String.t(),
+    timestamp: DateTime.t(),
+    payload: binary()
+  }
+
+  and returns the updated state after asking for a clean session
+
+  the `error` should consist of a map with
+
+  %{
+    message: String.t(),
+    tag: String.t(),
+    error_name: String.t(),
+    update_stats: bool()          # optional
+  }
+
+  The first two for the logging and the latter to execute device error triggers.
+  The optional `update_stats` parameter switches the update of stats when the
+  telemetry has been executed.
+  """
+  def handle_error(context, error) do
+    %{
+      state: state,
+      interface: interface,
+      message_id: message_id,
+      path: path,
+      timestamp: timestamp,
+      payload: payload
+    } = context
+
+    %{
+      message: message,
+      tag: tag,
+      error_name: error_name
+    } = error
+
+    update_stats = Map.get(error, :update_stats, true)
+
+    Logger.warning(message, tag: tag)
+
+    {:ok, state} = Core.Device.ask_clean_session(state, timestamp)
+    MessageTracker.discard(state.message_tracker, message_id)
+
+    :telemetry.execute(
+      [:astarte, :data_updater_plant, :data_updater, :discarded_message],
+      %{},
+      %{realm: state.realm}
+    )
+
+    base64_payload = Base.encode64(payload)
+
+    error_metadata = %{
+      "interface" => inspect(interface),
+      "path" => inspect(path),
+      "base64_payload" => base64_payload
+    }
+
+    Core.Trigger.execute_device_error_triggers(
+      state,
+      error_name,
+      error_metadata,
+      timestamp
+    )
+
+    if update_stats,
+      do: Core.DataHandler.update_stats(state, interface, nil, path, payload),
+      else: state
+  end
+end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/interface.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/interface.ex
@@ -219,6 +219,42 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Interface do
     end
   end
 
+  def get_value_change_triggers(state, interface_id, endpoint_id, path, value) do
+    value_change_triggers =
+      get_on_data_triggers(state, :on_value_change, interface_id, endpoint_id, path, value)
+
+    value_change_applied_triggers =
+      get_on_data_triggers(
+        state,
+        :on_value_change_applied,
+        interface_id,
+        endpoint_id,
+        path,
+        value
+      )
+
+    path_created_triggers =
+      get_on_data_triggers(state, :on_path_created, interface_id, endpoint_id, path, value)
+
+    path_removed_triggers =
+      get_on_data_triggers(state, :on_path_removed, interface_id, endpoint_id, path)
+
+    all_empty? =
+      [value_change_triggers, value_change_applied_triggers, path_created_triggers]
+      |> Enum.all?(&Enum.empty?/1)
+
+    triggers_tuple = {
+      value_change_triggers,
+      value_change_applied_triggers,
+      path_created_triggers,
+      path_removed_triggers
+    }
+
+    if all_empty?,
+      do: {:no_value_change_triggers, nil},
+      else: {:ok, triggers_tuple}
+  end
+
   defp path_matches?([], []) do
     true
   end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -180,7 +180,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       tag: "unexpected_internal_message"
     )
 
-    {:ok, new_state} = ask_clean_session(state, timestamp)
+    {:ok, new_state} = Core.Device.ask_clean_session(state, timestamp)
     MessageTracker.discard(new_state.message_tracker, message_id)
 
     :telemetry.execute(
@@ -218,7 +218,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     new_state =
       state
       |> TimeBasedActions.execute_time_based_actions(timestamp)
-      |> set_device_disconnected(timestamp)
+      |> Core.Device.set_device_disconnected(timestamp)
 
     MessageTracker.ack_delivery(new_state.message_tracker, message_id)
     Logger.info("Device disconnected.", tag: "device_disconnected")
@@ -316,7 +316,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           tag: "invalid_introspection"
         )
 
-        {:ok, new_state} = ask_clean_session(state, timestamp)
+        {:ok, new_state} = Core.Device.ask_clean_session(state, timestamp)
         MessageTracker.discard(new_state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -390,7 +390,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       :error ->
         Logger.warning("Invalid purge_properties payload", tag: "purge_properties_error")
 
-        {:ok, new_state} = ask_clean_session(new_state, timestamp)
+        {:ok, new_state} = Core.Device.ask_clean_session(new_state, timestamp)
         MessageTracker.discard(new_state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -422,7 +422,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       {:error, :session_not_found} ->
         Logger.warning("Cannot push data to device.", tag: "device_session_not_found")
 
-        {:ok, new_state} = ask_clean_session(new_state, timestamp)
+        {:ok, new_state} = Core.Device.ask_clean_session(new_state, timestamp)
         MessageTracker.discard(new_state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -444,7 +444,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           tag: "resend_interface_properties_failed"
         )
 
-        {:ok, new_state} = ask_clean_session(new_state, timestamp)
+        {:ok, new_state} = Core.Device.ask_clean_session(new_state, timestamp)
         MessageTracker.discard(new_state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -466,7 +466,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           tag: "empty_cache_error"
         )
 
-        {:ok, new_state} = ask_clean_session(new_state, timestamp)
+        {:ok, new_state} = Core.Device.ask_clean_session(new_state, timestamp)
         MessageTracker.discard(new_state.message_tracker, message_id)
 
         :telemetry.execute(
@@ -494,7 +494,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       tag: "unexpected_control_message"
     )
 
-    {:ok, new_state} = ask_clean_session(state, timestamp)
+    {:ok, new_state} = Core.Device.ask_clean_session(state, timestamp)
     MessageTracker.discard(new_state.message_tracker, message_id)
 
     :telemetry.execute(
@@ -745,94 +745,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     end)
 
     :ok
-  end
-
-  def set_device_disconnected(state, timestamp) do
-    timestamp_ms = div(timestamp, 10_000)
-
-    Queries.set_device_disconnected!(
-      state.realm,
-      state.device_id,
-      DateTime.from_unix!(timestamp_ms, :millisecond),
-      state.total_received_msgs,
-      state.total_received_bytes,
-      state.interface_exchanged_msgs,
-      state.interface_exchanged_bytes
-    )
-
-    maybe_execute_device_disconnected_trigger(state, timestamp_ms)
-
-    %{state | connected: false}
-  end
-
-  defp maybe_execute_device_disconnected_trigger(%State{connected: false}, _) do
-    :ok
-  end
-
-  defp maybe_execute_device_disconnected_trigger(state, timestamp_ms) do
-    trigger_target_with_policy_list =
-      Map.get(state.device_triggers, :on_device_disconnection, [])
-      |> Enum.map(fn target ->
-        {target, Map.get(state.trigger_id_to_policy_name, target.parent_trigger_id)}
-      end)
-
-    device_id_string = Device.encode_device_id(state.device_id)
-
-    TriggersHandler.device_disconnected(
-      trigger_target_with_policy_list,
-      state.realm,
-      device_id_string,
-      timestamp_ms
-    )
-
-    :telemetry.execute(
-      [:astarte, :data_updater_plant, :data_updater, :device_disconnection],
-      %{},
-      %{realm: state.realm}
-    )
-  end
-
-  def ask_clean_session(state, timestamp) do
-    Logger.warning("Disconnecting client and asking clean session.")
-    %State{realm: realm, device_id: device_id} = state
-
-    encoded_device_id = Device.encode_device_id(device_id)
-
-    with :ok <- Queries.set_pending_empty_cache(realm, device_id, true),
-         :ok <- force_disconnection(realm, encoded_device_id) do
-      new_state = set_device_disconnected(state, timestamp)
-
-      Logger.info("Successfully forced device disconnection.", tag: "forced_device_disconnection")
-
-      :telemetry.execute(
-        [:astarte, :data_updater_plant, :data_updater, :clean_session_request],
-        %{},
-        %{realm: new_state.realm}
-      )
-
-      {:ok, new_state}
-    else
-      {:error, reason} ->
-        Logger.warning("Disconnect failed due to error: #{inspect(reason)}")
-        # TODO: die gracefully here
-        {:error, :clean_session_failed}
-    end
-  end
-
-  defp force_disconnection(realm, encoded_device_id) do
-    case VMQPlugin.disconnect("#{realm}/#{encoded_device_id}", true) do
-      # Successfully disconnected
-      :ok ->
-        :ok
-
-      # Not found means it was already disconnected, succeed anyway
-      {:error, :not_found} ->
-        :ok
-
-      # Some other error, return it
-      {:error, reason} ->
-        {:error, reason}
-    end
   end
 
   defp send_control_consumer_properties(state) do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -197,7 +197,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     }
 
     # TODO maybe we don't want triggers on unexpected internal messages?
-    execute_device_error_triggers(
+    Core.Trigger.execute_device_error_triggers(
       new_state,
       "unexpected_internal_message",
       error_metadata,
@@ -224,272 +224,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     Logger.info("Device disconnected.", tag: "device_disconnected")
 
     %{new_state | last_seen_message: timestamp}
-  end
-
-  def execute_incoming_data_triggers(
-        state,
-        device,
-        interface,
-        interface_id,
-        path,
-        endpoint_id,
-        payload,
-        value,
-        timestamp
-      ) do
-    realm = state.realm
-
-    # any interface triggers
-    Core.Interface.get_on_data_triggers(state, :on_incoming_data, :any_interface, :any_endpoint)
-    |> Enum.each(fn trigger ->
-      target_with_policy_list = get_target_with_policy_list(state, trigger)
-
-      TriggersHandler.incoming_data(
-        target_with_policy_list,
-        realm,
-        device,
-        interface,
-        path,
-        payload,
-        timestamp
-      )
-    end)
-
-    # any endpoint triggers
-    Core.Interface.get_on_data_triggers(state, :on_incoming_data, interface_id, :any_endpoint)
-    |> Enum.each(fn trigger ->
-      target_with_policy_list = get_target_with_policy_list(state, trigger)
-
-      TriggersHandler.incoming_data(
-        target_with_policy_list,
-        realm,
-        device,
-        interface,
-        path,
-        payload,
-        timestamp
-      )
-    end)
-
-    # incoming data triggers
-    Core.Interface.get_on_data_triggers(
-      state,
-      :on_incoming_data,
-      interface_id,
-      endpoint_id,
-      path,
-      value
-    )
-    |> Enum.each(fn trigger ->
-      target_with_policy_list = get_target_with_policy_list(state, trigger)
-
-      TriggersHandler.incoming_data(
-        target_with_policy_list,
-        realm,
-        device,
-        interface,
-        path,
-        payload,
-        timestamp
-      )
-    end)
-
-    :ok
-  end
-
-  defp get_target_with_policy_list(state, trigger) do
-    trigger.trigger_targets
-    |> Enum.map(fn target ->
-      {target, Map.get(state.trigger_id_to_policy_name, target.parent_trigger_id)}
-    end)
-  end
-
-  def get_value_change_triggers(state, interface_id, endpoint_id, path, value) do
-    value_change_triggers =
-      Core.Interface.get_on_data_triggers(
-        state,
-        :on_value_change,
-        interface_id,
-        endpoint_id,
-        path,
-        value
-      )
-
-    value_change_applied_triggers =
-      Core.Interface.get_on_data_triggers(
-        state,
-        :on_value_change_applied,
-        interface_id,
-        endpoint_id,
-        path,
-        value
-      )
-
-    path_created_triggers =
-      Core.Interface.get_on_data_triggers(
-        state,
-        :on_path_created,
-        interface_id,
-        endpoint_id,
-        path,
-        value
-      )
-
-    path_removed_triggers =
-      Core.Interface.get_on_data_triggers(
-        state,
-        :on_path_removed,
-        interface_id,
-        endpoint_id,
-        path
-      )
-
-    if value_change_triggers != [] or value_change_applied_triggers != [] or
-         path_created_triggers != [] do
-      {:ok,
-       {value_change_triggers, value_change_applied_triggers, path_created_triggers,
-        path_removed_triggers}}
-    else
-      {:no_value_change_triggers, nil}
-    end
-  end
-
-  def execute_pre_change_triggers(
-        {value_change_triggers, _, _, _},
-        realm,
-        device_id_string,
-        interface_name,
-        path,
-        previous_value,
-        value,
-        timestamp,
-        trigger_id_to_policy_name_map
-      ) do
-    old_bson_value = Cyanide.encode!(%{v: previous_value})
-    payload = Cyanide.encode!(%{v: value})
-
-    if previous_value != value do
-      Enum.each(value_change_triggers, fn trigger ->
-        trigger_target_with_policy_list =
-          trigger.trigger_targets
-          |> Enum.map(fn target ->
-            {target, Map.get(trigger_id_to_policy_name_map, target.parent_trigger_id)}
-          end)
-
-        TriggersHandler.value_change(
-          trigger_target_with_policy_list,
-          realm,
-          device_id_string,
-          interface_name,
-          path,
-          old_bson_value,
-          payload,
-          timestamp
-        )
-      end)
-    end
-
-    :ok
-  end
-
-  def execute_post_change_triggers(
-        {_, value_change_applied_triggers, path_created_triggers, path_removed_triggers},
-        realm,
-        device,
-        interface,
-        path,
-        previous_value,
-        value,
-        timestamp,
-        trigger_id_to_policy_name_map
-      ) do
-    old_bson_value = Cyanide.encode!(%{v: previous_value})
-    payload = Cyanide.encode!(%{v: value})
-
-    if previous_value == nil and value != nil do
-      Enum.each(path_created_triggers, fn trigger ->
-        target_with_policy_list =
-          trigger.trigger_targets
-          |> Enum.map(fn target ->
-            {target, Map.get(trigger_id_to_policy_name_map, target.parent_trigger_id)}
-          end)
-
-        TriggersHandler.path_created(
-          target_with_policy_list,
-          realm,
-          device,
-          interface,
-          path,
-          payload,
-          timestamp
-        )
-      end)
-    end
-
-    if previous_value != nil and value == nil do
-      Enum.each(path_removed_triggers, fn trigger ->
-        target_with_policy_list =
-          trigger.trigger_targets
-          |> Enum.map(fn target ->
-            {target, Map.get(trigger_id_to_policy_name_map, target.parent_trigger_id)}
-          end)
-
-        TriggersHandler.path_removed(
-          target_with_policy_list,
-          realm,
-          device,
-          interface,
-          path,
-          timestamp
-        )
-      end)
-    end
-
-    if previous_value != value do
-      Enum.each(value_change_applied_triggers, fn trigger ->
-        target_with_policy_list =
-          trigger.trigger_targets
-          |> Enum.map(fn target ->
-            {target, Map.get(trigger_id_to_policy_name_map, target.parent_trigger_id)}
-          end)
-
-        TriggersHandler.value_change_applied(
-          target_with_policy_list,
-          realm,
-          device,
-          interface,
-          path,
-          old_bson_value,
-          payload,
-          timestamp
-        )
-      end)
-    end
-
-    :ok
-  end
-
-  def execute_device_error_triggers(state, error_name, error_metadata \\ %{}, timestamp) do
-    timestamp_ms = div(timestamp, 10_000)
-
-    trigger_target_with_policy_list =
-      Map.get(state.device_triggers, :on_device_error, [])
-      |> Enum.map(fn target ->
-        {target, Map.get(state.trigger_id_to_policy_name, target.parent_trigger_id)}
-      end)
-
-    device_id_string = Device.encode_device_id(state.device_id)
-
-    TriggersHandler.device_error(
-      trigger_target_with_policy_list,
-      state.realm,
-      device_id_string,
-      error_name,
-      error_metadata,
-      timestamp_ms
-    )
-
-    :ok
   end
 
   def handle_data(%State{discard_messages: true} = state, _, _, _, message_id, _) do
@@ -597,7 +331,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           "base64_payload" => base64_payload
         }
 
-        execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           new_state,
           "invalid_introspection",
           error_metadata,
@@ -697,7 +431,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           %{realm: new_state.realm}
         )
 
-        execute_device_error_triggers(new_state, "device_session_not_found", timestamp)
+        Core.Trigger.execute_device_error_triggers(
+          new_state,
+          "device_session_not_found",
+          timestamp
+        )
 
         new_state
 
@@ -715,7 +453,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
           %{realm: new_state.realm}
         )
 
-        execute_device_error_triggers(
+        Core.Trigger.execute_device_error_triggers(
           new_state,
           "resend_interface_properties_failed",
           timestamp
@@ -739,7 +477,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
         error_metadata = %{"reason" => inspect(reason)}
 
-        execute_device_error_triggers(new_state, "empty_cache_error", error_metadata, timestamp)
+        Core.Trigger.execute_device_error_triggers(
+          new_state,
+          "empty_cache_error",
+          error_metadata,
+          timestamp
+        )
 
         new_state
     end
@@ -767,7 +510,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
       "base64_payload" => base64_payload
     }
 
-    execute_device_error_triggers(
+    Core.Trigger.execute_device_error_triggers(
       new_state,
       "unexpected_control_message",
       error_metadata,

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/time_based_actions.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/time_based_actions.ex
@@ -20,7 +20,6 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActions do
   alias Astarte.Core.Device
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.Utils, as: SimpleTriggersProtobufUtils
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
-  alias Astarte.DataUpdaterPlant.DataUpdater.Impl
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
@@ -152,7 +151,7 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActions do
       encoded_device_id = Device.encode_device_id(device_id)
 
       :ok = force_device_deletion_from_broker(realm, encoded_device_id)
-      new_state = Impl.set_device_disconnected(state, timestamp)
+      new_state = Core.Device.set_device_disconnected(state, timestamp)
 
       Logger.info("Stop handling data from device in deletion, device_id #{encoded_device_id}")
 

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_error_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_error_test.exs
@@ -1,0 +1,494 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule UnexpectedValueType do
+  defstruct []
+end
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerErrorTest do
+  use Astarte.Cases.Data, async: true
+  use Astarte.Cases.Device
+  use ExUnitProperties
+  use Mimic
+
+  alias Astarte.Core.Mapping.ValueType
+  alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler
+  alias Astarte.DataUpdaterPlant.DataUpdater
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
+
+  import Astarte.Helpers.DataUpdater
+  import Astarte.InterfaceUpdateGenerators
+
+  setup_all %{realm_name: realm_name, device: device} do
+    setup_data_updater(realm_name, device.encoded_id)
+    state = DataUpdater.dump_state(realm_name, device.encoded_id)
+
+    %{state: state}
+  end
+
+  describe "handle_data/6 errors with" do
+    test "an invalid interface", context do
+      %{state: state, interfaces: interfaces} = context
+
+      # Invalid String.t()
+      invalid_name = <<0xFFFF::16>>
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        context =
+        gen_context(state, interfaces)
+        |> Enum.at(0)
+        |> Map.put(:interface, invalid_name)
+
+      expect(Core.Error, :handle_error, fn ^context, error ->
+        refute error.update_stats
+
+        state
+      end)
+
+      assert ^state =
+               DataHandler.handle_data(state, interface, path, payload, message_id, timestamp)
+    end
+
+    test "an invalid path", context do
+      %{state: state, interfaces: interfaces} = context
+
+      # Invalid String.t()
+      invalid_path = <<0xFFFF::16>>
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        context =
+        gen_context(state, interfaces)
+        |> Enum.at(0)
+        |> Map.put(:path, invalid_path)
+
+      expect(Core.Error, :handle_error, fn ^context, _error -> state end)
+
+      assert ^state =
+               DataHandler.handle_data(state, interface, path, payload, message_id, timestamp)
+    end
+
+    test "an invalid doublke-slashed path", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      # Double slashed invalid path
+      invalid_path = "//invalid"
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        context =
+        gen_context(state, interfaces)
+        |> Enum.at(0)
+        |> Map.put(:path, invalid_path)
+
+      expect(Core.Error, :handle_error, fn ^context, _error -> state end)
+
+      assert ^state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+
+    test "a cache miss", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        context =
+        gen_context(state, interfaces)
+        |> Enum.at(0)
+
+      expect(Core.Error, :handle_error, fn ^context, _error -> state end)
+
+      expect(Core.Interface, :maybe_handle_cache_miss, fn nil, ^interface, ^state ->
+        {:error, :interface_loading_failed}
+      end)
+
+      assert ^state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+
+    test "on server owned interfaces", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      server_owned_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.ownership == :server))
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        gen_context(state, server_owned_interfaces)
+        |> Enum.at(0)
+
+      {:ok, _descriptor, new_state} =
+        Core.Interface.maybe_handle_cache_miss(nil, interface, state)
+
+      expect(Core.Error, :handle_error, fn context, _error -> context.state end)
+
+      assert ^new_state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+
+    test "on mappings not found", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      device_owned_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.ownership == :device))
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        gen_context(state, device_owned_interfaces)
+        |> Enum.at(0)
+
+      {:ok, descriptor, new_state} =
+        Core.Interface.maybe_handle_cache_miss(nil, interface, state)
+
+      mappings = new_state.mappings
+
+      expect(Core.Interface, :resolve_path, fn ^path, ^descriptor, ^mappings ->
+        {:error, :mapping_not_found}
+      end)
+
+      expect(Core.Error, :handle_error, fn context, _error -> context.state end)
+
+      assert ^new_state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+
+    test "on guessed endpoints", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      device_owned_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.ownership == :device))
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        gen_context(state, device_owned_interfaces)
+        |> Enum.at(0)
+
+      {:ok, descriptor, new_state} =
+        Core.Interface.maybe_handle_cache_miss(nil, interface, state)
+
+      mappings = new_state.mappings
+
+      expect(Core.Interface, :resolve_path, fn ^path, ^descriptor, ^mappings ->
+        {:guessed, :non_relevant}
+      end)
+
+      expect(Core.Error, :handle_error, fn context, _error -> context.state end)
+
+      assert ^new_state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+
+    test "if the payload is not decodable", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      device_owned_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.ownership == :device))
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        gen_context(state, device_owned_interfaces)
+        |> Enum.at(0)
+
+      {:ok, _descriptor, new_state} =
+        Core.Interface.maybe_handle_cache_miss(nil, interface, state)
+
+      expect(PayloadsDecoder, :decode_bson_payload, fn ^payload, ^timestamp ->
+        {:error, :undecodable_bson_payload}
+      end)
+
+      expect(Core.Error, :handle_error, fn context, _error -> context.state end)
+
+      assert ^new_state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+
+    test "if an unexpected value type is supplied", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      device_owned_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.ownership == :device))
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        gen_context(state, device_owned_interfaces)
+        |> Enum.at(0)
+
+      {:ok, _descriptor, new_state} =
+        Core.Interface.maybe_handle_cache_miss(nil, interface, state)
+
+      expect(PayloadsDecoder, :decode_bson_payload, fn ^payload, ^timestamp ->
+        {%UnexpectedValueType{}, DateTime.utc_now(), nil}
+      end)
+
+      expect(Core.Error, :handle_error, fn context, _error -> context.state end)
+
+      assert ^new_state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+
+    test "if an unexpected key is in the value", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      device_owned_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.ownership == :device))
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        gen_context(state, device_owned_interfaces)
+        |> Enum.at(0)
+
+      {:ok, _descriptor, new_state} =
+        Core.Interface.maybe_handle_cache_miss(nil, interface, state)
+
+      expect(PayloadsDecoder, :decode_bson_payload, fn ^payload, ^timestamp ->
+        {%{"an_unexpected_key" => nil}, DateTime.utc_now(), nil}
+      end)
+
+      expect(Core.Error, :handle_error, fn context, _error -> context.state end)
+
+      assert ^new_state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+
+    test "if the payload is too big", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      device_owned_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.ownership == :device))
+
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      } =
+        gen_non_empty_value_context(state, device_owned_interfaces)
+        |> Enum.at(0)
+
+      {:ok, _descriptor, new_state} =
+        Core.Interface.maybe_handle_cache_miss(nil, interface, state)
+
+      expect(ValueType, :validate_value, fn _, value ->
+        {payload_value, _, _} =
+          PayloadsDecoder.decode_bson_payload(payload, DateTime.utc_now(:millisecond))
+
+        assert valid_value?(payload_value, value)
+
+        {:error, :value_size_exceeded}
+      end)
+
+      expect(Core.Error, :handle_error, fn context, _error -> context.state end)
+
+      assert ^new_state =
+               DataHandler.handle_data(
+                 state,
+                 interface,
+                 path,
+                 payload,
+                 message_id,
+                 timestamp
+               )
+    end
+  end
+
+  defp gen_non_empty_value_context(state, interfaces) do
+    gen all interface <- member_of(interfaces),
+            message_id <- repeatedly(&gen_message_id/0),
+            update <- valid_mapping_update_for(interface) |> filter(&(&1.value != %{})),
+            timestamp <- repeatedly(fn -> DateTime.utc_now(:millisecond) end) do
+      payload =
+        %{
+          "v" => update.value,
+          "t" => timestamp
+        }
+        |> Cyanide.encode!()
+
+      %{
+        state: state,
+        interface: interface.name,
+        message_id: message_id,
+        path: update.path,
+        timestamp: timestamp,
+        payload: payload
+      }
+    end
+  end
+
+  defp gen_context(state, interfaces) do
+    gen all interface <- member_of(interfaces),
+            message_id <- repeatedly(&gen_message_id/0),
+            update <- valid_mapping_update_for(interface),
+            timestamp <- repeatedly(fn -> DateTime.utc_now(:millisecond) end) do
+      payload =
+        %{
+          "v" => update.value,
+          "t" => timestamp
+        }
+        |> Cyanide.encode!()
+
+      %{
+        state: state,
+        interface: interface.name,
+        message_id: message_id,
+        path: update.path,
+        timestamp: timestamp,
+        payload: payload
+      }
+    end
+  end
+
+  defp gen_message_id, do: :erlang.unique_integer([:monotonic]) |> Integer.to_string()
+
+  defp valid_value?(%{} = payload_value, value) do
+    value in Map.values(payload_value)
+  end
+
+  defp valid_value?(%DateTime{} = payload_value, %DateTime{} = value),
+    do: DateTime.compare(payload_value, value) == :eq
+
+  defp valid_value?(payload_value, value), do: payload_value == value
+end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_test.exs
@@ -1,0 +1,45 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerTest do
+  use Astarte.Cases.Data, async: true
+  use Astarte.Cases.Device
+  use ExUnitProperties
+  use Mimic
+
+  alias Astarte.Core.Mapping.ValueType
+  alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler
+  alias Astarte.DataUpdaterPlant.DataUpdater
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
+
+  import Astarte.Helpers.DataUpdater
+  import Astarte.InterfaceUpdateGenerators
+
+  setup_all %{realm_name: realm_name, device: device} do
+    setup_data_updater(realm_name, device.encoded_id)
+    state = DataUpdater.dump_state(realm_name, device.encoded_id)
+
+    %{state: state}
+  end
+
+  describe "handle_data/6 " do
+  end
+end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/device_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/device_test.exs
@@ -1,0 +1,130 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DeviceTest do
+  use Astarte.Cases.Data, async: true
+  use Mimic
+  import Astarte.Helpers.DataUpdater
+
+  alias Astarte.Core.Device
+  alias Astarte.DataUpdaterPlant.DataUpdater
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
+  alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
+  alias Astarte.DataAccess.Devices.Device, as: DatabaseDevice
+  alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.DataAccess.Repo
+  alias Astarte.Helpers.Database
+
+  @timestamp_us_x_10 Database.make_timestamp("2025-05-14T14:00:32+00:00")
+
+  setup do
+    device_id = Database.random_device_id()
+    encoded_device_id = Device.encode_device_id(device_id)
+    {:ok, device_id: device_id, encoded_device_id: encoded_device_id}
+  end
+
+  describe "ask_clean_session/2" do
+    test "disconnects device and clears cache on successful disconnect", %{
+      realm_name: realm_name,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      state = setup_device_state(realm_name, device_id, encoded_device_id, [])
+
+      # Successfully disconnected
+      Mimic.expect(VMQPlugin, :disconnect, fn _client_id, _discard_state -> :ok end)
+
+      {:ok, new_state} = Core.Device.ask_clean_session(state, @timestamp_us_x_10)
+
+      assert read_device_empty_cache(realm_name, device_id) == true
+      assert new_state.connected == false
+    end
+
+    test "clears cache and marks device disconnected if already disconnected", %{
+      realm_name: realm_name,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      state = setup_device_state(realm_name, device_id, encoded_device_id, [])
+
+      # Not found means it was already disconnected, succeed anyway
+      Mimic.expect(VMQPlugin, :disconnect, fn _client_id, _discard_state ->
+        {:error, :not_found}
+      end)
+
+      {:ok, new_state} = Core.Device.ask_clean_session(state, @timestamp_us_x_10)
+
+      assert read_device_empty_cache(realm_name, device_id) == true
+      assert new_state.connected == false
+    end
+
+    test "returns error and clears cache on disconnect failure", %{
+      realm_name: realm_name,
+      device_id: device_id,
+      encoded_device_id: encoded_device_id
+    } do
+      # Insert initial device state
+      state = setup_device_state(realm_name, device_id, encoded_device_id, [])
+
+      # Some other error, return it
+      Mimic.expect(VMQPlugin, :disconnect, fn _client_id, _discard_state ->
+        {:error, :timeout}
+      end)
+
+      assert {:error, :clean_session_failed} =
+               Core.Device.ask_clean_session(state, @timestamp_us_x_10)
+
+      assert read_device_empty_cache(realm_name, device_id) == true
+    end
+  end
+
+  defp setup_device_state(
+         realm,
+         device_id,
+         encoded_device_id,
+         insert_opts,
+         timestamp \\ @timestamp_us_x_10
+       ) do
+    insert_device_and_start_data_updater(realm, device_id, insert_opts)
+
+    DataUpdater.handle_connection(
+      realm,
+      encoded_device_id,
+      "10.0.0.1",
+      Database.gen_tracking_id(),
+      timestamp
+    )
+
+    DataUpdater.dump_state(realm, encoded_device_id)
+  end
+
+  defp insert_device_and_start_data_updater(realm_name, device_id, params) do
+    encoded_device_id = Astarte.Core.Device.encode_device_id(device_id)
+    Database.insert_device(device_id, realm_name, params)
+
+    setup_data_updater(realm_name, encoded_device_id)
+    :ok
+  end
+
+  defp read_device_empty_cache(realm_name, device_id) do
+    Repo.get!(DatabaseDevice, device_id, prefix: Realm.keyspace_name(realm_name))
+    |> Map.fetch!(:pending_empty_cache)
+  end
+end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/error_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/error_test.exs
@@ -1,0 +1,146 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ErrorTest do
+  use Astarte.Cases.Data, async: true
+  use Astarte.Cases.Device
+  use ExUnitProperties
+  use Astarte.Generators.Utilities.ParamsGen
+  use Mimic
+
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.Error
+  alias Astarte.DataUpdaterPlant.MessageTracker
+  alias Astarte.DataUpdaterPlant.DataUpdater
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core
+
+  import Astarte.Helpers.DataUpdater
+  import Astarte.InterfaceUpdateGenerators
+
+  setup_all %{realm_name: realm_name, device: device} do
+    setup_data_updater(realm_name, device.encoded_id)
+    state = DataUpdater.dump_state(realm_name, device.encoded_id)
+
+    %{state: state}
+  end
+
+  describe "handle_error/2" do
+    property "handle_error/2 resets connection and discards the message, updating stats by default",
+             context do
+      %{state: state, interfaces: interfaces} = context
+
+      check all context <- gen_context(state, interfaces),
+                error <- gen_error(update_stats: true) do
+        set_expectations(context, error)
+        assert ^state = Error.handle_error(context, error)
+      end
+    end
+
+    property "handle_error/2 resets connection and discards the message, not updating stats if told to",
+             context do
+      %{state: state, interfaces: interfaces} = context
+
+      check all context <- gen_context(state, interfaces),
+                error <- gen_error(update_stats: false) do
+        set_expectations(context, error)
+        assert ^state = Error.handle_error(context, error)
+      end
+    end
+  end
+
+  defp set_expectations(context, error) do
+    %{
+      state: state,
+      interface: interface,
+      message_id: message_id,
+      path: path,
+      timestamp: timestamp,
+      payload: payload
+    } = context
+
+    %{
+      error_name: error_name
+    } = error
+
+    message_tracker = state.message_tracker
+
+    expect(Core.Device, :ask_clean_session, fn ^state, ^timestamp -> {:ok, state} end)
+
+    expect(
+      Core.Trigger,
+      :execute_device_error_triggers,
+      fn ^state, ^error_name, error_metadata, ^timestamp ->
+        expected_interface = inspect(interface)
+        expected_path = inspect(path)
+        expected_payload = Base.encode64(payload)
+
+        assert %{
+                 "interface" => ^expected_interface,
+                 "path" => ^expected_path,
+                 "base64_payload" => ^expected_payload
+               } = error_metadata
+
+        {:ok, state}
+      end
+    )
+
+    if error.update_stats,
+      do:
+        expect(Core.DataHandler, :update_stats, fn ^state, ^interface, nil, ^path, ^payload ->
+          state
+        end)
+
+    expect(MessageTracker, :discard, fn ^message_tracker, ^message_id -> :ok end)
+  end
+
+  defp gen_context(state, interfaces) do
+    gen all interface <- member_of(interfaces),
+            message_id <- repeatedly(&gen_message_id/0),
+            mapping <- member_of(interface.mappings),
+            path <- path_from_endpoint(mapping.endpoint),
+            timestamp <- repeatedly(&DateTime.utc_now/0),
+            payload <- binary() do
+      %{
+        state: state,
+        interface: interface,
+        message_id: message_id,
+        path: path,
+        timestamp: timestamp,
+        payload: payload
+      }
+    end
+  end
+
+  defp gen_error(params) do
+    params gen all message <- string(:utf8),
+                   tag <- string(:utf8),
+                   error_name <- string(:utf8),
+                   update_stats <- boolean(),
+                   params: params do
+      %{
+        message: message,
+        tag: tag,
+        error_name: error_name,
+        update_stats: update_stats
+      }
+    end
+  end
+
+  defp gen_message_id, do: :erlang.unique_integer([:monotonic]) |> Integer.to_string()
+end

--- a/apps/astarte_data_updater_plant/test/test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/test_helper.exs
@@ -18,6 +18,10 @@
 
 Mimic.copy(Astarte.DataAccess.Config)
 Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Server)
+Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Core.Device)
+Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger)
+Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler)
+Mimic.copy(Astarte.DataUpdaterPlant.MessageTracker)
 Mimic.copy(Astarte.DataUpdaterPlant.RPC.Server.Core)
 Mimic.copy(System)
 Mimic.copy(Xandra)

--- a/apps/astarte_data_updater_plant/test/test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/test_helper.exs
@@ -22,5 +22,6 @@ Mimic.copy(Astarte.DataUpdaterPlant.RPC.Server.Core)
 Mimic.copy(System)
 Mimic.copy(Xandra)
 Mimic.copy(Astarte.DataAccess.Health.Health)
+Mimic.copy(Astarte.DataUpdaterPlant.RPC.VMQPlugin)
 
 ExUnit.start(capture_log: true)

--- a/apps/astarte_data_updater_plant/test/test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/test_helper.exs
@@ -16,11 +16,15 @@
 # limitations under the License.
 #
 
+Mimic.copy(Astarte.Core.Mapping.ValueType)
 Mimic.copy(Astarte.DataAccess.Config)
 Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Server)
 Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Core.Device)
 Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger)
 Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler)
+Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Core.Error)
+Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.Core.Interface)
+Mimic.copy(Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder)
 Mimic.copy(Astarte.DataUpdaterPlant.MessageTracker)
 Mimic.copy(Astarte.DataUpdaterPlant.RPC.Server.Core)
 Mimic.copy(System)


### PR DESCRIPTION
Refactors `handle_data` to be more legible without compromising the logic

Adds tests for the function itself, especially errors