### PR TITLE
refactor(housekeeping)!: use default replication naming from scylladb

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/config.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/config.ex
@@ -57,7 +57,7 @@ defmodule Astarte.Housekeeping.Config do
           :astarte_keyspace_replication_strategy,
           os_env: "HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_STRATEGY",
           type: Astarte.Housekeeping.Config.ReplicationStrategy,
-          default: :simple
+          default: :simple_strategy
 
   @envdoc "Replication factor for the astarte keyspace, used when simple strategy is used for the astarte keyspace. defaults to 1"
   app_env :astarte_keyspace_replication_factor,
@@ -114,8 +114,8 @@ defmodule Astarte.Housekeeping.Config do
   """
   def validate_astarte_replication! do
     case astarte_keyspace_replication_strategy!() do
-      :simple -> validate_astarte_replication_factor!()
-      :network -> validate_astarte_replication_map!()
+      :simple_strategy -> validate_astarte_replication_factor!()
+      :network_topology_strategy -> validate_astarte_replication_map!()
       nil -> raise "Invalid replication strategy set for the astarte keyspace"
     end
   end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/config/replication_strategy_type.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/config/replication_strategy_type.ex
@@ -24,15 +24,9 @@ defmodule Astarte.Housekeeping.Config.ReplicationStrategy do
   """
   use Skogsra.Type
 
-  @allowed_modes ~w(simple network)
-
   @impl Skogsra.Type
-  def cast(value) when value in @allowed_modes do
-    case value do
-      "simple" -> {:ok, :simple}
-      "network" -> {:ok, :network}
-    end
-  end
+  def cast("SimpleStrategy"), do: {:ok, :simple_strategy}
+  def cast("NetworkTopologyStrategy"), do: {:ok, :network_topology_strategy}
 
   @impl Skogsra.Type
   def cast(_) do

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -1038,8 +1038,8 @@ defmodule Astarte.Housekeeping.Realms.Queries do
 
     replication =
       case Config.astarte_keyspace_replication_strategy!() do
-        :simple -> Config.astarte_keyspace_replication_factor!()
-        :network -> Config.astarte_keyspace_network_replication_map!()
+        :simple_strategy -> Config.astarte_keyspace_replication_factor!()
+        :network_topology_strategy -> Config.astarte_keyspace_network_replication_map!()
       end
 
     with {:ok, replication_map_str} <- build_replication_map_str(replication),


### PR DESCRIPTION
replace custom "simple" and "network" names with "SimpleStrategy" and "NetworkTopologyStrategy"

this also aligns the naming with realm creation

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
