### PR TITLE
refactor(DUP): move `prune_device_properties` to dedicated device module

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/device.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/device.ex
@@ -30,6 +30,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Device do
   alias Astarte.DataUpdaterPlant.MessageTracker
   alias Astarte.DataUpdaterPlant.DataUpdater.Cache
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
+  alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
   alias Astarte.Core.CQLUtils
@@ -353,5 +354,17 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Device do
       {:error, reason} ->
         {:error, reason}
     end
+  end
+
+  def prune_device_properties(state, decoded_payload, timestamp) do
+    {:ok, paths_set} =
+      PayloadsDecoder.parse_device_properties_payload(decoded_payload, state.introspection)
+
+    Enum.each(state.introspection, fn {interface, _} ->
+      # TODO: check result here
+      Core.Interface.prune_interface(state, interface, paths_set, timestamp)
+    end)
+
+    :ok
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -235,7 +235,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
     timestamp_ms = div(timestamp, 10_000)
 
-    :ok = prune_device_properties(new_state, "", timestamp_ms)
+    :ok = Core.Device.prune_device_properties(new_state, "", timestamp_ms)
 
     MessageTracker.ack_delivery(new_state.message_tracker, message_id)
 
@@ -259,7 +259,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
 
     case PayloadsDecoder.safe_inflate(zlib_payload) do
       {:ok, decoded_payload} ->
