### PR TITLE
HK API: correlate request and response

### DIFF
--- a/apps/astarte_housekeeping_api/config/prod.exs
+++ b/apps/astarte_housekeeping_api/config/prod.exs
@@ -29,5 +29,9 @@ config :logger, :console,
     :realm,
     :module,
     :function,
+    :method,
+    :request_path,
+    :status_code,
+    :request_id,
     :tag
   ]

--- a/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/endpoint.ex
+++ b/apps/astarte_housekeeping_api/lib/astarte_housekeeping_api_web/endpoint.ex
@@ -38,7 +38,6 @@ defmodule Astarte.Housekeeping.APIWeb.Endpoint do
   end
 
   plug Plug.RequestId
-  plug Plug.Logger
   plug CORSPlug
   plug Astarte.Housekeeping.APIWeb.HealthPlug
   plug Astarte.Housekeeping.APIWeb.MetricsPlug


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
Logs did not show the standard Phoenix `request_id`, making it impossible to correlate the request with its response. Include also more information that is standard among other Astarte services (e.g. method, request_path).

Moreover, make sure that log entries are not duplicated.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
