### PR TITLE
refactor(DUP): move `resend_all_properties` to dedicated device module

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -27,7 +27,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
   alias Astarte.DataUpdaterPlant.MessageTracker
-  alias Astarte.DataUpdaterPlant.DataUpdater.Impl
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
   alias Astarte.DataUpdaterPlant.TimeBasedActions
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
@@ -209,7 +208,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   end
 
   defp resend_all_properties(state, message_id, timestamp) do
-    case Impl.resend_all_properties(state) do
+    case Core.Device.resend_all_properties(state) do
       {:ok, new_state} ->
         {:ok, new_state}
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -18,11 +18,9 @@
 
 defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
-  alias Astarte.Core.CQLUtils
   alias Astarte.DataUpdaterPlant.Config
   alias Astarte.Core.Device
   alias Astarte.Core.InterfaceDescriptor
-  alias Astarte.Core.Mapping
   alias Astarte.Core.Mapping.EndpointsAutomaton
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.Core.Triggers.DataTrigger
@@ -34,7 +32,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.DataUpdaterPlant.MessageTracker
-  alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
   alias Astarte.DataUpdaterPlant.TriggersHandler
   alias Astarte.DataUpdaterPlant.TimeBasedActions
   require Logger
@@ -440,85 +437,5 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     updated_device_triggers = Map.put(device_triggers, event_type, updated_targets_list)
 
     {:ok, %{state | device_triggers: updated_device_triggers}}
-  end
-
-  def resend_all_properties(state) do
-    Logger.debug("Device introspection: #{inspect(state.introspection)}")
-
-    Enum.reduce_while(state.introspection, {:ok, state}, fn {interface, _}, {:ok, state_acc} ->
-      maybe_descriptor = Map.get(state_acc.interfaces, interface)
-
-      with {:ok, interface_descriptor, new_state} <-
-             Core.Interface.maybe_handle_cache_miss(maybe_descriptor, interface, state_acc),
-           :ok <- resend_all_interface_properties(new_state, interface_descriptor) do
-        {:cont, {:ok, new_state}}
-      else
-        {:error, :interface_loading_failed} ->
-          Logger.warning("Failed #{interface} interface loading.")
-          {:halt, {:error, :sending_properties_to_interface_failed}}
-
-        {:error, reason} ->
-          {:halt, {:error, reason}}
-      end
-    end)
-  end
-
-  defp resend_all_interface_properties(
-         %State{realm: realm, device_id: device_id, mappings: mappings} = _state,
-         %InterfaceDescriptor{type: :properties, ownership: :server} = interface_descriptor
-       ) do
-    encoded_device_id = Device.encode_device_id(device_id)
-
-    Core.Interface.each_interface_mapping(mappings, interface_descriptor, fn mapping ->
-      %Mapping{value_type: value_type} = mapping
-
-      column_name =
-        CQLUtils.type_to_db_column_name(value_type) |> String.to_existing_atom()
-
-      Queries.retrieve_property_values(realm, device_id, interface_descriptor, mapping)
-      |> Enum.reduce_while(:ok, fn %{:path => path, ^column_name => value}, _acc ->
-        case send_value(realm, encoded_device_id, interface_descriptor.name, path, value) do
-          {:ok, _bytes} ->
-            # TODO: use the returned bytes count in stats
-            {:cont, :ok}
-
-          {:error, reason} ->
-            {:halt, {:error, reason}}
-        end
-      end)
-    end)
-  end
-
-  defp resend_all_interface_properties(_state, %InterfaceDescriptor{} = _descriptor) do
-    :ok
-  end
-
-  defp send_value(realm, device_id_string, interface_name, path, value) do
-    topic = "#{realm}/#{device_id_string}/#{interface_name}#{path}"
-    encapsulated_value = %{v: value}
-
-    bson_value = Cyanide.encode!(encapsulated_value)
-
-    Logger.debug("Going to publish #{inspect(encapsulated_value)} on #{topic}.")
-
-    case VMQPlugin.publish(topic, bson_value, 2) do
-      {:ok, %{local_matches: local, remote_matches: remote}} when local + remote == 1 ->
-        {:ok, byte_size(topic) + byte_size(bson_value)}
-
-      {:ok, %{local_matches: local, remote_matches: remote}} when local + remote > 1 ->
-        # This should not happen so we print a warning, but we consider it a succesful publish
-        Logger.warning(
-          "Multiple match while publishing #{inspect(encapsulated_value)} on #{topic}.",
-          tag: "publish_multiple_matches"
-        )
-
-        {:ok, byte_size(topic) + byte_size(bson_value)}
-
-      {:ok, %{local_matches: local, remote_matches: remote}} when local + remote == 0 ->
-        {:error, :session_not_found}
-
-      {:error, reason} ->
-        {:error, reason}
-    end
   end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -31,7 +31,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
   alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
   alias Astarte.DataUpdaterPlant.MessageTracker
   alias Astarte.DataUpdaterPlant.RPC.VMQPlugin.ClientMock
-  alias Astarte.DataUpdaterPlant.DataUpdater.Impl
 
   setup_all %{realm_name: realm_name, device: device} do
     setup_data_updater(realm_name, device.encoded_id)
@@ -123,7 +122,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
         {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
-      expect(Impl, :resend_all_properties, fn _state ->
+      expect(Core.Device, :resend_all_properties, fn _state ->
         {:error, :sending_properties_to_interface_failed}
       end)
 

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/device_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/device_test.exs
@@ -201,6 +201,20 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DeviceTest do
     end
   end
 
+  describe "resend_all_properties/1" do
+    test "returns error when interface cache miss occurs", %{state: state} do
+      # Simulate a cache miss
+      Mimic.expect(Core.Interface, :maybe_handle_cache_miss, fn _maybe_descriptor,
+                                                                _interface,
+                                                                _state_acc ->
+        {:error, :interface_loading_failed}
+      end)
+
+      assert {:error, :sending_properties_to_interface_failed} ==
+               Core.Device.resend_all_properties(state)
+    end
+  end
+
   defp read_device_empty_cache(realm_name, device_id) do
     Repo.get!(DatabaseDevice, device_id, prefix: Realm.keyspace_name(realm_name))
     |> Map.fetch!(:pending_empty_cache)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Move `resend_all_properties/1` away from `impl.ex` and test separately
##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
