### PR TITLE
refactor(PA): Update default CFSSL_API_URL in test config to localhost

### DIFF
--- a/apps/astarte_pairing/README.md
+++ b/apps/astarte_pairing/README.md
@@ -36,10 +36,11 @@ docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
 docker run --rn -d --net=host -p 8080/tcp ispirata/docker-alpine-cfssl-autotest:astarte
 ```
 
-by default, `CASSANDRA_NODES` environment variable maps to `localhost`, so that
+
+by default `CASSANDRA_NODES` and `CFSSL_API_URL` environment variables map to localhost, so that
 
 ``` shell
-CFSSL_API_URL=http://localhost:8080 mix test
+mix test
 ```
 
 just works. In more complex scenarios you might need to tell to astarte where

--- a/apps/astarte_pairing/config/test.exs
+++ b/apps/astarte_pairing/config/test.exs
@@ -92,7 +92,7 @@ config :astarte_pairing, :broker_url, "mqtts://broker.beta.astarte.cloud:8883/"
 
 config :astarte_pairing,
        :cfssl_url,
-       System.get_env("CFSSL_API_URL") || "http://ispirata-docker-alpine-cfssl-autotest:8080"
+       System.get_env("CFSSL_API_URL") || "http://localhost:8080"
 
 config :astarte_pairing, :astarte_instance_id, "test"
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Updated `config/test.exs` to set the default `CFSSL_API_URL` to `localhost` when the environment variable is not set. This ensures that tests run without requiring users to manually export the environment variable, preventing confusion for newcomers about invalid test results.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
