### PR TITLE
ci: fix astarte image caching

### DIFF
--- a/.github/workflows/astarte-build-workflow.yaml
+++ b/.github/workflows/astarte-build-workflow.yaml
@@ -18,3 +18,20 @@ jobs:
         set: |
             *.cache-from=type=gha
             *.cache-to=type=gha,mode=max
+            astarte-housekeeping.output=type=docker,dest=${{ runner.temp }}/astarte-housekeeping.tar
+            astarte-realm-management.output=type=docker,dest=${{ runner.temp }}/astarte-realm-management.tar
+            astarte-pairing.output=type=docker,dest=${{ runner.temp }}/astarte-pairing.tar
+            astarte-appengine-api.output=type=docker,dest=${{ runner.temp }}/astarte-appengine-api.tar
+            astarte-data-updater-plant.output=type=docker,dest=${{ runner.temp }}/astarte-data-updater-plant.tar
+            astarte-trigger-engine.output=type=docker,dest=${{ runner.temp }}/astarte-trigger-engine.tar
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: astarte-images
+        path: |
+          ${{ runner.temp }}/astarte-housekeeping.tar
+          ${{ runner.temp }}/astarte-realm-management.tar
+          ${{ runner.temp }}/astarte-pairing.tar
+          ${{ runner.temp }}/astarte-appengine-api.tar
+          ${{ runner.temp }}/astarte-data-updater-plant.tar
+          ${{ runner.temp }}/astarte-trigger-engine.tar

--- a/.github/workflows/astarte-end-to-end-test-workflow.yaml
+++ b/.github/workflows/astarte-end-to-end-test-workflow.yaml
@@ -43,6 +43,13 @@ jobs:
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}
+    - name: Restore astarte images
+      uses: actions/download-artifact@v4
+      with:
+        name: astarte-images
+        path: ${{ runner.temp }}
+    - name: Load astarte images
+      run: ls ${{ runner.temp }}/*.tar | xargs --max-args 1 docker load --input
     - name: Start all Astarte services
       run: docker compose up -d
     - name: Wait for Astarte to come up


### PR DESCRIPTION
docker cache is not shared between jobs, the documentation suggests using artifact upload/download to share build images

https://docs.docker.com/build/ci/github-actions/share-image-jobs/

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
