### PR TITLE
fix(housekeeping): use correct schema version for astarte keyspace

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -1125,7 +1125,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     kv_store_map = %{
       group: "astarte",
       key: "schema_version",
-      value: Migrator.latest_realm_schema_version(),
+      value: Migrator.latest_astarte_schema_version(),
       value_type: :big_integer
     }
 


### PR DESCRIPTION
fixes a regression introduced in #1411, where the wrong function was used for setting the schema version for the astarte database

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
