### PR TITLE
chore: update readmes

### DIFF
--- a/apps/astarte_appengine_api/README.md
+++ b/apps/astarte_appengine_api/README.md
@@ -1,8 +1,56 @@
-Astarte App Engine
-==================
+⚙️ App Engine (ae)
+==========================
+
+AppEngine is Astarte's main API endpoint for end users. AppEngine exposes a
+RESTful API to retrieve and send data from/to devices, according to their
+interfaces. Every direct device interaction can be done from here. It also
+exposes Channels, a WebSocket-based solution for listening to device events in
+real-time with Triggers' same mechanism and semantics.
+
+When running a full astarte instance (e.g., trough [astarte in 5
+minutes](https://docs.astarte-platform.org/astarte/latest/010-astarte_in_5_minutes.html))
+REST API documentation can be viewed at the `/swagger` endpoint of appengine
+(example: <http://api.astarte.localhost/appengine/swagger/>).
 
 <img src="appengine_astarte_overview.svg" align="center" />
 
-Astarte App Engine serves a [REST API](priv/static/astarte_appengine_api.yaml) that allows applications to gather and send data to the devices fleet.
+## 🔧 Build
 
-REST API documentation can be viewed at http://appenginehost:4002/swagger/ .
+to build ae you can follow the usual elixir flow
+
+``` shell
+mix deps.get
+mix compile
+```
+
+to lint ae code and get some insights on pattern matching and typing you can
+run dialyzer.
+
+``` shell
+mix dialyzer
+```
+
+nb: all PRs have to be linter-approved, so running `mix dialyzer` before makeing
+a pull request saves everyone some precious review time!
+
+## 🧑‍🔬 Test
+
+to test ae you need a running instance of rabbitmq and a cassandra-compatible
+database, (we suggest scylla)
+
+``` shell
+docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
+```
+
+by default `CASSANDRA_NODES` environment variable map to `localhost`, so that
+
+``` shell
+mix test
+```
+
+just works. In more complex scenarios you might need to tell to astarte where
+these resources are located.
+
+``` shell
+CASSANDRA_NODES=localhost mix test
+```

--- a/apps/astarte_data_updater_plant/README.md
+++ b/apps/astarte_data_updater_plant/README.md
@@ -1,4 +1,54 @@
-Astarte Data Updater Plant
-==========================
+🧠 Data Updater Plant (dup)
+===================================
+
+Data Updater Plant is a replicable, scalable component which takes care of the
+ingestion pipeline. It gathers data from devices and orchestrates data flow
+amongst other components. It is, arguably, the most critical component of the
+system and the most resource hungry - the way dup is deployed, replicated and
+configured has a tremendous impact on Astarte's performances, especially when
+dealing with massive data flows.
 
 <img src="data_updater_astarte_overview.svg" align="center" />
+
+## 🔧 Build
+
+to build dup you can follow the usual elixir flow
+
+``` shell
+mix deps.get
+mix compile
+```
+
+to lint dup code and get some insights on pattern matching and typing you can
+run dialyzer.
+
+``` shell
+mix dialyzer
+```
+
+nb: all PRs have to be linter-approved, so running `mix dialyzer` before makeing
+a pull request saves everyone some precious review time!
+
+## 🧑‍🔬 Test
+
+to test dup you need a running instance of rabbitmq and a cassandra-compatible
+database, (we suggest scylla)
+
+``` shell
+docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
+docker run --rm  -d -p 5672:5672 -p 15672:15672 --name rabbit rabbitmq:3.12.0-management
+```
+
+by default `RABBITMQ_HOST` and `CASSANDRA_NODES` environment variables map to
+`localhost`, so that
+
+``` shell
+mix test
+```
+
+just works. In more complex scenarios you might need to tell to astarte where
+these resources are located.
+
+``` shell
+RABBITMQ_HOST=localhost CASSANDRA_NODES=localhost mix test
+```

--- a/apps/astarte_housekeeping/README.md
+++ b/apps/astarte_housekeeping/README.md
@@ -1,5 +1,48 @@
-Astarte Housekeeping
-========================
+🧹 Astarte Housekeeping (hk)
+============================
 
-Housekeeping runs administration tasks such as creating new realms and initialization.
-This API allows frontends and developers to create realms and configure them.
+Housekeeping is the equivalent of a superadmin API. It is usually not accessible
+to the end user but rather to Astarte's administrator who, in most cases, might
+deny overall outside access. It allows to manage and create Realms, and perform
+cluster-wide maintenance actions.
+
+## 🔧 Build
+
+to build hk you can follow the usual elixir flow
+
+``` shell
+mix deps.get
+mix compile
+```
+
+to lint hk code and get some insights on pattern matching and typing you can
+run dialyzer.
+
+``` shell
+mix dialyzer
+```
+
+nb: all PRs have to be linter-approved, so running `mix dialyzer` before makeing
+a pull request saves everyone some precious review time!
+
+## 🧑‍🔬 Test
+
+to test hk you need a running instance of rabbitmq and a cassandra-compatible
+database, (we suggest scylla)
+
+``` shell
+docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
+```
+
+by default `CASSANDRA_NODES` environment variable map to `localhost`, so that
+
+``` shell
+mix test
+```
+
+just works. In more complex scenarios you might need to tell to astarte where
+these resources are located.
+
+``` shell
+CASSANDRA_NODES=localhost mix test
+```

--- a/apps/astarte_pairing/README.md
+++ b/apps/astarte_pairing/README.md
@@ -1,8 +1,50 @@
-Astarte Pairing API
-===================
+🫂 Astarte Pairing (pg)
+=======================
 
-Astarte device pairing service.
+Pairing takes care of Device Authentication and Authorization. It interacts with
+Astarte's CA and orchestrates the way devices connect and interact with
+Transports. It also handles Device Registration. Agent, Device and Pairing
+interaction is described in detail [in the astarte
+documentation](https://docs.astarte-platform.org/astarte/snapshot/050-pairing_mechanism.html).
 
-This Astarte platform component takes care of device pairing, that happens everytime a new device connects for the first time to Astarte or when an already connected device needs to renew its credentials.
+## 🔧 Build
 
-The component offers a REST API which allows devices to get an API key and to renew SSL certificates.
+to build pg you can follow the usual elixir flow
+
+``` shell
+mix deps.get
+mix compile
+```
+
+to lint pg code and get some insights on pattern matching and typing you can
+run dialyzer.
+
+``` shell
+mix dialyzer
+```
+
+nb: all PRs have to be linter-approved, so running `mix dialyzer` before makeing
+a pull request saves everyone some precious review time!
+
+## 🧑‍🔬 Test
+
+to test pg you need a running instance of CFSSL and a cassandra-compatible
+database, (we suggest scylla)
+
+``` shell
+docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
+docker run --rn -d --net=host -p 8080/tcp ispirata/docker-alpine-cfssl-autotest:astarte
+```
+
+by default, `CASSANDRA_NODES` environment variable maps to `localhost`, so that
+
+``` shell
+CFSSL_API_URL=http://localhost:8080 mix test
+```
+
+just works. In more complex scenarios you might need to tell to astarte where
+these resources are located.
+
+``` shell
+CASSANDRA_NODES=localhost CFSSL_API_URL=http://localhost:8080 mix test
+```

--- a/apps/astarte_realm_management/README.md
+++ b/apps/astarte_realm_management/README.md
@@ -1,4 +1,49 @@
-Astarte Realm Management
-============================
+👑 Realm Management (rm)
+========================
 
-Astarte Realm Management serves a [REST API](priv/static/astarte_realm_management.yaml) that allows administration panels and applications to manage a certain realm, for tasks such as installing new interfaces.
+Realm Management is an administrator-like API for configuring a Realm. It is
+mainly used to manage Interfaces and Triggers. It serves a [REST
+API](priv/static/astarte_realm_management.yaml) that allows administration
+panels and applications to manage a certain realm, allowing CRUD operations on
+interfaces, triggers and allows device deletion and realm configuration.
+
+## 🔧 Build
+
+to build rm you can follow the usual elixir flow
+
+``` shell
+mix deps.get
+mix compile
+```
+
+to lint rm code and get some insights on pattern matching and typing you can
+run dialyzer.
+
+``` shell
+mix dialyzer
+```
+
+nb: all PRs have to be linter-approved, so running `mix dialyzer` before makeing
+a pull request saves everyone some precious review time!
+
+## 🧑‍🔬 Test
+
+to test rm you need a running instance of rabbitmq and a cassandra-compatible
+database, (we suggest scylla)
+
+``` shell
+docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
+```
+
+by default `CASSANDRA_NODES` environment variable map to `localhost`, so that
+
+``` shell
+mix test
+```
+
+just works. In more complex scenarios you might need to tell to astarte where
+these resources are located.
+
+``` shell
+CASSANDRA_NODES=localhost mix test
+```

--- a/apps/astarte_trigger_engine/README.md
+++ b/apps/astarte_trigger_engine/README.md
@@ -1,6 +1,51 @@
-Astarte Trigger Engine
-======================
+⚡ Trigger Engine (te)
+==============================
+
+Trigger Engine takes care of processing Triggers. It is a purely computational
+component which handles every Trigger's pipeline and triggers actions
+accordingly.
 
 <img src="trigger_engine_astarte_overview.svg" align="center" />
 
-Astarte Trigger Engine process events and executes configured actions, such as POSTing payloads to http, etc...
+## 🔧 Build
+
+to build dup you can follow the usual elixir flow
+
+``` shell
+mix deps.get
+mix compile
+```
+
+to lint dup code and get some insights on pattern matching and typing you can
+run dialyzer.
+
+``` shell
+mix dialyzer
+```
+
+nb: all PRs have to be linter-approved, so running `mix dialyzer` before makeing
+a pull request saves everyone some precious review time!
+
+## 🧑‍🔬 Test
+
+to test dup you need a running instance of rabbitmq and a cassandra-compatible
+database, (we suggest scylla)
+
+``` shell
+docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
+docker run --rm  -d -p 5672:5672 -p 15672:15672 --name rabbit rabbitmq:3.12.0-management
+```
+
+by default `RABBITMQ_HOST` and `CASSANDRA_NODES` environment variables map to
+`localhost`, so that
+
+``` shell
+mix test
+```
+
+just works. In more complex scenarios you might need to tell to astarte where
+these resources are located.
+
+``` shell
+RABBITMQ_HOST=localhost CASSANDRA_NODES=localhost mix test
+```


### PR DESCRIPTION
Adds more first-hand informations on components on how to build them, lint them and test them directly in the REAMDEs.