### PR TITLE
refactor(RM): move `fetch_interface` to the RM frontend

### DIFF
--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/interfaces/interfaces.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/interfaces/interfaces.ex
@@ -17,6 +17,7 @@
 #
 
 defmodule Astarte.RealmManagement.API.Interfaces do
+  alias Astarte.RealmManagement.API.Interfaces.Queries
   alias Astarte.Core.Interface
   alias Astarte.Core.Mapping.EndpointsAutomaton
   alias Astarte.Core.Mapping
@@ -41,9 +42,8 @@ defmodule Astarte.RealmManagement.API.Interfaces do
     end
   end
 
-  def get_interface(realm_name, interface_name, interface_major_version) do
-    RealmManagement.get_interface(realm_name, interface_name, interface_major_version)
-  end
+  @doc delegate_to: {Queries, :fetch_interface, 3}
+  defdelegate fetch_interface(realm, interface, major), to: Queries
 
   def create_interface(realm_name, params, opts \\ []) do
     changeset = Interface.changeset(%Interface{}, params)

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
@@ -24,8 +24,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
     GenericOkReply,
     GetInterfacesList,
     GetInterfacesListReply,
-    GetInterfaceSource,
-    GetInterfaceSourceReply,
     GetInterfaceVersionsList,
     GetInterfaceVersionsListReply,
     GetInterfaceVersionsListReplyVersionTuple,
@@ -62,18 +60,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
       realm_name: realm_name
     }
     |> encode_call(:get_interfaces_list)
-    |> @rpc_client.rpc_call(@destination)
-    |> decode_reply()
-    |> extract_reply()
-  end
-
-  def get_interface(realm_name, interface_name, interface_major_version) do
-    %GetInterfaceSource{
-      realm_name: realm_name,
-      interface_name: interface_name,
-      interface_major_version: interface_major_version
-    }
-    |> encode_call(:get_interface_source)
     |> @rpc_client.rpc_call(@destination)
     |> decode_reply()
     |> extract_reply()
@@ -202,10 +188,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
          {:get_interfaces_list_reply, %GetInterfacesListReply{interfaces_names: list}}
        ) do
     {:ok, list}
-  end
-
-  defp extract_reply({:get_interface_source_reply, %GetInterfaceSourceReply{source: source}}) do
-    {:ok, source}
   end
 
   defp extract_reply(

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/interface_controller.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api_web/controllers/interface_controller.ex
@@ -73,9 +73,8 @@ defmodule Astarte.RealmManagement.APIWeb.InterfaceController do
 
   def show(conn, %{"realm_name" => realm_name, "id" => id, "major_version" => major_version}) do
     with {:major_parsing, {parsed_major, ""}} <- {:major_parsing, Integer.parse(major_version)},
-         {:ok, interface_source} <- Interfaces.get_interface(realm_name, id, parsed_major),
-         {:ok, decoded_json} <- Jason.decode(interface_source) do
-      render(conn, "show.json", interface: decoded_json)
+         {:ok, interface_source} <- Interfaces.fetch_interface(realm_name, id, parsed_major) do
+      render(conn, "show.json", interface: interface_source)
     else
       {:major_parsing, _} ->
         {:error, :invalid_major}

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/interfaces/interfaces_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/interfaces/interfaces_test.exs
@@ -21,6 +21,9 @@ defmodule Astarte.RealmManagement.API.InterfacesTest do
   use ExUnitProperties
 
   @moduletag :interfaces
+  # TODO: This module is only being kept for reference. Remove it altogether
+  # when the interfaces functions have been migrated to the API service.
+  @moduletag :skip
 
   alias Astarte.Core.Interface
   alias Astarte.Core.Mapping
@@ -188,7 +191,7 @@ defmodule Astarte.RealmManagement.API.InterfacesTest do
       update_interface(realm, @interface_name, @interface_major)
 
       assert {:ok, interface_source} =
-               Interfaces.get_interface(realm, @interface_name, @interface_major)
+               Interfaces.fetch_interface(realm, @interface_name, @interface_major)
 
       assert {:ok, map} = Jason.decode(interface_source)
 
@@ -327,7 +330,7 @@ defmodule Astarte.RealmManagement.API.InterfacesTest do
       update_interface(realm, @interface_name, @interface_major)
 
       assert {:ok, interface_source} =
-               Interfaces.get_interface(realm, @interface_name, @interface_major)
+               Interfaces.fetch_interface(realm, @interface_name, @interface_major)
 
       assert {:ok, map} = Jason.decode(interface_source)
 
@@ -496,7 +499,7 @@ defmodule Astarte.RealmManagement.API.InterfacesTest do
       assert :ok = Interfaces.delete_interface(realm, @interface_name, @interface_major)
 
       assert {:error, :interface_not_found} =
-               Interfaces.get_interface(realm, @interface_name, @interface_major)
+               Interfaces.fetch_interface(realm, @interface_name, @interface_major)
     end
 
     test "fails if major version is other than 0", %{realm: realm} do
@@ -532,7 +535,7 @@ defmodule Astarte.RealmManagement.API.InterfacesTest do
                )
 
       assert {:error, :interface_not_found} =
