### PR TITLE
Refactor(HK): Update use of  `CSystem.execute_schema_change`

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/migrator.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/migrator.ex
@@ -315,7 +315,7 @@ defmodule Astarte.Housekeeping.Migrator do
 
     with {:ok, query} <- File.read(file),
          _ = Logger.info("Migration query:\n#{query}"),
-         {:ok, _result} <- CSystem.execute_schema_change(keyspace_conn, query),
+         {:ok, _result} <- CSystem.execute_schema_change(query),
          :ok <- set_schema_version(keyspace_conn, version) do
       execute_migrations(keyspace_conn, tail)
     else

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -239,7 +239,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
            :ok <- create_names_table(keyspace_name),
            :ok <- create_devices_table(keyspace_name),
            :ok <- create_endpoints_table(keyspace_name),
-           :ok <- create_interfaces_table(keyspace_conn),
+           :ok <- create_interfaces_table(keyspace_name),
            :ok <- create_individual_properties_table(keyspace_conn),
            :ok <- create_simple_triggers_table(keyspace_conn),
            :ok <- create_grouped_devices_table(keyspace_conn),
@@ -765,9 +765,9 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_interfaces_table({conn, realm}) do
+  defp create_interfaces_table(keyspace_name) do
     query = """
-    CREATE TABLE #{realm}.interfaces (
+    CREATE TABLE #{keyspace_name}.interfaces (
       name ascii,
       major_version int,
       minor_version int,
@@ -786,7 +786,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     );
     """
 
-    with {:ok, %Xandra.SchemaChange{}} <- CSystem.execute_schema_change(conn, query) do
+    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -242,7 +242,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
            :ok <- create_interfaces_table(keyspace_name),
            :ok <- create_individual_properties_table(keyspace_name),
            :ok <- create_simple_triggers_table(keyspace_name),
-           :ok <- create_grouped_devices_table(keyspace_conn),
+           :ok <- create_grouped_devices_table(keyspace_name),
            :ok <- create_deletion_in_progress_table(keyspace_conn),
            :ok <- insert_realm_public_key(realm_name, public_key_pem),
            :ok <- insert_realm_astarte_schema_version(realm_name),
@@ -589,9 +589,9 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_grouped_devices_table({conn, realm}) do
+  defp create_grouped_devices_table(keyspace_name) do
     query = """
-    CREATE TABLE #{realm}.grouped_devices (
+    CREATE TABLE #{keyspace_name}.grouped_devices (
       group_name varchar,
       insertion_uuid timeuuid,
       device_id uuid,
@@ -600,7 +600,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     );
     """
 
-    with {:ok, %Xandra.SchemaChange{}} <- CSystem.execute_schema_change(conn, query) do
+    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -241,7 +241,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
            :ok <- create_endpoints_table(keyspace_name),
            :ok <- create_interfaces_table(keyspace_name),
            :ok <- create_individual_properties_table(keyspace_name),
-           :ok <- create_simple_triggers_table(keyspace_conn),
+           :ok <- create_simple_triggers_table(keyspace_name),
            :ok <- create_grouped_devices_table(keyspace_conn),
            :ok <- create_deletion_in_progress_table(keyspace_conn),
            :ok <- insert_realm_public_key(realm_name, public_key_pem),
@@ -638,9 +638,9 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_simple_triggers_table({conn, realm}) do
+  defp create_simple_triggers_table(keyspace_name) do
     query = """
-    CREATE TABLE #{realm}.simple_triggers (
+    CREATE TABLE #{keyspace_name}.simple_triggers (
       object_id uuid,
       object_type int,
       parent_trigger_id uuid,
@@ -652,7 +652,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     );
     """
 
-    with {:ok, %Xandra.SchemaChange{}} <- CSystem.execute_schema_change(conn, query) do
+    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -238,7 +238,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
            :ok <- create_realm_kv_store(keyspace_name),
            :ok <- create_names_table(keyspace_name),
            :ok <- create_devices_table(keyspace_name),
