### PR TITLE
test(rm): fix DeviceRemover tests to work regardless of order

### DIFF
--- a/apps/astarte_realm_management/test/astarte_realm_management/device_removal/core_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/device_removal/core_test.exs
@@ -24,7 +24,6 @@ defmodule Astarte.RealmManagement.DeviceRemover.CoreTest do
   alias Astarte.DataAccess.Devices.Device
   alias Astarte.Core.CQLUtils
   alias Astarte.RealmManagement.Engine
-  alias Astarte.RealmManagement.Migrations.CreateDatastreamIndividualMultiInterface
   alias Astarte.RealmManagement.Queries
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.DataAccess.Repo
@@ -35,17 +34,16 @@ defmodule Astarte.RealmManagement.DeviceRemover.CoreTest do
 
   import ExUnit.CaptureLog
 
+  setup %{realm: realm} do
+    setup!(realm)
+  end
+
   describe "Device remover Core" do
     @describetag :device_remover
 
     property "delete_individual_datastream/2 removes individual datastream data of a valid device",
              %{realm: realm} do
       keyspace = Realm.keyspace_name(realm)
-
-      Ecto.Migrator.run(Repo, [{0, CreateDatastreamIndividualMultiInterface}], :up,
-        prefix: keyspace,
-        all: true
-      )
 
       check all(
               device_id <- Astarte.Core.Generators.Device.id(),
@@ -68,11 +66,6 @@ defmodule Astarte.RealmManagement.DeviceRemover.CoreTest do
     property "delete_individual_datastream/2 does not crash when individual datastream table is missing",
              %{realm: realm} do
       keyspace = Realm.keyspace_name(realm)
-
-      Ecto.Migrator.run(Repo, [{0, CreateDatastreamIndividualMultiInterface}], :up,
-        prefix: keyspace,
-        all: true
-      )
 
       Repo.query!("DROP TABLE #{keyspace}.individual_datastreams;")
 

--- a/apps/astarte_realm_management/test/support/helpers/database.ex
+++ b/apps/astarte_realm_management/test/support/helpers/database.ex
@@ -23,18 +23,18 @@ defmodule Astarte.Test.Helpers.Database do
   alias Astarte.DataAccess.Realms.Realm
 
   @create_keyspace """
-  CREATE KEYSPACE :keyspace
+  CREATE KEYSPACE IF NOT EXISTS :keyspace
     WITH
       replication = {'class': 'SimpleStrategy', 'replication_factor': '1'} AND
       durable_writes = true;
   """
 
   @drop_keyspace """
-  DROP KEYSPACE :keyspace
+  DROP KEYSPACE IF EXISTS :keyspace
   """
 
   @create_realms_table """
-  CREATE TABLE :keyspace.realms (
+  CREATE TABLE IF NOT EXISTS :keyspace.realms (
     realm_name varchar,
     device_registration_limit int,
 
@@ -43,7 +43,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_kv_store """
-  CREATE TABLE :keyspace.kv_store (
+  CREATE TABLE IF NOT EXISTS :keyspace.kv_store (
     group varchar,
     key varchar,
     value blob,
@@ -53,7 +53,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_names_table """
-  CREATE TABLE :keyspace.names (
+  CREATE TABLE IF NOT EXISTS :keyspace.names (
     object_name varchar,
     object_type int,
     object_uuid uuid,
@@ -63,7 +63,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_devices_table """
-  CREATE TABLE :keyspace.devices (
+  CREATE TABLE IF NOT EXISTS :keyspace.devices (
     device_id uuid,
     aliases map<ascii, varchar>,
     introspection map<ascii, int>,
@@ -95,7 +95,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_interfaces_table """
-  CREATE TABLE :keyspace.interfaces (
+  CREATE TABLE IF NOT EXISTS :keyspace.interfaces (
     name ascii,
     major_version int,
     minor_version int,
@@ -115,7 +115,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_endpoints_table """
-  CREATE TABLE :keyspace.endpoints (
+  CREATE TABLE IF NOT EXISTS :keyspace.endpoints (
     interface_id uuid,
     endpoint_id uuid,
     interface_name ascii,
@@ -139,7 +139,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_simple_triggers_table """
-  CREATE TABLE :keyspace.simple_triggers (
+  CREATE TABLE IF NOT EXISTS :keyspace.simple_triggers (
     object_id uuid,
     object_type int,
     parent_trigger_id uuid,
@@ -152,7 +152,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_individual_properties_table """
-  CREATE TABLE :keyspace.individual_properties (
+  CREATE TABLE IF NOT EXISTS :keyspace.individual_properties (
     device_id uuid,
     interface_id uuid,
     endpoint_id uuid,
@@ -179,7 +179,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_individual_datastreams_table """
-  CREATE TABLE :keyspace.individual_datastreams (
+  CREATE TABLE IF NOT EXISTS :keyspace.individual_datastreams (
       device_id uuid,
       interface_id uuid,
       endpoint_id uuid,
@@ -206,7 +206,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_groups_table """
-  CREATE TABLE :keyspace.grouped_devices (
+  CREATE TABLE IF NOT EXISTS :keyspace.grouped_devices (
     group_name varchar,
     insertion_uuid timeuuid,
     device_id uuid,
@@ -215,7 +215,7 @@ defmodule Astarte.Test.Helpers.Database do
   """
 
   @create_deletion_in_progress_table """
-  CREATE TABLE :keyspace.deletion_in_progress (
+  CREATE TABLE IF NOT EXISTS :keyspace.deletion_in_progress (
       device_id uuid,
       vmq_ack boolean,
       dup_start_ack boolean,


### PR DESCRIPTION
Some of these tests drop database tables to validate behavior in edge cases.
However, if other tests were run after dropping tables, subsequent tests would find a corrupted initial setup and would fail. This change ensures that the keyspace is correctly setup for each test.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->