-               Interfaces.get_interface(realm, @interface_name, @interface_major)
+               Interfaces.fetch_interface(realm, @interface_name, @interface_major)
     end
   end
 

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/auth/auth_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/auth/auth_test.exs
@@ -17,9 +17,9 @@
 #
 
 defmodule Astarte.RealmManagement.APIWeb.AuthTest do
+  use Astarte.RealmManagement.API.DataCase
   use Astarte.RealmManagement.APIWeb.ConnCase
 
-  alias Astarte.Helpers
   alias Astarte.RealmManagement.API.Helpers.JWTTestHelper
 
   @valid_auth_path "^interfaces$"
@@ -31,8 +31,7 @@ defmodule Astarte.RealmManagement.APIWeb.AuthTest do
 
   require Logger
 
-  setup %{conn: conn, realm_name: realm_name, jwt_public_key: key} do
-    Helpers.Database.insert_public_key!(realm_name, key)
+  setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
   end
 

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/device_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/device_controller_test.exs
@@ -17,7 +17,8 @@
 #
 
 defmodule Astarte.RealmManagement.APIWeb.DeviceControllerTest do
-  use Astarte.RealmManagement.APIWeb.ConnCase, async: true
+  use Astarte.RealmManagement.API.DataCase, async: true
+  use Astarte.RealmManagement.APIWeb.ConnCase
   use Astarte.Cases.Device
 
   alias Astarte.RealmManagement.API.Helpers.JWTTestHelper

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/interface_version_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/interface_version_controller_test.exs
@@ -17,7 +17,8 @@
 #
 
 defmodule Astarte.RealmManagement.APIWeb.InterfaceVersionControllerTest do
-  use Astarte.RealmManagement.APIWeb.ConnCase, async: true
+  use Astarte.RealmManagement.API.DataCase, async: true
+  use Astarte.RealmManagement.APIWeb.ConnCase
 
   alias Astarte.RealmManagement.API.Helpers.JWTTestHelper
   alias Astarte.RealmManagement.API.Helpers.RPCMock.DB

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/realm_config_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/realm_config_controller_test.exs
@@ -17,7 +17,8 @@
 #
 
 defmodule Astarte.RealmManagement.APIWeb.RealmControllerTest do
-  use Astarte.RealmManagement.APIWeb.ConnCase, async: true
+  use Astarte.RealmManagement.API.DataCase, async: true
+  use Astarte.RealmManagement.APIWeb.ConnCase
 
   alias Astarte.Helpers
   alias Astarte.RealmManagement.API.Config

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/trigger_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/trigger_controller_test.exs
@@ -17,7 +17,8 @@
 #
 
 defmodule Astarte.RealmManagement.APIWeb.TriggerControllerTest do
-  use Astarte.RealmManagement.APIWeb.ConnCase, async: true
+  use Astarte.RealmManagement.API.DataCase, async: true
+  use Astarte.RealmManagement.APIWeb.ConnCase
 
   @moduletag :triggers
 

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/trigger_policy_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/trigger_policy_controller_test.exs
@@ -17,7 +17,8 @@
 #
 
 defmodule Astarte.RealmManagement.APIWeb.TriggerPolicyControllerTest do
-  use Astarte.RealmManagement.APIWeb.ConnCase, async: true
+  use Astarte.RealmManagement.API.DataCase, async: true
+  use Astarte.RealmManagement.APIWeb.ConnCase
   @moduletag :trigger_policy
 
   alias Astarte.RealmManagement.API.Helpers.JWTTestHelper

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/version_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/version_controller_test.exs
@@ -17,7 +17,8 @@
 #
 
 defmodule Astarte.RealmManagement.APIWeb.VersionControllerTest do
