### PR TITLE
chore: remove unused references to `astarte_rpc`

### DIFF
--- a/apps/astarte_appengine_api/config/test.exs
+++ b/apps/astarte_appengine_api/config/test.exs
@@ -24,8 +24,6 @@ config :logger, :console,
     :tag
   ]
 
-config :astarte_rpc, :amqp_connection, host: System.get_env("RABBITMQ_HOST") || "rabbitmq"
-
 config :astarte_appengine_api,
        :data_updater_plant_rpc_client,
        Astarte.AppEngine.API.RPC.DataUpdaterPlant.ClientMock

--- a/apps/astarte_data_updater_plant/config/config.exs
+++ b/apps/astarte_data_updater_plant/config/config.exs
@@ -15,8 +15,6 @@ config :astarte_data_updater_plant, :amqp_events_exchange_name, "astarte_events"
 
 config :astarte_data_updater_plant, :amqp_consumer_prefetch_count, 300
 
-config :astarte_rpc, :amqp_queue, "data_updater_plant_rpc"
-
 config :astarte_data_updater_plant, :amqp_adapter, ExRabbitPool.RabbitMQ
 
 config :astarte_data_updater_plant, ecto_repos: [Astarte.DataAccess.Repo]

--- a/apps/astarte_data_updater_plant/config/test.exs
+++ b/apps/astarte_data_updater_plant/config/test.exs
@@ -1,7 +1,5 @@
 import Config
 
-config :astarte_rpc, :amqp_connection, host: System.get_env("RABBITMQ_HOST") || "localhost"
-
 config :astarte_data_updater_plant, :amqp_consumer_options,
   host: System.get_env("RABBITMQ_HOST") || "localhost"
 


### PR DESCRIPTION
this removes compilation warnings. the configuration of astarte_rpc
was removed from services which don't use astarte_rpc anymore