### PR TITLE
fix(rm): avoid crash when deleting devices with invalid introspection

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/core.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/core.ex
@@ -20,11 +20,12 @@
 
 defmodule Astarte.RealmManagement.DeviceRemoval.Core do
   @moduledoc """
-  This module contains all the funcitons needed by the `DeviceRemover` Task.
+  This module contains all the functions needed by the `DeviceRemover` Task.
   """
   alias Astarte.Core.CQLUtils
-  alias Astarte.RealmManagement.Queries
   alias Astarte.Core.InterfaceDescriptor
+  alias Astarte.DataAccess.Interface
+  alias Astarte.RealmManagement.Queries
 
   @doc """
   Deletes individual datastreams for a device in a realm.
@@ -100,8 +101,8 @@ defmodule Astarte.RealmManagement.DeviceRemoval.Core do
   end
 
   defp check_interface_has_object_aggregation!(realm_name, {interface_name, interface_major}) do
-    case Queries.retrieve_interface_descriptor!(realm_name, interface_name, interface_major) do
-      %InterfaceDescriptor{aggregation: :object} -> true
+    case Interface.fetch_interface_descriptor(realm_name, interface_name, interface_major) do
+      {:ok, %InterfaceDescriptor{aggregation: :object}} -> true
       _ -> false
     end
   end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -1270,38 +1270,6 @@ defmodule Astarte.RealmManagement.Queries do
     Repo.one(query, opts)
   end
 
-  def retrieve_interface_descriptor!(
-        realm_name,
-        interface_name,
-        interface_major
-      ) do
-    keyspace = Realm.keyspace_name(realm_name)
-
-    opts = [
-      prefix: keyspace,
-      consistency: Consistency.domain_model(:read)
-    ]
-
-    interface =
-      Repo.get_by!(Interface, [name: interface_name, major_version: interface_major], opts)
-
-    %InterfaceDescriptor{
-      name: interface.name,
-      major_version: interface.major_version,
-      minor_version: interface.minor_version,
-      type: interface.type,
-      ownership: interface.ownership,
-      aggregation: interface.aggregation,
-      interface_id: interface.interface_id,
-      automaton: {
-        :erlang.binary_to_term(interface.automaton_transitions),
-        :erlang.binary_to_term(interface.automaton_accepting_states)
-      },
-      storage: interface.storage,
-      storage_type: interface.storage_type
-    }
-  end
-
   def retrieve_individual_datastreams_keys!(realm_name, device_id) do
     keyspace = Realm.keyspace_name(realm_name)
 


### PR DESCRIPTION
previously, devices with invalid introspection would make the device removal process crash because the interface was not found.

by using the existing function from astarte data access, we avoid this crash by simply ignoring interfaces that don't exist

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
