### PR TITLE
chore!: remove stacktrace from telemetry events

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/telemetry.ex
@@ -150,7 +150,7 @@ defmodule Astarte.AppEngine.APIWeb.Telemetry do
 
       # Database exception metrics
       counter("astarte.appengine.database.execute_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),
@@ -162,7 +162,7 @@ defmodule Astarte.AppEngine.APIWeb.Telemetry do
 
       # Database preparation metrics
       counter("astarte.appengine.database.prepare_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant_web/telemetry.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant_web/telemetry.ex
@@ -184,7 +184,7 @@ defmodule Astarte.DataUpdaterPlantWeb.Telemetry do
 
       # Database exception metrics
       counter("astarte.data_updater_plant.database.execute_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),
@@ -196,7 +196,7 @@ defmodule Astarte.DataUpdaterPlantWeb.Telemetry do
 
       # Database preparation metrics
       counter("astarte.data_updater_plant.database.prepare_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping_web/telemetry.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping_web/telemetry.ex
@@ -112,7 +112,7 @@ defmodule Astarte.HousekeepingWeb.Telemetry do
 
       # Database exception metrics
       counter("astarte.housekeeping.database.execute_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),
@@ -124,7 +124,7 @@ defmodule Astarte.HousekeepingWeb.Telemetry do
 
       # Database preparation metrics
       counter("astarte.housekeeping.database.prepare_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),

--- a/apps/astarte_pairing/lib/astarte_pairing_web/telemetry.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/telemetry.ex
@@ -135,7 +135,7 @@ defmodule Astarte.PairingWeb.Telemetry do
 
       # Database exception metrics
       counter("astarte.pairing.database.execute_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),
@@ -147,7 +147,7 @@ defmodule Astarte.PairingWeb.Telemetry do
 
       # Database preparation metrics
       counter("astarte.pairing.database.prepare_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),

--- a/apps/astarte_realm_management/lib/astarte_realm_management_web/telemetry.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management_web/telemetry.ex
@@ -117,7 +117,7 @@ defmodule Astarte.RealmManagementWeb.Telemetry do
 
       # Database exception metrics
       counter("astarte.realm_management.database.execute_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),
@@ -129,7 +129,7 @@ defmodule Astarte.RealmManagementWeb.Telemetry do
 
       # Database preparation metrics
       counter("astarte.realm_management.database.prepare_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),

--- a/apps/astarte_trigger_engine/lib/astarte_trigger_engine_web/telemetry.ex
+++ b/apps/astarte_trigger_engine/lib/astarte_trigger_engine_web/telemetry.ex
@@ -86,7 +86,7 @@ defmodule Astarte.TriggerEngineWeb.Telemetry do
 
       # Database exception metrics
       counter("astarte.trigger_engine.database.execute_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),
@@ -98,7 +98,7 @@ defmodule Astarte.TriggerEngineWeb.Telemetry do
 
       # Database preparation metrics
       counter("astarte.trigger_engine.database.prepare_query.exception.count",
-        tags: [:query, :reason, :kind, :stacktrace],
+        tags: [:query, :reason, :kind],
         tag_values: &to_valid_values/1,
         unit: {:native, :second}
       ),


### PR DESCRIPTION
remove stacktrace from telemetry events in order to reduce the cardinality of prometheus telemetries

they may be re-introduced at a later time if we find they would be helpful when debugging issues
