### PR TITLE
refactor(HK): Remove `delete_realm` RPC

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/engine.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/engine.ex
@@ -19,7 +19,6 @@
 defmodule Astarte.Housekeeping.Engine do
   require Logger
 
-  alias Astarte.Housekeeping.Config
   alias Astarte.Housekeeping.Queries
 
   def create_realm(
@@ -48,22 +47,6 @@ defmodule Astarte.Housekeeping.Engine do
       max_retention,
       opts
     )
-  end
-
-  def delete_realm(realm, opts \\ []) do
-    if Config.enable_realm_deletion!() do
-      _ = Logger.info("Deleting realm", tag: "delete_realm", realm: realm)
-
-      Queries.delete_realm(realm, opts)
-    else
-      _ =
-        Logger.info("HOUSEKEEPING_ENABLE_REALM_DELETION is disabled, realm will not be deleted.",
-          tag: "realm_deletion_disabled",
-          realm: realm
-        )
-
-      {:error, :realm_deletion_disabled}
-    end
   end
 
   def is_realm_existing(realm) do

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/rpc/handler.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/rpc/handler.ex
@@ -24,7 +24,6 @@ defmodule Astarte.Housekeeping.RPC.Handler do
   alias Astarte.RPC.Protocol.Housekeeping.{
     Call,
     CreateRealm,
-    DeleteRealm,
     GenericErrorReply,
     GenericOkReply,
     GetRealmsList,
@@ -160,39 +159,6 @@ defmodule Astarte.Housekeeping.RPC.Handler do
           )
 
         generic_error(:existing_realm, "realm already exists")
-
-      {:error, {reason, details}} ->
-        generic_error(reason, details)
-
-      {:error, reason} ->
-        generic_error(reason)
-    end
-  end
-
-  # Here for retrocompatibility with old protos serialized with Exprotobuf
-  defp call_rpc({:delete_realm, %DeleteRealm{realm: ""}}) do
-    _ = Logger.warning("DeleteRealm with empty realm.", tag: "rpc_delete_empty_realm")
-    generic_error(:empty_name, "empty realm name")
-  end
-
-  defp call_rpc({:delete_realm, %DeleteRealm{realm: nil}}) do
-    _ = Logger.warning("DeleteRealm with empty realm.", tag: "rpc_delete_empty_realm")
-    generic_error(:empty_name, "empty realm name")
-  end
-
-  defp call_rpc({:delete_realm, %DeleteRealm{realm: realm, async_operation: async}}) do
-    with {:ok, true} <- Engine.is_realm_existing(realm),
-         :ok <- Engine.delete_realm(realm, async: async) do
-      generic_ok(async)
-    else
-      {:ok, false} ->
-        _ =
-          Logger.warning("DeleteRealm with non-existing realm.",
-            tag: "rpc_delete_non_existing_realm",
-            realm: realm
-          )
-
-        generic_error(:realm_not_found)
 
       {:error, {reason, details}} ->
         generic_error(reason, details)

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/engine_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/engine_test.exs
@@ -78,42 +78,6 @@ defmodule Astarte.Housekeeping.EngineTest do
     end
   end
 
-  describe "delete a realm," do
-    setup do
-      realm_name = Astarte.Core.Generators.Realm.realm_name() |> Enum.at(0)
-
-      on_exit(fn ->
-        Database.destroy_test_astarte_keyspace!(:xandra)
-        Database.destroy_test_keyspace!(:xandra, realm_name)
-      end)
-
-      Database.setup!(realm_name)
-      %{realm_name: realm_name}
-    end
-
-    test "deletions returns ok", %{realm_name: realm_name} do
-      assert :ok = Engine.delete_realm(realm_name, [])
-    end
-
-    test "async deletions returns ok", %{realm_name: realm_name} do
-      on_exit(fn ->
-        Process.sleep(1000)
-        Database.destroy_test_astarte_keyspace!(:xandra)
-      end)
-
-      assert :ok = Engine.delete_realm(realm_name, async: true)
-    end
-
-    test "fails in case of db error", %{realm_name: realm_name} do
-      Xandra.Cluster |> stub(:run, fn _, _, _ -> {:error, "generic error"} end)
-
-      assert {:error, "generic error"} =
-               Engine.delete_realm(realm_name)
-
-      Database.destroy_test_astarte_keyspace!(:xandra)
-    end
-  end
-
   describe "Realm update" do
     setup do
       realm_name = Astarte.Core.Generators.Realm.realm_name() |> Enum.at(0)

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/rpc/amqp_server_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/rpc/amqp_server_test.exs
@@ -22,7 +22,6 @@ defmodule Astarte.Housekeeping.RPC.HandlerTest do
   alias Astarte.RPC.Protocol.Housekeeping.{
     Call,
     CreateRealm,
-    DeleteRealm,
     GenericErrorReply,
     GenericOkReply,
     GetRealmReply,
@@ -269,68 +268,5 @@ defmodule Astarte.Housekeeping.RPC.HandlerTest do
              %Reply{reply: {:get_realms_list_reply, %GetRealmsListReply{realms_names: _names}}},
              Reply.decode(list_reply)
            )
