### PR TITLE
fix(dup): crash when performing updates of deleted values

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -555,10 +555,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     opts = [
       prefix: keyspace_name,
       consistency: Consistency.device_info(:write),
-      allow_insert: false
+      allow_insert: false,
+      allow_stale: true
     ]
 
     Repo.update!(changeset, opts)
+
+    :ok
   end
 
   def fetch_device_introspection_minors(realm, device_id) do
@@ -865,7 +868,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
     opts = [
       prefix: keyspace_name,
       consistency: Consistency.device_info(:write),
-      allow_insert: false
+      allow_insert: false,
+      allow_stale: true
     ]
 
     with {:ok, _} <- Repo.safe_update(deletion_in_progress, opts) do

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/queries_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/queries_test.exs
@@ -446,6 +446,17 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.QueriesTest do
     end
   end
 
+  describe "ack_start_device_deletion/2" do
+    @tag :regression
+    test "does not do anything when the deletion in progress entry does not exist", context do
+      %{realm_name: realm_name} = context
+      device_id = DeviceGenerator.id() |> Enum.at(0)
+
+      assert :ok = Queries.ack_start_device_deletion(realm_name, device_id)
+      assert {:ok, false} = Queries.check_device_deletion_in_progress(realm_name, device_id)
+    end
+  end
+
   defp populate_deletion_in_progress(realm_name) do
     keyspace = Realm.keyspace_name(realm_name)
 

--- a/apps/astarte_realm_management/test/test_helper.exs
+++ b/apps/astarte_realm_management/test/test_helper.exs
@@ -18,6 +18,7 @@
 
 Mimic.copy(Astarte.DataAccess.Config)
 Mimic.copy(Astarte.RealmManagement.DeviceRemoval.Core)
+Mimic.copy(Astarte.RealmManagement.Queries)
 Mimic.copy(Task.Supervisor)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
previously, updates were changed from upserts to normal updates to
avoid re-inserting previously deleted values. This introduced a bug
because Ecto would complain about stale values if the update did not
modify the struct in the database. fix this by setting the appropriate
flag (`allow_stale`)

regression tests for previous fixes have been added to prevent this
from happening again

the update functions now return `:ok`. this does not change the usage
of the functions as the return value was just discarded, but returning
the deletion in progress entry when the value did not exist in the
database is incorrect