### PR TITLE
fix: handle missing interface in introspection

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/device.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/device.ex
@@ -208,31 +208,14 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Device do
     :ok = Queries.add_old_interfaces(realm, new_state.device_id, old_introspection)
     :ok = Queries.remove_old_interfaces(realm, new_state.device_id, readded_introspection)
 
-    # Deliver interface_minor_updated triggers if needed
-    for {interface_name, old_minor} <- old_minors,
-        interface_major = Map.fetch!(state.introspection, interface_name),
-        Map.get(db_introspection_map, interface_name) == interface_major,
-        new_minor = Map.get(db_introspection_minor_map, interface_name),
-        new_minor != old_minor do
-      interface_id = CQLUtils.interface_id(interface_name, interface_major)
-
-      interface_minor_updated_target_with_policy_list =
-        Map.get(device_triggers, {:on_interface_minor_updated, interface_id}, [])
-        |> Enum.map(fn target ->
-          {target, Map.get(state.trigger_id_to_policy_name, target.parent_trigger_id)}
-        end)
-
-      TriggersHandler.interface_minor_updated(
-        interface_minor_updated_target_with_policy_list,
-        realm,
-        device_id_string,
-        interface_name,
-        interface_major,
-        old_minor,
-        new_minor,
-        timestamp_ms
-      )
-    end
+    maybe_deliver_interface_minor_updated_triggers(
+      state,
+      db_introspection_map,
+      db_introspection_minor_map,
+      device_triggers,
+      old_minors,
+      timestamp_ms
+    )
 
     # Removed/updated interfaces must be purged away, otherwise data will be written using old
     # interface_id.
@@ -266,6 +249,41 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Device do
         total_received_msgs: new_state.total_received_msgs + 1,
         total_received_bytes: new_state.total_received_bytes + byte_size(payload)
     }
+  end
+
+  defp maybe_deliver_interface_minor_updated_triggers(
+         state,
+         db_introspection_map,
+         db_introspection_minor_map,
+         device_triggers,
+         old_minors,
+         timestamp_ms
+       ) do
+    # Deliver interface_minor_updated triggers if needed
+    for {interface_name, old_minor} <- old_minors,
+        interface_major = Map.fetch!(state.introspection, interface_name),
+        Map.get(db_introspection_map, interface_name) == interface_major,
+        new_minor = Map.get(db_introspection_minor_map, interface_name),
+        new_minor != old_minor do
+      interface_id = CQLUtils.interface_id(interface_name, interface_major)
+
+      interface_minor_updated_target_with_policy_list =
+        Map.get(device_triggers, {:on_interface_minor_updated, interface_id}, [])
+        |> Enum.map(fn target ->
+          {target, Map.get(state.trigger_id_to_policy_name, target.parent_trigger_id)}
+        end)
+
+      TriggersHandler.interface_minor_updated(
+        interface_minor_updated_target_with_policy_list,
+        state.realm,
+        Astarte.Core.Device.encode_device_id(state.device_id),
+        interface_name,
+        interface_major,
+        old_minor,
+        new_minor,
+        timestamp_ms
+      )
+    end
   end
 
   def ask_clean_session(state, timestamp) do


### PR DESCRIPTION
Previously, the device process could crash when handling introspection if a new interface was provided. This should fix it as the fetch of interface major can fail and therefore not trigger `interface_minor_update` triggers