-           :ok <- create_endpoints_table(keyspace_conn),
+           :ok <- create_endpoints_table(keyspace_name),
            :ok <- create_interfaces_table(keyspace_conn),
            :ok <- create_individual_properties_table(keyspace_conn),
            :ok <- create_simple_triggers_table(keyspace_conn),
@@ -711,9 +711,9 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_endpoints_table({conn, realm}) do
+  defp create_endpoints_table(keyspace_name) do
     query = """
-    CREATE TABLE #{realm}.endpoints (
+    CREATE TABLE #{keyspace_name}.endpoints (
       interface_id uuid,
       endpoint_id uuid,
       interface_name ascii,
@@ -736,7 +736,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     );
     """
 
-    with {:ok, %Xandra.SchemaChange{}} <- CSystem.execute_schema_change(conn, query) do
+    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -240,7 +240,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
            :ok <- create_devices_table(keyspace_name),
            :ok <- create_endpoints_table(keyspace_name),
            :ok <- create_interfaces_table(keyspace_name),
-           :ok <- create_individual_properties_table(keyspace_conn),
+           :ok <- create_individual_properties_table(keyspace_name),
            :ok <- create_simple_triggers_table(keyspace_conn),
            :ok <- create_grouped_devices_table(keyspace_conn),
            :ok <- create_deletion_in_progress_table(keyspace_conn),
@@ -605,16 +605,15 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_individual_properties_table({conn, realm}) do
+  defp create_individual_properties_table(keyspace_name) do
     query = """
-    CREATE TABLE #{realm}.individual_properties (
+    CREATE TABLE #{keyspace_name}.individual_properties (
       device_id uuid,
       interface_id uuid,
       endpoint_id uuid,
       path varchar,
       reception_timestamp timestamp,
       reception_timestamp_submillis smallint,
-
       double_value double,
       integer_value int,
       boolean_value boolean,
@@ -634,7 +633,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     )
     """
 
-    with {:ok, %Xandra.SchemaChange{}} <- CSystem.execute_schema_change(conn, query) do
+    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -1029,7 +1029,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     Xandra.Cluster.run(:xandra, [timeout: 60_000], fn conn ->
       with :ok <- create_astarte_keyspace(conn),
            :ok <- create_realms_table(conn),
-           :ok <- create_astarte_kv_store(conn),
+           :ok <- create_astarte_kv_store(),
            :ok <- insert_astarte_schema_version(conn) do
         :ok
       else
@@ -1108,7 +1108,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_astarte_kv_store(conn) do
+  defp create_astarte_kv_store do
     query = """
     CREATE TABLE #{Realm.astarte_keyspace_name()}.kv_store (
       group varchar,
@@ -1121,8 +1121,8 @@ defmodule Astarte.Housekeeping.Realms.Queries do
 
     consistency = Consistency.domain_model(:write)
 
-    with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(conn, query, %{}, consistency: consistency) do
+    with {:ok, %{rows: nil, num_rows: 1}} <-
+           Repo.query(query, [], consistency: consistency) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -237,7 +237,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
            {:ok, keyspace_conn} <- build_keyspace_conn(conn, keyspace_name),
            :ok <- create_realm_kv_store(keyspace_name),
            :ok <- create_names_table(keyspace_name),
-           :ok <- create_devices_table(keyspace_conn),
+           :ok <- create_devices_table(keyspace_name),
            :ok <- create_endpoints_table(keyspace_conn),
            :ok <- create_interfaces_table(keyspace_conn),
            :ok <- create_individual_properties_table(keyspace_conn),
@@ -674,9 +674,9 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_devices_table({conn, realm}) do
+  defp create_devices_table(keyspace_name) do
     query = """
-    CREATE TABLE #{realm}.devices (
+    CREATE TABLE #{keyspace_name}.devices (
       device_id uuid,
       aliases map<ascii, varchar>,
       introspection map<ascii, int>,
@@ -700,14 +700,13 @@ defmodule Astarte.Housekeeping.Realms.Queries do
       last_credentials_request_ip inet,
       last_seen_ip inet,
       attributes map<varchar, varchar>,
-
-      groups map<text, timeuuid>,
+      groups map<varchar, timeuuid>,
 
       PRIMARY KEY (device_id)
     );
     """
 
-    with {:ok, %Xandra.SchemaChange{}} <- CSystem.execute_schema_change(conn, query) do
+    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -236,7 +236,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
            :ok <- create_realm_keyspace(conn, keyspace_name, replication_map_str),
            {:ok, keyspace_conn} <- build_keyspace_conn(conn, keyspace_name),
            :ok <- create_realm_kv_store(keyspace_name),
-           :ok <- create_names_table(keyspace_conn),
+           :ok <- create_names_table(keyspace_name),
            :ok <- create_devices_table(keyspace_conn),
            :ok <- create_endpoints_table(keyspace_conn),
            :ok <- create_interfaces_table(keyspace_conn),
@@ -658,17 +658,18 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_names_table({conn, realm}) do
+  defp create_names_table(keyspace_name) do
     query = """
