### PR TITLE
ci: fix typo

### DIFF
--- a/.github/workflows/astarte-pairing-workflow.yaml
+++ b/.github/workflows/astarte-pairing-workflow.yaml
@@ -1,4 +1,4 @@
-name: Build and Test Astarte Pairing API
+name: Build and Test Astarte Pairing
 
 on:
   # Run when pushing to stable branches


### PR DESCRIPTION
the file was referring to the no longer existing api service