### PR TITLE
ci: activate dialyzer

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -58,8 +58,7 @@ jobs:
       run: mkdir -p dialyzer_cache && mix dialyzer --plt
     - name: Run dialyzer
       working-directory: ./apps/${{ inputs.app }}
-      # FIXME: This should be set to fail when dialyzer issues are fixed
-      run: mix dialyzer || exit 0
+      run: mix dialyzer
 
   test-coverage:
     name: Build and Test


### PR DESCRIPTION
runs `mix dialyzer` in ci and does not discard its errors