### PR TITLE
refactor(RM): remove `get_trigger_policies_list` RPC

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -560,12 +560,6 @@ defmodule Astarte.RealmManagement.Engine do
     end
   end
 
-  def get_trigger_policies_list(realm_name) do
-    _ = Logger.debug("Get trigger policy list", tag: "get_trigger_policies_list")
-
-    Queries.get_trigger_policies_list(realm_name)
-  end
-
   def trigger_policy_source(realm_name, policy_name) do
     _ =
       Logger.debug("Get trigger policy source.",

--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -995,22 +995,6 @@ defmodule Astarte.RealmManagement.Queries do
     KvStore.insert(params, opts)
   end
 
-  def get_trigger_policies_list(realm_name) do
-    keyspace = Realm.keyspace_name(realm_name)
-
-    query =
-      from store in KvStore,
-        select: store.key,
-        where: [group: "trigger_policy"]
-
-    opts = [
-      prefix: keyspace,
-      consistency: Consistency.domain_model(:read)
-    ]
-
-    Repo.fetch_all(query, opts)
-  end
-
   def fetch_trigger_policy(realm_name, policy_name) do
     keyspace = Realm.keyspace_name(realm_name)
 

--- a/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
@@ -41,8 +41,6 @@ defmodule Astarte.RealmManagement.RPC.Handler do
     Reply,
     UpdateJWTPublicKeyPEM,
     InstallTriggerPolicy,
-    GetTriggerPoliciesList,
-    GetTriggerPoliciesListReply,
     GetTriggerPolicySource,
     GetTriggerPolicySourceReply,
     DeleteTriggerPolicy,
@@ -109,14 +107,6 @@ defmodule Astarte.RealmManagement.RPC.Handler do
 
   def encode_reply(:update_jwt_public_key_pem, :ok) do
     {:ok, Reply.encode(%Reply{error: false, reply: {:generic_ok_reply, %GenericOkReply{}}})}
-  end
-
-  def encode_reply(:get_trigger_policies_list, {:ok, reply}) do
-    msg = %GetTriggerPoliciesListReply{
-      trigger_policies_names: reply
-    }
-
-    {:ok, Reply.encode(%Reply{error: false, reply: {:get_trigger_policies_list_reply, msg}})}
   end
 
   def encode_reply(:get_trigger_policy_source, {:ok, reply}) do
@@ -261,14 +251,6 @@ defmodule Astarte.RealmManagement.RPC.Handler do
               encode_reply(
                 :install_policy,
                 Engine.install_trigger_policy(realm_name, policy_json, async: async_operation)
-              )
-
-            {:get_trigger_policies_list, %GetTriggerPoliciesList{realm_name: realm_name}} ->
-              _ = Logger.metadata(realm: realm_name)
-
-              encode_reply(
-                :get_trigger_policies_list,
-                Engine.get_trigger_policies_list(realm_name)
               )
 
             {:get_trigger_policy_source,

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
@@ -32,8 +32,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
     InstallInterface,
     Reply,
     InstallTriggerPolicy,
-    GetTriggerPoliciesList,
-    GetTriggerPoliciesListReply,
     GetTriggerPolicySource,
     GetTriggerPolicySourceReply,
     DeleteTriggerPolicy,
@@ -100,16 +98,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
       async_operation: Keyword.get(opts, :async_operation, true)
     }
     |> encode_call(:delete_interface)
-    |> @rpc_client.rpc_call(@destination)
-    |> decode_reply()
-    |> extract_reply()
-  end
-
-  def get_trigger_policies_list(realm_name) do
-    %GetTriggerPoliciesList{
-      realm_name: realm_name
-    }
-    |> encode_call(:get_trigger_policies_list)
     |> @rpc_client.rpc_call(@destination)
     |> decode_reply()
     |> extract_reply()
@@ -218,13 +206,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
 
   defp extract_reply({:get_interface_source_reply, %GetInterfaceSourceReply{source: source}}) do
     {:ok, source}
-  end
-
-  defp extract_reply(
-         {:get_trigger_policies_list_reply,
-          %GetTriggerPoliciesListReply{trigger_policies_names: list}}
-       ) do
-    {:ok, list}
   end
 
   defp extract_reply(

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/policies/policies.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/policies/policies.ex
@@ -19,12 +19,13 @@
 defmodule Astarte.RealmManagement.API.Triggers.Policies do
   alias Astarte.Core.Triggers.Policy
   alias Astarte.RealmManagement.API.RPC.RealmManagement
+  alias Astarte.RealmManagement.API.Triggers.Policies.Queries
 
   @doc """
   Returns the list of trigger policies. Returns either `{:ok, list}` or an `{:error, reason}` tuple.
   """
   def list_trigger_policies(realm_name) do
-    with {:ok, policies_list} <- RealmManagement.get_trigger_policies_list(realm_name) do
+    with {:ok, policies_list} <- Queries.get_trigger_policies_list(realm_name) do
       policies_list
     end
   end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/policies/queries.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/policies/queries.ex
@@ -1,0 +1,58 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagement.API.Triggers.Policies.Queries do
+  alias Astarte.DataAccess.Consistency
+  alias Astarte.DataAccess.KvStore
+  alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.DataAccess.Repo
+
+  import Ecto.Query
+
+  @doc """
+  Fetches the list of trigger policy names for a given realm.
+
+  ## Parameters
+    - `realm_name` (`String.t`): The name of the realm from which to fetch the trigger policies.
+
+  ## Returns
+    - `{:ok, policies_list}`: A tuple containing `:ok` and a list of policies.
+    - `{:error, reason}`: If there was an error fetching the policies.
+
+  ## Example
+
+      iex> get_trigger_policies_list("my_realm")
+      {:ok, ["policy_1", "policy_2", "policy_3"]}
+  """
+  def get_trigger_policies_list(realm_name) do
+    keyspace = Realm.keyspace_name(realm_name)
+
+    query =
+      from(store in KvStore,
+        select: store.key,
+        where: [group: "trigger_policy"]
+      )
+
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.domain_model(:read)
+    ]
+
+    Repo.fetch_all(query, opts)
+  end
+end

--- a/apps/astarte_realm_management_api/test/support/helpers/astarte_realm_management_mock.ex
+++ b/apps/astarte_realm_management_api/test/support/helpers/astarte_realm_management_mock.ex
@@ -37,8 +37,6 @@ defmodule Astarte.RealmManagement.API.Helpers.RPCMock do
     Reply,
     UpdateJWTPublicKeyPEM,
     InstallTriggerPolicy,
-    GetTriggerPoliciesList,
-    GetTriggerPoliciesListReply,
     DeleteTriggerPolicy,
     GetTriggerPolicySource,
     GetTriggerPolicySourceReply,
@@ -186,19 +184,6 @@ defmodule Astarte.RealmManagement.API.Helpers.RPCMock do
         generic_error(reason)
         |> ok_wrap
     end
-  end
-
-  defp execute_rpc(
-         {:get_trigger_policies_list,
-          %GetTriggerPoliciesList{
-            realm_name: realm_name
-          }}
-       ) do
-    list = DB.get_trigger_policies_list(realm_name)
-
-    %GetTriggerPoliciesListReply{trigger_policies_names: list}
-    |> encode_reply(:get_trigger_policies_list_reply)
-    |> ok_wrap
   end
 
   defp execute_rpc(


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
- Replace the `get_trigger_policies_list` function implementation using RPC with direct database access
- Remove `get_trigger_policies_list` RPC as it is not used by any component

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
