### PR TITLE
ci: don't skip dialyzer plt build with cache hit

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -54,7 +54,6 @@ jobs:
       run: mix deps.get
     - name: Create PLTs dir
       working-directory: ./apps/${{ inputs.app }}
-      if: ${{ steps.plt_cache.outputs.cache-hit != 'true' }}
       run: mkdir -p dialyzer_cache && mix dialyzer --plt
     - name: Run dialyzer
       working-directory: ./apps/${{ inputs.app }}


### PR DESCRIPTION
dialyzer is smart enough to avoid rebuilding cache for already built modules

fixes issue with dialyzer step failing for local dependencies because they didn't get rebuilt
