### PR TITLE
fix(dup): correctly reconnect to amqp after a connection loss

### DIFF
--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/amqp_events_producer_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/amqp_events_producer_test.exs
@@ -1,0 +1,53 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataUpdaterPlant.AMQPEventsProducerTest do
+  # Needs to be executed synchronously to avoid dirsrupting other tests
+  use ExUnit.Case
+  use Mimic
+
+  alias AMQP.Channel
+  alias Astarte.DataUpdaterPlant.AMQPEventsProducer
+
+  @tag :regression
+  test "events producer reconnects in case of error" do
+    test_pid = self()
+    pid = GenServer.whereis(AMQPEventsProducer)
+    channel = :sys.get_state(pid)
+    assert is_struct(channel, Channel)
+
+    ExRabbitPool
+    |> expect(:checkout_channel, fn _conn -> {:error, :disconnected} end)
+    |> expect(:checkout_channel, fn _conn -> {:error, :out_of_channels} end)
+    |> expect(:checkout_channel, fn conn ->
+      res = Mimic.call_original(ExRabbitPool, :checkout_channel, [conn])
+      send(test_pid, :reconnection_done)
+
+      res
+    end)
+    |> allow(self(), pid)
+
+    Channel.close(channel)
+
+    # Wait for reconnection to happen
+    assert_receive :reconnection_done
+
+    new_status = :sys.get_state(pid)
+    assert is_struct(new_status, Channel)
+  end
+end

--- a/apps/astarte_data_updater_plant/test/test_helper.exs
+++ b/apps/astarte_data_updater_plant/test/test_helper.exs
@@ -35,6 +35,7 @@ Mimic.copy(Astarte.DataUpdaterPlant.RPC.VMQPlugin)
 Mimic.copy(Astarte.DataUpdaterPlant.TriggersHandler)
 Mimic.copy(System)
 Mimic.copy(Xandra)
+Mimic.copy(ExRabbitPool)
 Mimic.copy(Astarte.DataAccess.Health.Health)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
the refactor in b57bf46 broke the reconnection logic by removing the handle of the reconnection message. this also explains why the arguments in the `Process.send_after` call have been out of order for months without anyone noticing.

this logic is now reintroduced with the following modifications:
- we do not reconnect if we're already connected to a channel. this is needed to prevent subsequent `:init` messages from making the producer unusable: this would result in a call to `ExRabbitPool.checkout_channel` when all channels in the pool are already allocated, resulting in an `:out_of_channels` error which will recursively schedule a reconnection and fail.
- a regression test has been added for the feature. to avoid the test being 20 seconds long, the backoff has been set to 0 in tests
