### PR TITLE
feat(dup): separate amqp trigger exchanges in their own vhost

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_triggers_producer.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/amqp_triggers_producer.ex
@@ -1,0 +1,150 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.AMQPTriggersProducer do
+  @moduledoc """
+    AMQP producer for Astarte triggers.
+
+    This module is responsible for publishing messages related to triggers
+    to the AMQP broker. It uses a GenServer to manage the connection and
+    publishing logic.
+  """
+
+  require Logger
+  use GenServer
+
+  alias AMQP.Channel
+  alias Astarte.DataUpdaterPlant.Config
+
+  @connection_backoff 10000
+  @adapter Config.amqp_adapter!()
+
+  # Publisc API
+
+  @doc """
+    Starts the AMQP triggers producer GenServer.
+    It initializes the connection to the AMQP broker and prepares it for publishing messages.
+    The `args` parameter can be used to pass additional configuration options if needed.
+  """
+  def start_link(args \\ []) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  @doc """
+    Publishes a message to the specified exchange with the given routing key and payload.
+    The `opts` parameter can be used to specify additional options for the message.
+    It uses a longer timeout to allow RabbitMQ to process requests even if loaded.
+
+    ## Parameters
+    - `exchange`: The name of the exchange to publish the message to.
+    - `routing_key`: The routing key to use for the message.
+    - `payload`: The message payload to be sent.
+    - `opts`: Additional options for the message, such as headers or delivery mode. These will be passed to the AMQP adapter.
+  """
+  def publish(exchange, routing_key, payload, opts) do
+    # Use a longer timeout to allow RabbitMQ to process requests even if loaded
+    GenServer.call(__MODULE__, {:publish, exchange, routing_key, payload, opts}, 60_000)
+  end
+
+  @doc """
+    Declares an exchange in RabbitMQ.
+    This is necessary to ensure that the exchange exists before publishing messages to it.
+    The exchange is declared as durable and of type `:direct`.
+
+    ## Parameters
+    - `exchange`: The name of the exchange to declare.
+
+    This function uses a longer timeout to allow RabbitMQ to process requests even if loaded.
+  """
+  def declare_exchange(exchange) do
+    # Use a longer timeout to allow RabbitMQ to process requests even if loaded
+    GenServer.call(__MODULE__, {:declare_exchange, exchange}, 60_000)
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    with {:error, reason} <- init_producer() do
+      {:stop, reason}
+    end
+  end
+
+  @impl GenServer
+  def handle_call({:publish, exchange, routing_key, payload, opts}, _from, chan) do
+    reply = @adapter.publish(chan, exchange, routing_key, payload, opts)
+
+    {:reply, reply, chan}
+  end
+
+  @impl GenServer
+  def handle_call({:declare_exchange, exchange}, _from, chan) do
+    # TODO: we need to decide who is responsible of deleting the exchange once it is
+    # no longer needed
+    reply = @adapter.declare_exchange(chan, exchange, type: :direct, durable: true)
+
+    {:reply, reply, chan}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _, :process, _pid, reason}, _channel) do
+    Logger.warning("RabbitMQ connection lost: #{inspect(reason)}. Trying to reconnect...",
+      tag: "events_producer_conn_lost"
+    )
+
+    case init_producer() do
+      {:ok, channel} ->
+        {:noreply, channel}
+
+      {:error, _reason} ->
+        schedule_connect()
+        {:noreply, :not_connected}
+    end
+  end
+
+  defp init_producer() do
+    conn = ExRabbitPool.get_connection_worker(:triggers_producer_pool)
+
+    with {:ok, channel} <- checkout_channel(conn) do
+      %Channel{pid: channel_pid} = channel
+      Process.monitor(channel_pid)
+
+      Logger.debug("AMQPEventsProducer initialized",
+        tag: "event_producer_init_ok"
+      )
+
+      {:ok, channel}
+    end
+  end
+
+  defp checkout_channel(conn) do
+    with {:error, reason} <- ExRabbitPool.checkout_channel(conn) do
+      Logger.warning(
+        "Failed to check out channel for producer: #{inspect(reason)}",
+        tag: "event_producer_channel_checkout_fail"
+      )
+
+      {:error, :event_producer_channel_checkout_fail}
+    end
+  end
+
+  defp schedule_connect() do
+    Logger.warning("Retrying connection in #{@connection_backoff} ms")
+    Process.send_after(self(), :init, @connection_backoff)
+  end
+end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/producers_supervisor.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/producers_supervisor.ex
@@ -27,6 +27,7 @@ defmodule Astarte.DataUpdaterPlant.ProducersSupervisor do
   require Logger
 
   alias Astarte.DataUpdaterPlant.AMQPEventsProducer
+  alias Astarte.DataUpdaterPlant.AMQPTriggersProducer
   alias Astarte.DataUpdaterPlant.Config
 
   def start_link(init_arg) do
@@ -37,12 +38,23 @@ defmodule Astarte.DataUpdaterPlant.ProducersSupervisor do
   def init(_init_arg) do
     Logger.info("AMQPDataProducer supervisor init.", tag: "data_producer_sup_init")
 
-    children = [
-      {ExRabbitPool.PoolSupervisor,
-       rabbitmq_config: Config.amqp_producer_options!(),
-       connection_pools: [Config.events_producer_pool_config!()]},
-      AMQPEventsProducer
-    ]
+    events_pool =
+      Supervisor.child_spec(
+        {ExRabbitPool.PoolSupervisor,
+         rabbitmq_config: Config.amqp_producer_options!(),
+         connection_pools: [Config.events_producer_pool_config!()]},
+        id: :events_producer_pool
+      )
+
+    triggers_pool =
+      Supervisor.child_spec(
+        {ExRabbitPool.PoolSupervisor,
+         rabbitmq_config: Config.amqp_triggers_producer_options!(),
+         connection_pools: [Config.triggers_producer_pool_config!()]},
+        id: :triggers_producer_pool
+      )
+
+    children = [events_pool, triggers_pool, AMQPEventsProducer, AMQPTriggersProducer]
 
     Supervisor.init(children, strategy: :rest_for_one)
   end


### PR DESCRIPTION
Previously `AMQP` triggers published on exchanges in the same vhost as all other astarte exchanges. This was no bliss but only a curse, as we relied on complex regexp for permission management in rabbitmq to allow clients access only to their exchanges. This PR sets the ground to solve this devops issue by moving amqp exchanges into their own vhost (if astarte is configured to do so, defaulting to the current behavior).

## `AMQPTriggersProducer`
The `ProducersSupervisor` initializes two pools of rabbitmq connections trough `ExRabbitPool`: one for the astarte internals and one for amqp triggers. The connection pool for triggers is configured to use the vhost provided by astarte trough environment variables

## Publish dispatch logic
in trigger handler if the target exchange is nil (which only happens for `astarte_event`s) the publication happens on astarte internal exhanges, otherwise the `AMQPTriggersProducer` is used, publishing in the correct exchange