-        :ok = prune_device_properties(new_state, decoded_payload, timestamp_ms)
+        :ok = Core.Device.prune_device_properties(new_state, decoded_payload, timestamp_ms)
         MessageTracker.ack_delivery(new_state.message_tracker, message_id)
 
         %{
@@ -616,18 +616,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
     updated_device_triggers = Map.put(device_triggers, event_type, updated_targets_list)
 
     {:ok, %{state | device_triggers: updated_device_triggers}}
-  end
-
-  defp prune_device_properties(state, decoded_payload, timestamp) do
-    {:ok, paths_set} =
-      PayloadsDecoder.parse_device_properties_payload(decoded_payload, state.introspection)
-
-    Enum.each(state.introspection, fn {interface, _} ->
-      # TODO: check result here
-      Core.Interface.prune_interface(state, interface, paths_set, timestamp)
-    end)
-
-    :ok
   end
 
   defp send_control_consumer_properties(state) do

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/device_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/device_test.exs
@@ -19,19 +19,26 @@
 defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DeviceTest do
   use Astarte.Cases.Data, async: true
   use Astarte.Cases.Device
+  use ExUnitProperties
   use Mimic
 
   import Astarte.Helpers.DataUpdater
+  import Astarte.InterfaceUpdateGenerators
+  import Ecto.Query
 
   alias Astarte.DataUpdaterPlant.DataUpdater
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
+  alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
   alias Astarte.DataAccess.Devices.Device, as: DatabaseDevice
+  alias Astarte.DataAccess.Interface, as: InterfaceQueries
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.DataAccess.Repo
   alias Astarte.Helpers.Database
 
   @timestamp_us_x_10 Database.make_timestamp("2025-05-14T14:00:32+00:00")
+
+  setup_all :populate_interfaces
 
   setup_all %{realm_name: realm_name, device: device} do
     setup_data_updater(realm_name, device.encoded_id)
@@ -82,6 +89,115 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DeviceTest do
                Core.Device.ask_clean_session(state, @timestamp_us_x_10)
 
       assert read_device_empty_cache(realm_name, state.device_id) == true
+    end
+  end
+
+  describe "prune_device_properties/3" do
+    property "keeps only specified properties when decoded_payload is not empty", context do
+      %{
+        state: state,
+        interfaces: interfaces,
+        realm_name: realm_name,
+        device: device
+      } = context
+
+      valid_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.type == :properties and &1.ownership == :device))
+
+      check all interfaces <- list_of(member_of(valid_interfaces), min_length: 1),
+                interfaces = Enum.uniq_by(interfaces, &{&1.name, &1.major_version}),
+                mapping_updates =
+                  Map.new(interfaces, fn interface ->
+                    {interface, list_of(valid_mapping_update_for(interface))}
+                  end),
+                mapping_updates <- fixed_map(mapping_updates),
+                mapping_updates_list =
+                  Enum.flat_map(mapping_updates, fn {interface, updates} ->
+                    updates
+                    |> Enum.uniq_by(& &1.path)
+                    |> Enum.map(&{interface, &1})
+                  end),
+                split_size <- integer(0..Enum.count(mapping_updates_list)),
+                mapping_updates_list <- shuffle(mapping_updates_list),
+                {to_keep, to_delete} = Enum.split(mapping_updates_list, split_size),
+                decoded_payload =
+                  to_keep
+                  |> Enum.map_join(";", fn {interface, mapping_update} ->
+                    interface.name <> mapping_update.path
+                  end) do
+        Enum.each(mapping_updates_list, fn {interface, mapping_update} ->
+          Database.insert_values(realm_name, device, interface, [mapping_update])
+        end)
+
+        :ok = Core.Device.prune_device_properties(state, decoded_payload, DateTime.utc_now())
+
+        keyspace = Realm.keyspace_name(realm_name)
+
+        properties =
+          from("individual_properties", select: [:path, :device_id, :interface_id])
+          |> Repo.all(prefix: keyspace)
+
+        Enum.each(to_keep, fn {interface, mapping_update} ->
+          expected_kept = %{
+            path: mapping_update.path,
+            device_id: device.device_id,
+            interface_id: interface.interface_id
+          }
+
+          assert expected_kept in properties
+        end)
+
+        Enum.each(to_delete, fn {interface, mapping_update} ->
+          expected_pruned = %{
+            path: mapping_update.path,
+            device_id: device.device_id,
+            interface_id: interface.interface_id
+          }
+
+          assert expected_pruned not in properties
+        end)
+
+        Enum.each(mapping_updates_list, fn {interface, mapping_update} ->
+          Database.delete_values(realm_name, device, interface, [mapping_update])
+        end)
+      end
+    end
+
+    test "does not remove properties of server owned interfaces", %{
+      state: state,
+      realm_name: realm_name,
+      device: device,
+      individual_properties_server_interface: interface,
+      registered_paths: registered_paths
+    } do
+      paths = registered_paths |> Map.fetch!({interface.name, interface.major_version})
+
+      :ok = Core.Device.prune_device_properties(state, "", DateTime.utc_now())
+
+      {:ok, interface_descriptor} =
+        InterfaceQueries.fetch_interface_descriptor(
+          realm_name,
+          interface.name,
+          interface.major_version
+        )
+
+      expected_paths = Enum.sort(paths)
+
+      actual_paths =
+        interface.mappings
+        |> Enum.map(& &1.endpoint_id)
+        |> Enum.flat_map(
+          &Queries.all_device_owned_property_endpoint_paths!(
+            realm_name,
+            device.device_id,
+            interface_descriptor,
+            &1
+          )
+        )
+        |> Enum.sort()
+
+      assert actual_paths == expected_paths
     end
   end
 

--- a/apps/astarte_data_updater_plant/test/support/helpers/database.ex
+++ b/apps/astarte_data_updater_plant/test/support/helpers/database.ex
@@ -532,6 +532,27 @@ defmodule Astarte.Helpers.Database do
     end)
   end
 
+  def delete_values(realm_name, device, interface, mapping_updates) do
+    mappings_map = interface.mappings |> Map.new(&{&1.endpoint_id, &1})
+
+    {:ok, interface_descriptor} =
+      Interface.fetch_interface_descriptor(realm_name, interface.name, interface.major_version)
+
+    Enum.each(mapping_updates, fn mapping_update ->
+      {:ok, mapping} =
+        Core.Interface.resolve_path(mapping_update.path, interface_descriptor, mappings_map)
+
+      :ok =
+        Queries.delete_property_from_db(
+          realm_name,
+          device.device_id,
+          interface_descriptor,
+          mapping.endpoint_id,
+          mapping_update.path
+        )
+    end)
+  end
+
   defp initial_timestamp do
     # Start of January 2020 in decimicrosecond
     minimum = 157_783_680_000_000


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Move `prune_device_properties/3` away from `impl.ex` and test separately

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
