### PR TITLE
refactor(e2e): move realm creation to astarte_e2e

### DIFF
--- a/.github/workflows/astarte-end-to-end-test-workflow.yaml
+++ b/.github/workflows/astarte-end-to-end-test-workflow.yaml
@@ -63,15 +63,11 @@ jobs:
         wget https://github.com/astarte-platform/astartectl/releases/download/v22.11.02/astartectl_22.11.02_linux_x86_64.tar.gz
         tar xf astartectl_22.11.02_linux_x86_64.tar.gz
         chmod +x astartectl
-    - name: Create realm
+    - name: Generate realm keypair and JWT
       run: |
         ./astartectl utils gen-keypair test
-        ./astartectl housekeeping realms create test --astarte-url http://api.astarte.localhost --realm-public-key test_public.pem -k compose/astarte-keys/housekeeping_private.pem -y
-        echo "E2E_REALM=test" >> $GITHUB_ENV
-        sleep 5
-    - name: Ensure Trigger Engine started the consumer
-      # TODO: use a proper way to do this
-      run: sleep 30
+        E2E_HOUSEKEEPING_API_JWT=$(./astartectl utils gen-jwt housekeeping -k compose/astarte-keys/housekeeping_private.pem)
+        echo "E2E_HOUSEKEEPING_API_JWT=$E2E_HOUSEKEEPING_API_JWT" >> $GITHUB_ENV
     - name: Generate JWT
       run: |
         JWT=$(./astartectl utils gen-jwt appengine channels pairing realm-management -k test_private.pem)
@@ -82,6 +78,7 @@ jobs:
         E2E_HOST: "astarte-e2e"
         E2E_PAIRING_URL: http://api.astarte.localhost/pairing
         E2E_APPENGINE_URL: http://api.astarte.localhost/appengine
+        E2E_HOUSEKEEPING_URL: http://api.astarte.localhost/housekeeping
         E2E_REALM_MANAGEMENT_URL: http://api.astarte.localhost/realmmanagement
         E2E_AMQP_CONSUMER_HOST: rabbitmq
         E2E_IGNORE_SSL_ERRORS: true
@@ -89,7 +86,13 @@ jobs:
         E2E_CHECK_REPETITIONS: 5
         E2E_MAILER_TO_ADDRESS: mail@example.com
         E2E_MAIL_SUBJECT: "Subj: Astarte Notification"
-      run: docker run --env-file=<(env | grep '^E2E_') --network astarte --hostname "$E2E_HOST" astarte-e2e
+      run: |
+       docker run \
+        -e E2E_REALM_PUBLIC_KEY_PEM="$(cat ../../test_public.pem)" \
+        --env-file=<(env | grep '^E2E_' | grep -v '^E2E_REALM_PUBLIC_KEY_PEM=') \
+        --network astarte \
+        --hostname "$E2E_HOST" \
+        astarte-e2e
     - name: Check Docker
       if: ${{ failure() }}
       run: docker compose logs

--- a/tools/astarte_e2e/lib/astarte_e2e/application.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/application.ex
@@ -20,15 +20,22 @@ defmodule AstarteE2E.Application do
   use Application
 
   alias AstarteE2E.Config
+  alias AstarteE2E.Realm
   alias AstarteE2E.ServiceNotifier
 
   require Logger
+
+  @trigger_engine_consumer_tracker_cycle_duration :timer.seconds(30)
 
   @impl true
   def start(_type, _args) do
     Logger.info("Starting AstarteE2E application.", tag: "application_start")
 
