### PR TITLE
deat(dup): support xandra telemetry bounce

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -341,6 +341,16 @@ defmodule Astarte.DataUpdaterPlant.Config do
           os_env: "DATA_UPDATER_PLANT_AMQP_TRIGGERS_PRODUCER_SSL_CUSTOM_SNI",
           type: :binary
 
+  @envdoc """
+  "The handling method for database events. The default is `expose`, which means that the events are exposed trough telemetry. The other possible value, `log`, means that the events are logged instead."
+  """
+  app_env :database_events_handling_method,
+          :astarte_data_updater_plant,
+          :database_events_handling_method,
+          os_env: "DATABASE_EVENTS_HANDLING_METHOD",
+          type: Astarte.DataUpdaterPlant.Config.TelemetryType,
+          default: :expose
+
   # Since we have one channel per queue, this is not configurable
   def amqp_consumer_channels_per_connection_number!() do
     ceil(data_queue_total_count!() / amqp_consumer_connection_number!())

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config/telemetry_type.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config/telemetry_type.ex
@@ -1,0 +1,42 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.Config.TelemetryType do
+  @moduledoc """
+  The telemetry type that the node should use to report metrics.
+  """
+
+  use Skogsra.Type
+
+  @allowed_strategies ~w(expose log)
+
+  @impl Skogsra.Type
+  def cast(value) when value in @allowed_strategies do
+    case value do
+      "expose" -> {:ok, :expose}
+      "log" -> {:ok, :log}
+    end
+  end
+
+  @impl Skogsra.Type
+  def cast(_) do
+    :error
+  end
+end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant_web/telemetry.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant_web/telemetry.ex
@@ -19,6 +19,8 @@
 defmodule Astarte.DataUpdaterPlantWeb.Telemetry do
   use Supervisor
   import Telemetry.Metrics
+
+  alias Astarte.DataUpdaterPlantWeb.Telemetry.DatabaseEvents
   alias Astarte.DataUpdaterPlant.Config
 
   def start_link(arg) do
@@ -26,7 +28,10 @@ defmodule Astarte.DataUpdaterPlantWeb.Telemetry do
   end
 
   def init(_arg) do
