### PR TITLE
refactor(RM): Remove get_interface_versions_list RPC 

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -111,12 +111,6 @@ defmodule Astarte.RealmManagement.Engine do
     end
   end
 
-  def list_interface_versions(realm_name, interface_name) do
-    _ = Logger.debug("List interface versions.", interface: interface_name)
-
-    Queries.interface_available_versions(realm_name, interface_name)
-  end
-
   def get_interfaces_list(realm_name) do
     _ = Logger.debug("Get interfaces list.")
 

--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -320,33 +320,6 @@ defmodule Astarte.RealmManagement.Queries do
     :ok
   end
 
-  def interface_available_versions(realm_name, interface_name) do
-    keyspace = Realm.keyspace_name(realm_name)
-
-    interface_versions_query =
-      from Interface,
-        select: [:major_version, :minor_version],
-        where: [name: ^interface_name]
-
-    consistency = Consistency.domain_model(:read)
-
-    with {:ok, interface_versions} <-
-           Repo.fetch_all(interface_versions_query, prefix: keyspace, consistency: consistency) do
-      case interface_versions do
-        [] ->
-          {:error, :interface_not_found}
-
-        interfaces ->
-          major_minor_mapping =
-            Enum.map(interfaces, fn interface ->
-              [major_version: interface.major_version, minor_version: interface.minor_version]
-            end)
-
-          {:ok, major_minor_mapping}
-      end
-    end
-  end
-
   def is_interface_major_available?(realm_name, interface_name, interface_major) do
     keyspace = Realm.keyspace_name(realm_name)
 

--- a/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/rpc/handler.ex
@@ -31,9 +31,6 @@ defmodule Astarte.RealmManagement.RPC.Handler do
     GetInterfacesListReply,
     GetInterfaceSource,
     GetInterfaceSourceReply,
-    GetInterfaceVersionsList,
-    GetInterfaceVersionsListReply,
-    GetInterfaceVersionsListReplyVersionTuple,
     GetJWTPublicKeyPEM,
     GetJWTPublicKeyPEMReply,
     InstallInterface,
@@ -69,20 +66,6 @@ defmodule Astarte.RealmManagement.RPC.Handler do
     }
 
     {:ok, Reply.encode(%Reply{error: false, reply: {:get_interface_source_reply, msg}})}
-  end
-
-  def encode_reply(:get_interface_versions_list, {:ok, reply}) do
-    msg = %GetInterfaceVersionsListReply{
-      versions:
-        for version <- reply do
-          %GetInterfaceVersionsListReplyVersionTuple{
-            major_version: version[:major_version],
-            minor_version: version[:minor_version]
-          }
-        end
-    }
-
-    {:ok, Reply.encode(%Reply{error: false, reply: {:get_interface_versions_list_reply, msg}})}
   end
 
   def encode_reply(:get_interfaces_list, {:ok, reply}) do
@@ -177,15 +160,6 @@ defmodule Astarte.RealmManagement.RPC.Handler do
               encode_reply(
                 :get_interface_source,
                 Engine.interface_source(realm_name, interface_name, interface_major_version)
-              )
-
-            {:get_interface_versions_list,
-             %GetInterfaceVersionsList{realm_name: realm_name, interface_name: interface_name}} ->
-              _ = Logger.metadata(realm: realm_name)
-
-              encode_reply(
-                :get_interface_versions_list,
-                Engine.list_interface_versions(realm_name, interface_name)
               )
 
             {:get_interfaces_list, %GetInterfacesList{realm_name: realm_name}} ->

--- a/apps/astarte_realm_management/test/astarte_realm_management/rpc/handler_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/rpc/handler_test.exs
@@ -23,8 +23,6 @@ defmodule Astarte.RealmManagement.RPC.HandlerTest do
     GenericErrorReply,
     GetInterfacesListReply,
     GetInterfaceSourceReply,
-    GetInterfaceVersionsListReply,
-    GetInterfaceVersionsListReplyVersionTuple,
     Reply
   }
 
@@ -72,33 +70,6 @@ defmodule Astarte.RealmManagement.RPC.HandlerTest do
     }
 
     {:ok, buf} = Handler.encode_reply(:get_interface_source, {:ok, "this_is_the_source"})
-    assert Reply.decode(buf) == expectedReply
-
-    expectedReply = %Reply{
-      version: 0,
-      error: false,
-      reply:
-        {:get_interface_versions_list_reply,
-         %GetInterfaceVersionsListReply{
-           versions: [
-             %GetInterfaceVersionsListReplyVersionTuple{
-               major_version: 1,
-               minor_version: 2
-             },
-             %GetInterfaceVersionsListReplyVersionTuple{
-               major_version: 2,
-               minor_version: 0
-             }
-           ]
-         }}
-    }
-
-    {:ok, buf} =
-      Handler.encode_reply(
-        :get_interface_versions_list,
-        {:ok, [[major_version: 1, minor_version: 2], [major_version: 2, minor_version: 0]]}
-      )
-
     assert Reply.decode(buf) == expectedReply
 
     expectedReply = %Reply{

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/interfaces/interfaces.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/interfaces/interfaces.ex
@@ -42,7 +42,7 @@ defmodule Astarte.RealmManagement.API.Interfaces do
 
   def list_interface_major_versions(realm_name, id) do
     with {:ok, interface_versions_list} <-
-           RealmManagement.get_interface_versions_list(realm_name, id),
+           Queries.fetch_interface_versions_list(realm_name, id),
          interface_majors <- Enum.map(interface_versions_list, fn el -> el[:major_version] end) do
       {:ok, interface_majors}
     end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/rpc/realm_management.ex
@@ -23,9 +23,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
     GenericOkReply,
     GetInterfacesList,
     GetInterfacesListReply,
-    GetInterfaceVersionsList,
-    GetInterfaceVersionsListReply,
-    GetInterfaceVersionsListReplyVersionTuple,
     Reply,
     InstallTriggerPolicy,
     DeleteTriggerPolicy
@@ -37,17 +34,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
 
   @rpc_client Config.rpc_client!()
   @destination Astarte.RPC.Protocol.RealmManagement.amqp_queue()
-
-  def get_interface_versions_list(realm_name, interface_name) do
-    %GetInterfaceVersionsList{
-      realm_name: realm_name,
-      interface_name: interface_name
-    }
-    |> encode_call(:get_interface_versions_list)
-    |> @rpc_client.rpc_call(@destination)
-    |> decode_reply()
-    |> extract_reply()
-  end
 
   def get_interfaces_list(realm_name) do
     %GetInterfacesList{
@@ -114,22 +100,6 @@ defmodule Astarte.RealmManagement.API.RPC.RealmManagement do
         _ = Logger.warning("Received unknown error: #{inspect(name)}.", tag: "amqp_generic_error")
         {:error, :unknown}
     end
-  end
-
-  defp extract_reply(
-         {:get_interface_versions_list_reply, %GetInterfaceVersionsListReply{versions: versions}}
-       ) do
-    result =
-      for version <- versions do
-        %GetInterfaceVersionsListReplyVersionTuple{
-          major_version: major_version,
-          minor_version: minor_version
-        } = version
-
-        [major_version: major_version, minor_version: minor_version]
-      end
-
-    {:ok, result}
   end
 
   defp extract_reply(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Replace the `get_interface_versions_list` function implementation using RPC with direct database access

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