-    CREATE TABLE #{realm}.names (
+    CREATE TABLE #{keyspace_name}.names (
       object_name varchar,
       object_type int,
       object_uuid uuid,
+
       PRIMARY KEY ((object_name), object_type)
     );
     """
 
-    with {:ok, %Xandra.SchemaChange{}} <- CSystem.execute_schema_change(conn, query) do
+    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -1028,7 +1028,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
   def initialize_database do
     Xandra.Cluster.run(:xandra, [timeout: 60_000], fn conn ->
       with :ok <- create_astarte_keyspace(conn),
-           :ok <- create_realms_table(conn),
+           :ok <- create_realms_table(),
            :ok <- create_astarte_kv_store(),
            :ok <- insert_astarte_schema_version(conn) do
         :ok
@@ -1091,7 +1091,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp create_realms_table(conn) do
+  defp create_realms_table do
     query = """
     CREATE TABLE #{Realm.astarte_keyspace_name()}.realms (
       realm_name varchar,
@@ -1102,8 +1102,8 @@ defmodule Astarte.Housekeeping.Realms.Queries do
 
     consistency = Consistency.domain_model(:write)
 
-    with {:ok, %Xandra.SchemaChange{}} <-
-           Xandra.execute(conn, query, %{}, consistency: consistency) do
+    with {:ok, %{rows: nil, num_rows: 1}} <-
+           Repo.query(query, [], consistency: consistency) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/mix.exs
+++ b/apps/astarte_housekeeping/mix.exs
@@ -70,7 +70,7 @@ defmodule Astarte.Housekeeping.Mixfile do
   defp astarte_required_modules(_) do
     [
       {:astarte_data_access,
-       github: "astarte-platform/astarte_data_access", branch: "release-1.2"},
+       github: "OmarBrbutovic/astarte_data_access", branch: "update_CSystem"},
       {:astarte_core, github: "astarte-platform/astarte_core", branch: "release-1.2"}
     ]
   end

