### PR TITLE
fix(rm): ensure devices are cleaned up after being deleted

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/device_remover.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/device_remover.ex
@@ -28,9 +28,18 @@ defmodule Astarte.RealmManagement.DeviceRemoval.DeviceRemover do
   require Logger
   alias Astarte.Core.Device
   alias Astarte.RealmManagement.DeviceRemoval.Core
+  alias Astarte.RealmManagement.Queries
 
   @spec run(%{:device_id => <<_::128>>, :realm_name => binary()}) :: :ok | no_return()
-  def run(%{realm_name: realm_name, device_id: device_id}) do
+  def run(%{realm_name: realm_name, device_id: device_id} = args) do
+    case Queries.check_device_exists(realm_name, device_id) do
+      true -> do_run(args)
+      false -> cleanup(args)
+    end
+  end
+
+  @spec do_run(%{:device_id => <<_::128>>, :realm_name => binary()}) :: :ok | no_return()
+  defp do_run(%{realm_name: realm_name, device_id: device_id}) do
     encoded_device_id = Device.encode_device_id(device_id)
     _ = Logger.info("Starting to remove device #{encoded_device_id}", tag: "device_delete_start")
 
@@ -44,5 +53,13 @@ defmodule Astarte.RealmManagement.DeviceRemoval.DeviceRemover do
 
     _ = Logger.info("Successfully removed device #{encoded_device_id}", tag: "device_delete_ok")
     :ok
+  end
+
+  @spec cleanup(%{:device_id => <<_::128>>, :realm_name => binary()}) :: :ok
+  defp cleanup(%{realm_name: realm_name, device_id: device_id}) do
+    # As the device is guaranteed to be deleted at least once, it may happen that a crash happened
+    # between the device cancellation and the deletion in progress entry cancellation.
+    # If we're here, we just need to delete the deletion in progress entry
+    Queries.remove_device_from_deletion_in_progress!(realm_name, device_id)
   end
 end

--- a/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/queries.ex
@@ -1295,7 +1295,6 @@ defmodule Astarte.RealmManagement.Queries do
         endpoint_id,
         path
       ) do
-    # TODO: validate realm name
     keyspace_name = Realm.keyspace_name(realm_name)
 
     query =
@@ -1336,7 +1335,6 @@ defmodule Astarte.RealmManagement.Queries do
   end
 
   def delete_individual_properties_values!(realm_name, device_id, interface_id) do
-    # TODO: validate realm name
     keyspace_name = Realm.keyspace_name(realm_name)
 
     query =
@@ -1372,7 +1370,6 @@ defmodule Astarte.RealmManagement.Queries do
   end
 
   def delete_object_datastream_values!(realm_name, device_id, path, table_name) do
-    # TODO: validate realm name
     keyspace_name = Realm.keyspace_name(realm_name)
 
     query =
@@ -1407,7 +1404,6 @@ defmodule Astarte.RealmManagement.Queries do
   end
 
   def delete_alias_values!(realm_name, device_alias) do
-    # TODO: validate realm name
     keyspace_name = Realm.keyspace_name(realm_name)
 
     query =
@@ -1476,7 +1472,6 @@ defmodule Astarte.RealmManagement.Queries do
   end
 
   def delete_kv_store_entry!(realm_name, group, key) do
-    # TODO: validate realm name
     keyspace_name = Realm.keyspace_name(realm_name)
 
     query =
@@ -1494,7 +1489,6 @@ defmodule Astarte.RealmManagement.Queries do
   end
 
   def delete_device!(realm_name, device_id) do
-    # TODO: validate realm name
     keyspace_name = Realm.keyspace_name(realm_name)
 
     query =
@@ -1513,7 +1507,6 @@ defmodule Astarte.RealmManagement.Queries do
   end
 
   def remove_device_from_deletion_in_progress!(realm_name, device_id) do
-    # TODO: validate realm name
     keyspace_name = Realm.keyspace_name(realm_name)
 
     query =


### PR DESCRIPTION
As the device is guaranteed to be deleted at least once, it may happen
that a crash happened between the device cancellation and the deletion
in progress entry cancellation.

Account for this possibility and let the process terminate successfully
after a cleanup