-    with :ok <- Config.validate() do
+    with :ok <- Config.validate(),
+         :ok <- Realm.create_realm!() do
+      # ensure trigger engine started the consumer for the new realm
+      :timer.sleep(@trigger_engine_consumer_tracker_cycle_duration)
+
       children = [
         {Registry, keys: :unique, name: Registry.AstarteE2E},
         AstarteE2EWeb.Telemetry,

--- a/tools/astarte_e2e/lib/astarte_e2e/config.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/config.ex
@@ -24,6 +24,7 @@ defmodule AstarteE2E.Config do
   alias AstarteE2E.Config.ListOfStrings
   alias AstarteE2E.Config.BambooMailAdapter
   alias AstarteE2E.Config.NormalizedMailAddress
+  alias AstarteE2E.Config.JWTPublicKeyPEMType
 
   @type client_option ::
           {:url, String.t()}
@@ -51,6 +52,12 @@ defmodule AstarteE2E.Config do
     type: :binary,
     required: true
 
+  @envdoc "Astarte Housekeeping URL (e.g. https://api.astarte.example.com/housekeeping)."
+  app_env :housekeeping_url, :astarte_e2e, :housekeeping_url,
+    os_env: "E2E_HOUSEKEEPING_URL",
+    type: :binary,
+    required: true
+
   @envdoc "Ignore SSL errors. Defaults to false. Changing the value to true is not advised for production environments unless you're aware of what you're doing."
   app_env :ignore_ssl_errors, :astarte_e2e, :ignore_ssl_errors,
     os_env: "E2E_IGNORE_SSL_ERRORS",
@@ -73,7 +80,8 @@ defmodule AstarteE2E.Config do
   app_env :realm, :astarte_e2e, :realm,
     os_env: "E2E_REALM",
     type: :binary,
-    required: true
+    default: "test",
+    required: false
 
   @envdoc "The Astarte JWT employed to access Astarte APIs. The token can be generated with: `$ astartectl utils gen-jwt <service> -k <your-private-key>.pem`."
   app_env :jwt, :astarte_e2e, :jwt,
@@ -176,6 +184,18 @@ defmodule AstarteE2E.Config do
   app_env :mail_service, :astarte_e2e, :mail_service,
     os_env: "E2E_MAIL_SERVICE",
     type: BambooMailAdapter
+
+  @envdoc "The JWT public key."
+  app_env :jwt_public_key_pem, :astarte_e2e, :jwt_public_key_pem,
+    os_env: "E2E_REALM_PUBLIC_KEY_PEM",
+    required: true,
+    type: JWTPublicKeyPEMType
+
+  @envdoc "JWT for housekeeping authentication."
+  app_env :housekeeping_jwt, :astarte_e2e, :housekeeping_jwt,
+    os_env: "E2E_HOUSEKEEPING_API_JWT",
+    type: :binary,
+    required: true
 
   @envdoc "Host for the AMQP consumer connection"
   app_env :amqp_consumer_host, :astarte_e2e, :amqp_consumer_host,

--- a/tools/astarte_e2e/lib/astarte_e2e/config/jwt_public_key_pem_type.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/config/jwt_public_key_pem_type.ex
@@ -1,0 +1,48 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule AstarteE2E.Config.JWTPublicKeyPEMType do
+  use Skogsra.Type
+
+  require Logger
+
+  @impl Skogsra.Type
+  @spec cast(String.t()) :: String.t() | :error
+  def cast(value)
+
+  def cast(value) do
+    if String.starts_with?(value, "-----BEGIN PUBLIC KEY-----") do
+      {:ok, value}
+    else
+      # assume the value to be the path in which the key is stored
+      case File.read(value) do
+        {:ok, key} ->
+          {:ok, key}
+
+        {:error, reason} ->
+          Logger.warning("Error while reading file: #{inspect(reason)}.",
+            tag: "file_error_jwt_key"
+          )
+
+          :error
+      end
+    end
+  end
+
+  def cast(_), do: :error
+end

--- a/tools/astarte_e2e/lib/astarte_e2e/realm.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/realm.ex
@@ -1,0 +1,57 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule AstarteE2E.Realm do
+  require Logger
+
+  alias AstarteE2E.Config
+
+  def create_realm!() do
+    base_url = Config.housekeeping_url!()
+    astarte_jwt = Config.housekeeping_jwt!()
+    {:ok, realm} = Config.realm()
+    jwt_public_key_pem = Config.jwt_public_key_pem!()
+
+    url = Path.join([base_url, "v1", "realms"]) <> "?async_operation=false"
+
+    body =
+      %{
+        data: %{
+          realm_name: realm,
+          jwt_public_key_pem: jwt_public_key_pem
+        }
+      }
+      |> Jason.encode!()
+
+    headers = [
+      {"Content-Type", "application/json"},
+      {"Authorization", "Bearer #{astarte_jwt}"}
+    ]
+
+    case HTTPoison.post(url, body, headers) do
+      {:ok, %HTTPoison.Response{status_code: 201}} ->
+        :ok
+
+      {:ok, %HTTPoison.Response{status_code: code, body: body}} ->
+        raise "Failed to create realm: #{code} #{body}"
+
+      {:error, %HTTPoison.Error{} = error} ->
+        raise "HTTP error while creating realm: #{inspect(error)}"
+    end
+  end
+end

--- a/tools/astarte_e2e/lib/astarte_e2e/task_scheduler.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/task_scheduler.ex
@@ -35,6 +35,7 @@ defmodule AstarteE2E.TaskScheduler do
   @impl GenServer
   def init(_init_arg) do
     Process.flag(:trap_exit, true)
+
     interfaces = Interface.generate_interfaces!()
     :ok = Interface.install_interfaces!(interfaces)
 


### PR DESCRIPTION
Create Realm directly in astarte_e2e instead of a separate CI step.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

Create realm inside astarte_e2e tool, instead of CI.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

