### PR TITLE
refactor(e2e): don't start volatile trigger client with the device

### DIFF
--- a/tools/astarte_e2e/lib/astarte_e2e/data_trigger.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/data_trigger.ex
@@ -67,9 +67,7 @@ defmodule AstarteE2E.DataTrigger do
       properties_interface: properties_interface
     ]
 
-    with {:ok, device_supervisor_pid} <- Device.start_link(opts),
-         device_pid = Device.astarte_device_pid(device_supervisor_pid),
-         :ok <- Astarte.Device.wait_for_connection(device_pid),
+    with {:ok, device_pid} <- Device.start_link(opts),
          :ok <- install_data_trigger(opts) do
       state = %{
         realm: realm,

--- a/tools/astarte_e2e/lib/astarte_e2e/device_deletion.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/device_deletion.ex
@@ -19,7 +19,7 @@ defmodule AstarteE2E.DeviceDeletion do
 
       {:ok, device_pid} = Device.start_link(device_opts)
 
-      Process.exit(device_pid, :normal)
+      Process.exit(device_pid, :shutdown)
 
       state = %{device_id: device_id, realm: realm, device_pid: device_pid}
 

--- a/tools/astarte_e2e/lib/astarte_e2e/volatile_trigger_roundtrip/executor.ex
+++ b/tools/astarte_e2e/lib/astarte_e2e/volatile_trigger_roundtrip/executor.ex
@@ -19,6 +19,7 @@
 defmodule AstarteE2E.VolatileTriggerRoundtrip.Executor do
   use GenServer
 
+  alias AstarteE2E.Client
   alias AstarteE2E.Config
   alias AstarteE2E.Device
   alias AstarteE2E.VolatileTriggerRoundtrip.Scheduler
@@ -47,10 +48,17 @@ defmodule AstarteE2E.VolatileTriggerRoundtrip.Executor do
         |> Keyword.put(:device_id, encoded_id)
         |> Keyword.put(:interfaces, interfaces)
 
+      client_opts =
+        Config.client_opts()
+        |> Keyword.put(:device_id, encoded_id)
+
       {:ok, device} = Device.start_link(device_opts)
+      {:ok, client} = Client.start_link(client_opts)
+      Client.wait_for_connection(realm, encoded_id)
+
       {:ok, scheduler} = Scheduler.start_link(scheduler_opts)
 
-      {:ok, %{device: device, scheduler: scheduler}}
+      {:ok, %{device: device, scheduler: scheduler, client: client}}
     else
       error -> {:stop, error, nil}
     end


### PR DESCRIPTION
treat the device module as a wrapper around the sdk's device module

always wait for connection before proceeding. solves an issue with volatile triggers trying to be installed while the device is not yet connected

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
