### PR TITLE
refactor(rm): manually convert action map to action struct

### DIFF
--- a/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/triggers.ex
+++ b/apps/astarte_realm_management_api/lib/astarte_realm_management_api/triggers/triggers.ex
@@ -62,11 +62,28 @@ defmodule Astarte.RealmManagement.API.Triggers do
             tagged_simple_triggers: tagged_simple_triggers,
             policy: policy
           }} <- RealmManagement.get_trigger(realm_name, trigger_name),
-         {:ok, action_map} <- Jason.decode(action, keys: :atoms!) do
+         {:ok, action_map} <- Jason.decode(action) do
       simple_triggers_configs =
         Enum.map(tagged_simple_triggers, &SimpleTriggerConfig.from_tagged_simple_trigger/1)
 
-      action_struct = struct(Action, action_map)
+      action_struct =
+        %Action{}
+        |> Changeset.cast(action_map, [
+          :http_url,
+          :http_method,
+          :http_static_headers,
+          :template,
+          :template_type,
+          :http_post_url,
+          :ignore_ssl_errors,
+          :amqp_exchange,
+          :amqp_routing_key,
+          :amqp_static_headers,
+          :amqp_message_expiration_ms,
+          :amqp_message_priority,
+          :amqp_message_persistent
+        ])
+        |> Changeset.apply_changes()
 
       {:ok,
        %Trigger{

--- a/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/trigger_controller_test.exs
+++ b/apps/astarte_realm_management_api/test/astarte_realm_management_api_web/controllers/trigger_controller_test.exs
@@ -99,7 +99,7 @@ defmodule Astarte.RealmManagement.APIWeb.TriggerControllerTest do
       post_conn =
         post(conn, trigger_path(conn, :create, realm), data: valid_trigger_attrs())
 
-      response = json_response(post_conn, 201)["data"]
+      json_response(post_conn, 201)["data"]
 
       delete_conn =
         delete(conn, trigger_path(conn, :delete, realm, valid_trigger_attrs()["name"]))


### PR DESCRIPTION
https://github.com/astarte-platform/astarte/pull/1237 changed the get_trigger function to now return the action struct, but to do so it uses keys: atoms! in the Jason.decode call, which is also applied recursively to the static headers, and may fail if the header does not have a pre-existing atom.

by manually assigning each field to the struct, we avoid this problem

 I have read [CONTRIBUTING.md](https://github.com/astarte-platform/astarte/CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](https://github.com/astarte-platform/astarte/CODE_OF_CONDUCT.md)
 I have added to [CHANGELOG.md](https://github.com/astarte-platform/astarte/CHANGELOG.md) relevant changes and any other user facing change
 I have added or ran the appropriate tests
What this PR does / why we need it:
Which issue(s) this PR fixes:
Fixes #

Special notes for your reviewer:
Does this PR introduce a user-facing change?
 Yes
 No
Additional documentation e.g. usage docs, diagrams, etc.: