### PR TITLE
test(dup): fix data handler's valid_result helper

### DIFF
--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_error_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_error_test.exs
@@ -481,12 +481,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerErrorTest do
 
   defp gen_message_id, do: :erlang.unique_integer([:monotonic]) |> Integer.to_string()
 
-  defp valid_value?(%{} = payload_value, value) do
-    value in Map.values(payload_value)
-  end
-
   defp valid_value?(%DateTime{} = payload_value, %DateTime{} = value),
     do: DateTime.compare(payload_value, value) == :eq
+
+  defp valid_value?(%{} = payload_value, value) do
+    payload_value == value || payload_value |> Map.values() |> Enum.any?(&valid_value?(&1, value))
+  end
 
   defp valid_value?(payload_value, value), do: payload_value == value
 end


### PR DESCRIPTION
- datetimes are maps, so we need to invert the order to make sure the first one matches
- handle the case where both the payload value and the value are maps
- reuse `valid_value?` instead of using `in` to account for datetimes or other special handling

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