+    attach_handlers()
+
     children = [
+      {Task.Supervisor, name: Astarte.DataUpdaterPlantWeb.TelemetryTaskSupervisor},
       {:telemetry_poller, measurements: periodic_measurements(), period: 10_000},
       {TelemetryMetricsPrometheus.Core, metrics: metrics()},
       {Plug.Cowboy,
@@ -175,8 +180,55 @@ defmodule Astarte.DataUpdaterPlantWeb.Telemetry do
       counter("astarte.data_updater_plant.amqp_events_producer.channel_crash.count",
         tags: [:reason],
         description: "AMQP events producer channel crashes by reason"
+      ),
+
+      # Database exception metrics
+      counter("astarte.data_updater_plant.database.execute_query.exception.count",
+        tags: [:query, :reason, :kind, :stacktrace],
+        tag_values: &to_valid_values/1,
+        unit: {:native, :second}
+      ),
+      counter("astarte.data_updater_plant.database.execute_query.stop.count",
+        tags: [:query, :reason],
+        tag_values: &to_valid_values/1,
+        unit: {:native, :second}
+      ),
+
+      # Database preparation metrics
+      counter("astarte.data_updater_plant.database.prepare_query.exception.count",
+        tags: [:query, :reason, :kind, :stacktrace],
+        tag_values: &to_valid_values/1,
+        unit: {:native, :second}
+      ),
+      counter("astarte.data_updater_plant.database.prepare_query.stop.count",
+        tags: [:query, :reason],
+        tag_values: &to_valid_values/1,
+        unit: {:native, :second}
+      ),
+
+      # Database connection metrics
+      counter(
+        "astarte.data_updater_plant.database.cluster.control_connection.failed_to_connect.count",
+        tag_values: &to_valid_values/1,
+        tags: [:cluster_name, :host, :reason]
+      ),
+      counter("astarte.data_updater_plant.database.failed_to_connect.conut",
+        tag_values: &to_valid_values/1,
+        tags: [:connection_name, :address, :port]
       )
     ]
+  end
+
+  defp to_valid_values(%{query: query, reason: reason}) do
+    %{query: query.statement, reason: Xandra.Error.message(reason)}
+  end
+
+  defp to_valid_values(%{cluster_name: cluster_name, host: host, reason: reason}) do
+    %{cluster_name: cluster_name, host: inspect(host), reason: to_string(reason)}
+  end
+
+  defp to_valid_values(%{connection_name: connection_name, address: address, port: port}) do
+    %{connection_name: connection_name, address: inspect(address), port: inspect(port)}
   end
 
   defp periodic_measurements do
@@ -184,6 +236,38 @@ defmodule Astarte.DataUpdaterPlantWeb.Telemetry do
       # A module, function and arguments to be invoked periodically.
       # This function must call :telemetry.execute/3 and a metric must be added above.
       # {MyApp, :count_users, []}
+    ]
+  end
+
+  defp attach_handlers do
+    :telemetry.attach_many(
+      DatabaseEvents,
+      xandra_events(),
+      &DatabaseEvents.handle_event/4,
+      Config.database_events_handling_method!()
+    )
+  end
+
+  defp xandra_events do
+    [
+      [:xandra, :connected],
+      [:xandra, :disconnected],
+      [:xandra, :failed_to_connect],
+      [:xandra, :prepared_cache, :hit],
+      [:xandra, :prepared_cache, :miss],
+      [:xandra, :prepare_query, :stop],
+      [:xandra, :execute_query, :stop],
+      [:xandra, :client_timeout],
+      [:xandra, :timed_out_response],
+      [:xandra, :server_warnings],
+      [:xandra, :cluster, :change_event],
+      [:xandra, :cluster, :control_connection, :connected],
+      [:xandra, :cluster, :control_connection, :disconnected],
+      [:xandra, :cluster, :control_connection, :failed_to_connect],
+      [:xandra, :cluster, :pool, :started],
+      [:xandra, :cluster, :pool, :restarted],
+      [:xandra, :cluster, :pool, :stopped],
+      [:xandra, :cluster, :discovered_peers]
     ]
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant_web/telemetry/database_events.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant_web/telemetry/database_events.ex
@@ -1,0 +1,85 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlantWeb.Telemetry.DatabaseEvents do
+  @moduledoc """
+    Telemetry handler for database events.
+
+    This module listens to database events and emits telemetry events
+    with the relevant measurements and metadata.
+  """
+
+  @bounce_events [
+    [:prepare_query, :stop],
+    [:prepare_query, :exception],
+    [:execute, :stop],
+    [:execute, :exception],
+    [:cluster, :control_connection, :failed_to_connect],
+    [:failed_to_connect]
+  ]
+
+  require Logger
+  alias Astarte.DataUpdaterPlantWeb.TelemetryTaskSupervisor
+
+  @doc """
+  Handles telemetry events related to database operations.
+
+  See the documentation of Xandra for more details on the events:
+  https://hexdocs.pm/xandra/telemetry-events.html
+
+  This handler drops the `:xandra` prefix from the event name and
+  executes the telemetry event with the provided measurements and metadata.
+  """
+  def handle_event([:xandra | event], measurements, metadata, :expose) do
+    with :bounce <- validate_event(event) do
+      Task.Supervisor.start_child(TelemetryTaskSupervisor, fn ->
+        with :ok <- filter_event(event, metadata) do
+          :telemetry.execute(
+            [:astarte, :data_updater_plant, :database] ++ event,
+            measurements,
+            metadata
+          )
+        end
+      end)
+    end
+  end
+
+  def handle_event(event, measurements, metadata, :log) do
+    Xandra.Telemetry.handle_event(event, measurements, metadata, :no_config)
+  end
+
+  defp validate_event(event) do
+    case event in @bounce_events do
+      true -> :bounce
+      false -> :ok
+    end
+  end
+
+  defp filter_event([:execute_query, _], metadata), do: has_reason(metadata)
+  defp filter_event([:prepare_query, _], metadata), do: has_reason(metadata)
+  defp filter_event(_event, _metadata), do: :ok
+
+  defp has_reason(metadata) do
+    case Map.has_key?(metadata, :reason) do
+      true -> :ok
+      false -> :do_not_bounce
+    end
+  end
+end


### PR DESCRIPTION
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests

#### What this PR does / why we need it:

Bounces xandra telemetry events, adding visibility on database errors and exceptions.

##### Does this PR introduce a user-facing change?
* [x] Yes
* [ ] No
