### PR TITLE
refactor(pairing): expand pairing metrics

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/agent_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/agent_controller.ex
@@ -33,6 +33,8 @@ defmodule Astarte.PairingWeb.AgentController do
   end
 
   def delete(conn, %{"realm_name" => realm, "device_id" => device_id}) do
+    :telemetry.execute([:astarte, :pairing, :unregister_device], %{}, %{realm: realm})
+
     with :ok <- Agent.unregister_device(realm, device_id) do
       conn
       |> resp(:no_content, "")

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/device_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/device_controller.ex
@@ -67,6 +67,8 @@ defmodule Astarte.PairingWeb.DeviceController do
       }) do
     alias AstarteMQTTV1.CredentialsStatus, as: CredentialsStatus
 
+    :telemetry.execute([:astarte, :pairing, :verify_credentials], %{}, %{realm: realm})
+
     with {:ok, secret} <- get_secret(conn),
          {:ok, %CredentialsStatus{} = status} <-
            Credentials.verify_astarte_mqtt_v1(realm, hw_id, secret, params) do

--- a/apps/astarte_pairing/lib/astarte_pairing_web/telemetry.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/telemetry.ex
@@ -119,6 +119,14 @@ defmodule Astarte.PairingWeb.Telemetry do
       counter("astarte.pairing.get_credentials.count",
         tags: [:realm],
         description: "Get credentials requests total count"
+      ),
+      counter("astarte.pairing.verify_credentials.count",
+        tags: [:realm],
+        description: "Get verify credentials requests total count"
+      ),
+      counter("astarte.pairing.unregister_device.count",
+        tags: [:realm],
+        description: "Get unregister device requests total count"
       )
     ]
   end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
- Updated the telemetry event name from [:astarte, :pairing, :api, :request]
to [:astarte, :pairing, :request] to match the defined metric names:
  - astarte.pairing.request.count
  - astarte.pairing.request.request_body_bytes
  - astarte.pairing.request.response_body_bytes
-  Expanded metrics to count number of verify_credentials and
unregister device requests

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
