### PR TITLE
chore(housekeeping): ensure correct return type for async operations

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -208,7 +208,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
             )
           end)
 
-        :ok
+        {:ok, :started}
       else
         do_create_realm(
           realm_name,

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
@@ -163,8 +163,8 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
     end
 
     test "async creations returns ok", %{realm_name: realm_name} do
-      assert :ok = Queries.create_realm(realm_name, "test1publickey", 1, 1, 1, async: true)
-      Process.sleep(1000)
+      assert {:ok, :started} =
+               Queries.create_realm(realm_name, "test1publickey", 1, 1, 1, async: true)
     end
 
     test "creations returns an error", %{realm_name: realm_name} do


### PR DESCRIPTION
async queries should return `{:ok, :started}`. This is correctly handled
in the code, except it's not being returned by the `create_realm`
function

return the correct value, and remove a random 1-second sleep from the
tests