### PR TITLE
chore(rm): address (the majority of) `dialyzer` errors

### DIFF
--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/auth/auth.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/auth/auth.ex
@@ -21,6 +21,7 @@ defmodule Astarte.RealmManagement.API.Auth do
 
   require Logger
 
+  @spec fetch_public_key(String.t()) :: {:ok, String.t()} | {:error, :public_key_not_found}
   def fetch_public_key(realm) do
     Queries.fetch_jwt_public_key_pem(realm)
   end

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/device_removal/core.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/device_removal/core.ex
@@ -35,10 +35,9 @@ defmodule Astarte.RealmManagement.API.DeviceRemoval.Core do
   end
 
   defp retrieve_individual_datastreams_keys!(realm_name, device_id) do
-    if Queries.table_exist?(realm_name, "individual_datastreams") do
-      Queries.retrieve_individual_datastreams_keys!(realm_name, device_id)
-    else
-      []
+    case Queries.table_exist?(realm_name, "individual_datastreams") do
+      {:ok, true} -> Queries.retrieve_individual_datastreams_keys!(realm_name, device_id)
+      {:ok, false} -> []
     end
   end
 

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/device_removal/core.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/device_removal/core.ex
@@ -67,10 +67,9 @@ defmodule Astarte.RealmManagement.API.DeviceRemoval.Core do
   end
 
   defp retrieve_individual_properties_keys!(realm_name, device_id) do
-    if Queries.table_exist?(realm_name, "individual_properties") do
-      Queries.retrieve_individual_properties_keys!(realm_name, device_id)
-    else
-      []
+    case Queries.table_exist?(realm_name, "individual_properties") do
+      {:ok, true} -> Queries.retrieve_individual_properties_keys!(realm_name, device_id)
+      {:ok, false} -> []
     end
   end
 

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/realm_config/queries.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/realm_config/queries.ex
@@ -35,6 +35,8 @@ defmodule Astarte.RealmManagement.API.RealmConfig.Queries do
   Gets the jwt public key pem for the realm with name `realm_name`. returns
   {:error, :public_key_not_found} if the realm could not be found.
   """
+  @spec fetch_jwt_public_key_pem(String.t()) ::
+          {:ok, String.t()} | {:error, :public_key_not_found}
   def fetch_jwt_public_key_pem(realm_name) do
     keyspace = Realm.keyspace_name(realm_name)
 

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/action.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/action.ex
@@ -23,11 +23,11 @@ defmodule Astarte.RealmManagement.API.Triggers.Action do
   or in an Astarte.RealmManagement.API.Triggers.HttpAction struct.
   Validation is performed in the related modules.
   """
-  use Ecto.Schema
+  use TypedEctoSchema
   alias Astarte.RealmManagement.API.Triggers.Action
 
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :http_url, :string
     field :http_method, :string
     field :http_static_headers, {:map, :string}

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/amqp_action.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/amqp_action.ex
@@ -17,14 +17,14 @@
 #
 
 defmodule Astarte.RealmManagement.API.Triggers.AMQPAction do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
   alias Astarte.RealmManagement.API.Triggers.AMQPAction
 
   @max_headers_size 64 * 1024
 
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :amqp_exchange, :string
     field :amqp_routing_key, :string
     field :amqp_static_headers, {:map, :string}

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/http_action.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/http_action.ex
@@ -17,12 +17,12 @@
 #
 
 defmodule Astarte.RealmManagement.API.Triggers.HttpAction do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
   alias Astarte.RealmManagement.API.Triggers.HttpAction
 
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :http_url, :string
     field :http_method, :string
     field :http_static_headers, {:map, :string}

--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/trigger.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/trigger.ex
@@ -17,7 +17,7 @@
 #
 
 defmodule Astarte.RealmManagement.API.Triggers.Trigger do
-  use Ecto.Schema
+  use TypedEctoSchema
   import Ecto.Changeset
   alias Ecto.Changeset
   alias Astarte.Core.Triggers.SimpleTriggerConfig
@@ -25,7 +25,7 @@ defmodule Astarte.RealmManagement.API.Triggers.Trigger do
 
   @derive {Phoenix.Param, key: :name}
   @primary_key false
-  embedded_schema do
+  typed_embedded_schema do
     field :name, :string
     embeds_one :action, Action
     field :policy, :string


### PR DESCRIPTION
Based on #1378 

Fixes the majority of `mix dialyzer` errors, leaving one error in `KvStore`  insertions

This also removes the unused `rpc` modules to interact with the backend service as nobody is using it