--- a/apps/astarte_housekeeping/mix.lock
+++ b/apps/astarte_housekeeping/mix.lock
@@ -1,6 +1,6 @@
 %{
   "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "710afe5f03c05e2ba36fba1cf9cea05f616475ba", [branch: "release-1.2"]},
-  "astarte_data_access": {:git, "https://github.com/astarte-platform/astarte_data_access.git", "991f8d99b31cccd626b434251b577b5001259ced", [branch: "release-1.2"]},
+  "astarte_data_access": {:git, "https://github.com/OmarBrbutovic/astarte_data_access.git", "97ea6218c9aa5af2283842af4a3d7fedead1e2cd", [branch: "update_CSystem"]},
   "astarte_generators": {:git, "https://github.com/astarte-platform/astarte_generators.git", "f6f5457cca05647b455c33854827073cef82a8ff", []},
   "castore": {:hex, :castore, "1.0.7", "b651241514e5f6956028147fe6637f7ac13802537e895a724f90bf3e36ddd1dd", [:mix], [], "hexpm", "da7785a4b0d2a021cd1292a60875a784b6caef71e76bf4917bdee1f390455cf5"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
@@ -40,10 +40,10 @@ defmodule Astarte.Housekeeping.MigratorTest do
       assert :ok = Migrator.run_astarte_keyspace_migrations()
     end
 
-    test "returns ok with incomplete db (missing kv_store table)" do
+    test "returns error with incomplete db (missing kv_store table)" do
       Database.destroy_astarte_kv_store_table!()
 
-      assert :ok = Migrator.run_astarte_keyspace_migrations()
+      assert {:error, :database_error} = Migrator.run_astarte_keyspace_migrations()
     end
 
     test "returns error due do xandra problem" do

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
@@ -19,6 +19,8 @@
 defmodule Astarte.Housekeeping.Realms.QueriesTest do
   use Astarte.Housekeeping.DataCase, async: true
   use Mimic
+
+  alias Astarte.DataAccess.Repo
   alias Astarte.Housekeeping.Helpers.Database
   alias Astarte.Housekeeping.Realms.Queries
   alias Astarte.Housekeeping.Realms
@@ -146,7 +148,7 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
     end
 
     test "creations returns an error", %{realm_name: realm_name} do
-      Xandra.Cluster |> stub(:run, fn _, _, _ -> {:error, "generic error"} end)
+      Repo |> stub(:query, fn _, _, _ -> {:error, "generic error"} end)
 
       assert {:error, "generic error"} =
                Queries.create_realm(realm_name, "test1publickey", 1, 1, 1, [])

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/realms/realms_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/realms/realms_test.exs
@@ -24,6 +24,7 @@ defmodule Astarte.Housekeeping.RealmsTest do
   import Astarte.Housekeeping.Fixtures.Realm
 
   alias Astarte.Core.Generators.Realm, as: GeneratorsRealm
+  alias Astarte.DataAccess.Repo
   alias Astarte.Housekeeping.Config
   alias Astarte.Housekeeping.Helpers.Database
   alias Astarte.Housekeeping.Realms
@@ -319,7 +320,7 @@ defmodule Astarte.Housekeeping.RealmsTest do
     end
 
     test "deletions returns an error", %{realm_name: realm_name} do
-      Xandra.Cluster |> stub(:run, fn _, _, _ -> {:error, "generic error"} end)
+      Repo |> stub(:query, fn _, _, _ -> {:error, "generic error"} end)
 
       assert {:error, "generic error"} = Realms.delete_realm(realm_name)
     end

--- a/apps/astarte_housekeeping/test/test_helper.exs
+++ b/apps/astarte_housekeeping/test/test_helper.exs
@@ -18,6 +18,7 @@
 
 Mimic.copy(Astarte.DataAccess.Health.Health)
 Mimic.copy(Astarte.DataAccess.Config)
+Mimic.copy(Astarte.DataAccess.Repo)
 Mimic.copy(Astarte.Housekeeping.Realms)
 Mimic.copy(Astarte.Housekeeping.Config)
 Mimic.copy(Astarte.Housekeeping.Realms.Queries)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Refactored multiple functions to use the updated `CSystem.execute_schema_change/1`, eliminating the need for an explicit Xandra connection. The conversions were done in no particular order and are part of a series of PRs, as there are many functions to update. The goal is to eliminate direct usage of Xandra queries and replace them with Ecto-based queries for better consistency and maintainability.

Depends on #1406 and [DataAccess #112](https://github.com/astarte-platform/astarte_data_access/pull/112)

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
