### PR TITLE
chore(rm): remove `@tag :skip` from tests

### DIFF
--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/interfaces/interfaces.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/interfaces/interfaces.ex
@@ -104,7 +104,7 @@ defmodule Astarte.RealmManagement.API.Interfaces do
           tag: "invalid_interface_document"
         )
 
-      {:error, :invalid_interface_document}
+      {:error, changeset}
     end
   end
 

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api/interfaces/interfaces_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api/interfaces/interfaces_test.exs
@@ -130,8 +130,10 @@ defmodule Astarte.RealmManagement.API.InterfacesTest do
     end
 
     test "fails with invalid attrs", %{realm: realm} do
-      assert {:error, :invalid_interface_document} =
+      assert {:error, changeset} =
                Interfaces.install_interface(realm, @invalid_attrs)
+
+      assert [type: {"is invalid", _}] = changeset.errors
     end
 
     test "succeeds using a synchronous call", %{realm: realm} do
@@ -326,11 +328,6 @@ defmodule Astarte.RealmManagement.API.InterfacesTest do
                  @interface_major,
                  update_attrs
                )
-    end
-
-    test "fails with invalid attrs", %{realm: realm} do
-      assert {:error, :invalid_interface_document} =
-               Interfaces.install_interface(realm, @invalid_attrs)
     end
 
     test "succeeds with valid attrs using a synchronous call", %{realm: realm} do


### PR DESCRIPTION
Removes the `:skip` tag from tests that should run, namely interface creation and update tests tests