-  use Astarte.RealmManagement.APIWeb.ConnCase, async: true
+  use Astarte.RealmManagement.API.DataCase, async: true
+  use Astarte.RealmManagement.APIWeb.ConnCase
 
   alias Astarte.RealmManagement.API.Helpers.JWTTestHelper
   alias Astarte.RealmManagement.API.Helpers.RPCMock.DB

--- a/apps/astarte_realm_management_api/test/support/cases/conn_case.ex
+++ b/apps/astarte_realm_management_api/test/support/cases/conn_case.ex
@@ -30,8 +30,11 @@ defmodule Astarte.RealmManagement.APIWeb.ConnCase do
   inside a transaction which is reset at the beginning
   of the test unless the test case is marked as async.
   """
-
   use ExUnit.CaseTemplate
+
+  alias Astarte.RealmManagement.API.Helpers.JWTTestHelper
+
+  import Plug.Conn
 
   using do
     quote do
@@ -39,13 +42,20 @@ defmodule Astarte.RealmManagement.APIWeb.ConnCase do
       import Plug.Conn
       import Phoenix.ConnTest
       import Astarte.RealmManagement.APIWeb.Router.Helpers
-      use Astarte.RealmManagement.API.DataCase
       # The default endpoint for testing
       @endpoint Astarte.RealmManagement.APIWeb.Endpoint
     end
   end
 
-  setup do
-    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  setup_all do
+    token = JWTTestHelper.gen_jwt_all_access_token()
+    conn = Phoenix.ConnTest.build_conn()
+
+    auth_conn =
+      conn
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("authorization", "Bearer #{token}")
+
+    %{conn: conn, auth_conn: auth_conn}
   end
 end

--- a/apps/astarte_realm_management_api/test/support/helpers/astarte_realm_management_mock.ex
+++ b/apps/astarte_realm_management_api/test/support/helpers/astarte_realm_management_mock.ex
@@ -24,8 +24,6 @@ defmodule Astarte.RealmManagement.API.Helpers.RPCMock do
     GetDatastreamMaximumStorageRetentionReply,
     GenericErrorReply,
     GenericOkReply,
-    GetInterfaceSource,
-    GetInterfaceSourceReply,
     GetInterfacesList,
     GetInterfacesListReply,
     GetInterfaceVersionsList,
@@ -116,24 +114,6 @@ defmodule Astarte.RealmManagement.API.Helpers.RPCMock do
     %GetJWTPublicKeyPEMReply{jwt_public_key_pem: pem}
     |> encode_reply(:get_jwt_public_key_pem_reply)
     |> ok_wrap
-  end
-
-  defp execute_rpc(
-         {:get_interface_source,
-          %GetInterfaceSource{
-            realm_name: realm_name,
-            interface_name: name,
-            interface_major_version: major
-          }}
-       ) do
-    if source = DB.get_interface_source(realm_name, name, major) do
-      %GetInterfaceSourceReply{source: source}
-      |> encode_reply(:get_interface_source_reply)
-      |> ok_wrap
-    else
-      generic_error(:interface_not_found)
-      |> ok_wrap
-    end
   end
 
   defp execute_rpc(

--- a/apps/astarte_realm_management_api/test/support/helpers/astarte_realm_management_mock_db.ex
+++ b/apps/astarte_realm_management_api/test/support/helpers/astarte_realm_management_mock_db.ex
@@ -94,14 +94,6 @@ defmodule Astarte.RealmManagement.API.Helpers.RPCMock.DB do
     end)
   end
 
-  def get_interface_source(realm, name, major) do
-    if interface = get_interface(realm, name, major) do
-      Jason.encode!(interface)
-    else
-      nil
-    end
-  end
-
   def get_interface(realm, name, major) do
     Agent.get(current_agent(), fn %{interfaces: interfaces} ->
       Map.get(interfaces, {realm, name, major})


### PR DESCRIPTION
Moves `fetch_interface` from RealmManagement to  the `API` frontend service. This is part of a series of PRs trying to refactor our services and rationalise our infrastructure.

- `RealmManagement.API` service now has the `RealmManagement` test and dev dependency
- The `fetch_interface` query gets moved to the frontend service
- Old tests are skipped, I found this approach simpler instead of trying to make everything work for tests that should disappear in a couple of weeks
- New tests have been put in place, adding support for astarte test cases (database and conn)