### PR TITLE
feat(pairing)!: device registration trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `HOUSEKEEPING_ASTARTE_KEYSPACE_NETWORK_REPLICATION_MAP` - Datacenter replication map when using NetworkTopologyStrategy (no default, required when using network strategy)
 - Added database events handling configuration across all services:
   - `DATABASE_EVENTS_HANDLING_METHOD` - Controls how database events are handled: "expose" (via telemetry) or "log" (to logs) (default: "expose")
+- [astarte_pairing] Added device registration triggers
 
 ### Changed
 - BREAKING: Merged API services into main services, eliminating separate containers:
@@ -37,6 +38,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `HOUSEKEEPING_AMQP_USERNAME` - AMQP username (default: guest)
   - `HOUSEKEEPING_AMQP_PASSWORD` - AMQP password (default: guest)
   - `HOUSEKEEPING_AMQP_MANAGEMENT_PORT` - AMQP management API port (default: 15672)
+- BREAKING: [astarte_pairing] AMQP Producer configuration is now mandatory using the `ASTARTE_EVENTS_PRODUCER_AMQP_*` environment variables
 
 ## [1.2.1] - Unreleased
 ### Fixed

--- a/apps/astarte_pairing/lib/astarte_pairing/application.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/application.ex
@@ -26,6 +26,8 @@ defmodule Astarte.Pairing.Application do
   require Logger
 
   @app_version Mix.Project.config()[:version]
+  @trigger_lifetime_ttl :timer.seconds(60)
+  @trigger_cache_name Config.trigger_cache_name!()
 
   # See https://hexdocs.pm/elixir/Application.html
   # for more information on OTP Applications
@@ -46,7 +48,13 @@ defmodule Astarte.Pairing.Application do
     children = [
       Astarte.PairingWeb.Telemetry,
       {Astarte.Pairing.CredentialsSecret.Cache, []},
-      Astarte.PairingWeb.Endpoint
+      Astarte.PairingWeb.Endpoint,
+      {ConCache,
+       [
+         name: @trigger_cache_name,
+         ttl_check_interval: :timer.seconds(1),
+         global_ttl: @trigger_lifetime_ttl
+       ]}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/apps/astarte_pairing/lib/astarte_pairing/config.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/config.ex
@@ -79,6 +79,13 @@ defmodule Astarte.Pairing.Config do
           type: Astarte.Pairing.Config.TelemetryType,
           default: :expose
 
+  @envdoc """
+  "set the name for the triggers cache, used for caching trigggers and avoid constant db access, defaults to 'trigger_cache'"
+  """
+  app_env :trigger_cache_name, :astarte_pairing, :trigger_cache_name,
+    type: :atom,
+    default: :trigger_cache
+
   @doc """
   Returns the cassandra node configuration
   """

--- a/apps/astarte_pairing/mix.exs
+++ b/apps/astarte_pairing/mix.exs
@@ -117,7 +117,9 @@ defmodule Astarte.Pairing.Mixfile do
       {:cqex, "~> 1.0", only: :test},
       {:cqerl, "~> 2.1", override: true, only: :test},
       {:mimic, "~> 1.11", only: :test},
-      {:credo, "~> 1.7", only: [:dev, :test], runtime: false}
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
+      {:con_cache, "~> 1.1"},
+      {:astarte_events, path: astarte_lib("astarte_events")}
     ]
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       - ./.env
     environment:
       PAIRING_CFSSL_URL: "http://cfssl:8080"
+      ASTARTE_EVENTS_PRODUCER_AMQP_HOST: "rabbitmq"
     restart: on-failure
     depends_on:
       - "rabbitmq"


### PR DESCRIPTION
emit an event when a device is correctly registered

BREAKING CHANGE: pairing now requires
ASTARTE_EVENTS_PRODUCER_AMQP_HOST to be set in order to successfully
generate events


depends on https://github.com/astarte-platform/astarte/pull/1533