### PR TITLE
refactor(ae): use Exandra for all queries

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/application.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/application.ex
@@ -44,8 +44,6 @@ defmodule Astarte.AppEngine.API.Application do
 
     data_access_opts = [xandra_options: xandra_options]
 
-    ae_xandra_opts = Keyword.put(xandra_options, :name, :xandra)
-
     # Define workers and child supervisors to be supervised
     children = [
       {Cluster.Supervisor,
@@ -57,7 +55,6 @@ defmodule Astarte.AppEngine.API.Application do
       Astarte.AppEngine.API.Rooms.MasterSupervisor,
       Astarte.AppEngine.API.Rooms.AMQPClient,
       Astarte.AppEngine.APIWeb.Endpoint,
-      {Xandra.Cluster, ae_xandra_opts},
       {Astarte.DataAccess, data_access_opts},
       {Astarte.AppEngine.API.Repo, xandra_options}
     ]

--- a/apps/astarte_appengine_api/test/support/helpers/database.ex
+++ b/apps/astarte_appengine_api/test/support/helpers/database.ex
@@ -666,18 +666,12 @@ defmodule Astarte.Helpers.Database do
   def fake_connect_device(encoded_device_id, connected) when is_boolean(connected) do
     {:ok, device_id} = Astarte.Core.Device.decode_device_id(encoded_device_id)
 
-    Xandra.Cluster.run(:xandra, fn conn ->
-      query = """
-      INSERT INTO #{Realm.keyspace_name(@test_realm)}.devices
-      (device_id, connected) VALUES (:device_id, :connected)
-      """
-
-      params = %{"device_id" => device_id, "connected" => connected}
-      prepared = Xandra.prepare!(conn, query)
-      %Xandra.Void{} = Xandra.execute!(conn, prepared, params)
-    end)
-
-    :ok
+    %DeviceSchema{}
+    |> Ecto.Changeset.change(%{
+      device_id: device_id,
+      connected: connected
+    })
+    |> Repo.insert!(prefix: Realm.keyspace_name(@test_realm))
   end
 
   def create_datastream_receiving_device do


### PR DESCRIPTION
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
#### What this PR does / why we need it:
using Exandra in the last AppEngine query and stop starting Xandra through the supervisor 


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