-  end
-
-  test "DeleteRealm successful call" do
-    Engine.create_realm(
-      @test_realm,
-      @public_key_pem,
-      @replication_factor,
-      @device_limit,
-      @datastream_maximum_storage_retention
-    )
-
-    encoded =
-      %Call{call: {:delete_realm, %DeleteRealm{realm: @test_realm}}}
-      |> Call.encode()
-
-    {:ok, reply} = Handler.handle_rpc(encoded)
-
-    assert Reply.decode(reply) == generic_ok()
-  end
-
-  test "DeleteRealm with empty realm_name fails" do
-    encoded =
-      %Call{call: {:delete_realm, %DeleteRealm{realm: ""}}}
-      |> Call.encode()
-
-    {:ok, reply} = Handler.handle_rpc(encoded)
-
-    assert Reply.decode(reply) == generic_error("empty_name", "empty realm name")
-  end
-
-  test "DeleteRealm with non-existing realm fails" do
-    encoded =
-      %Call{call: {:delete_realm, %DeleteRealm{realm: @not_existing_realm}}}
-      |> Call.encode()
-
-    {:ok, reply} = Handler.handle_rpc(encoded)
-
-    assert Reply.decode(reply) == generic_error("realm_not_found")
-  end
-
-  test "DeleteRealm fails if realm deletion is disabled" do
-    on_exit(fn ->
-      DatabaseTestHelper.realm_cleanup(@test_realm)
-      Config.reload_enable_realm_deletion()
-    end)
-
-    Engine.create_realm(
-      @test_realm,
-      @public_key_pem,
-      @replication_factor,
-      @device_limit,
-      @datastream_maximum_storage_retention
-    )
-
-    Config.put_enable_realm_deletion(false)
-
-    encoded =
-      %Call{call: {:delete_realm, %DeleteRealm{realm: @test_realm}}}
-      |> Call.encode()
-
-    {:ok, reply} = Handler.handle_rpc(encoded)
-
-    assert Reply.decode(reply) == generic_error("realm_deletion_disabled")
   end
 end

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/config.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/config.ex
@@ -56,6 +56,15 @@ defmodule Astarte.Housekeeping.API.Config do
     type: :integer,
     default: 5000
 
+  @envdoc """
+  By default Astarte Housekeeping doesn't support realm deletion. Set this variable to true to
+  enable this feature. WARNING: this feature can cause permanent data loss when deleting a realm.
+  """
+  app_env :enable_realm_deletion, :astarte_housekeeping_api, :enable_realm_deletion,
+    os_env: "HOUSEKEEPING_API_ENABLE_REALM_DELETION",
+    type: :boolean,
+    default: false
+
   @doc """
   Returns true if the authentication is disabled.
   """

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/realms.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/realms/realms.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017-2023 SECO Mind Srl
+# Copyright 2017 - 2025  SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -110,10 +110,6 @@ defmodule Astarte.Housekeeping.API.Realms do
 
   """
   def delete_realm(realm_name, opts \\ []) do
-    case Housekeeping.delete_realm(realm_name, opts) do
-      :ok -> :ok
-      {:ok, :started} -> :ok
-      {:error, reason} -> {:error, reason}
-    end
+    Queries.delete_realm(realm_name, opts)
   end
 end

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api/rpc/housekeeping.ex
@@ -20,7 +20,6 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
   alias Astarte.RPC.Protocol.Housekeeping.{
     Call,
     CreateRealm,
-    DeleteRealm,
     GenericErrorReply,
     GenericOkReply,
     GetRealmReply,
@@ -95,16 +94,6 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
     |> extract_reply()
   end
 
-  def delete_realm(realm_name, opts) do
-    async_operation = Keyword.get(opts, :async_operation, true)
-
-    %DeleteRealm{realm: realm_name, async_operation: async_operation}
-    |> encode_call(:delete_realm)
-    |> @rpc_client.rpc_call(@destination, Config.rpc_timeout!())
-    |> decode_reply()
-    |> extract_reply()
-  end
-
   defp encode_call(call, callname) do
     %Call{call: {callname, call}}
     |> Call.encode()
@@ -167,18 +156,6 @@ defmodule Astarte.Housekeeping.API.RPC.Housekeeping do
 
   defp extract_reply({:generic_error_reply, %GenericErrorReply{error_name: "realm_not_found"}}) do
     {:error, :realm_not_found}
-  end
-
-  defp extract_reply(
-         {:generic_error_reply, %GenericErrorReply{error_name: "realm_deletion_disabled"}}
-       ) do
-    {:error, :realm_deletion_disabled}
-  end
-
-  defp extract_reply(
-         {:generic_error_reply, %GenericErrorReply{error_name: "connected_devices_present"}}
-       ) do
-    {:error, :connected_devices_present}
   end
 
   defp extract_reply(

--- a/apps/astarte_housekeeping_api/test/support/helpers/astarte_housekeeping_mock.ex
+++ b/apps/astarte_housekeeping_api/test/support/helpers/astarte_housekeeping_mock.ex
@@ -20,7 +20,6 @@ defmodule Astarte.Housekeeping.Mock do
   alias Astarte.RPC.Protocol.Housekeeping.{
     Call,
     CreateRealm,
-    DeleteRealm,
     GenericErrorReply,
     GenericOkReply,
     GetRealmsList,
@@ -69,19 +68,6 @@ defmodule Astarte.Housekeeping.Mock do
            device_registration_limit: dev_reg_limit,
            datastream_maximum_storage_retention: ds_max_retention
          }) do
-      :ok ->
-        %GenericOkReply{async_operation: async}
-        |> encode_reply(:generic_ok_reply)
-        |> ok_wrap
-
-      {:error, reason} ->
-        generic_error(reason)
-        |> ok_wrap
-    end
-  end
-
-  defp execute_rpc({:delete_realm, %DeleteRealm{realm: realm, async_operation: async}}) do
-    case Astarte.Housekeeping.Mock.DB.delete_realm(realm) do
       :ok ->
         %GenericOkReply{async_operation: async}
         |> encode_reply(:generic_ok_reply)

--- a/apps/astarte_housekeeping_api/test/support/helpers/astarte_housekeeping_mock_db.ex
+++ b/apps/astarte_housekeeping_api/test/support/helpers/astarte_housekeeping_mock_db.ex
@@ -47,19 +47,6 @@ defmodule Astarte.Housekeeping.Mock.DB do
     Agent.get(current_agent(), &Map.get(&1, realm_name))
   end
 
-  def delete_realm(realm_name) do
-    cond do
-      !realm_exists?(realm_name) ->
-        {:error, :realm_not_found}
-
-      realm_deletion_disabled?() ->
-        {:error, :realm_deletion_disabled}
-
-      true ->
-        Agent.update(current_agent(), &Map.delete(&1, realm_name))
-    end
-  end
-
   def realm_exists?(realm_name) do
     Agent.get(current_agent(), &Map.has_key?(&1, realm_name))
   end
@@ -70,10 +57,6 @@ defmodule Astarte.Housekeeping.Mock.DB do
 
   def set_realm_deletion_status(status) when is_boolean(status) do
     Agent.update(current_agent(), &Map.put(&1, :realm_deletion_disabled, !status))
-  end
-
-  defp realm_deletion_disabled? do
-    Agent.get(current_agent(), &Map.get(&1, :realm_deletion_disabled, false))
   end
 
   defp current_agent do

--- a/apps/astarte_housekeeping_api/test/test_helper.exs
+++ b/apps/astarte_housekeeping_api/test/test_helper.exs
@@ -18,6 +18,9 @@
 
 Mimic.copy(Astarte.DataAccess.Health.Health)
 Mimic.copy(Astarte.DataAccess.Config)
+Mimic.copy(Astarte.Housekeeping.API.Config)
+Mimic.copy(Astarte.Housekeeping.API.Realms.Queries)
 Mimic.copy(Xandra)
+Mimic.copy(Xandra.Cluster)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Replace the `delete_realm` function implementation with RPC with direct database access.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
