### PR TITLE
test(dup):  Extract device disconnection test from simple flow

### DIFF
--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
@@ -53,19 +53,34 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
   setup :verify_on_exit!
 
   setup_all do
-    realm = "autotestrealm#{System.unique_integer([:positive])}"
-    {:ok, _keyspace_name} = DatabaseTestHelper.create_test_keyspace(realm)
+    realm_string = "autotestrealm#{System.unique_integer([:positive])}"
+    {:ok, _keyspace_name} = DatabaseTestHelper.create_test_keyspace(realm_string)
 
     on_exit(fn ->
-      DatabaseTestHelper.destroy_local_test_keyspace(realm)
+      DatabaseTestHelper.destroy_local_test_keyspace(realm_string)
     end)
 
-    {:ok, _pid} = AMQPTestHelper.start_link()
-    %{realm: realm}
+    # Need to be an atom because it's the name we are starting our helper with
+    helper_name = String.to_atom("helper_#{realm_string}")
+
+    consumer_name = String.to_atom("consumer_#{realm_string}")
+
+    realm = String.to_atom(realm_string)
+
+    {:ok, _pid} = AMQPTestHelper.start_link(name: helper_name, realm: realm)
+
+    {:ok, _consumer_pid} =
+      AMQPTestHelper.start_events_consumer(
+        name: consumer_name,
+        realm: realm_string,
+        helper_name: helper_name
+      )
+
+    {:ok, %{realm: realm_string, helper_name: helper_name}}
   end
 
-  test "simple flow", %{realm: realm} do
-    AMQPTestHelper.clean_queue()
+  test "simple flow", %{realm: realm, helper_name: helper_name} do
+    AMQPTestHelper.clean_queue(helper_name)
 
     keyspace_name = Realm.keyspace_name(realm)
     encoded_device_id = "f0VMRgIBAQAAAAAAAAAAAA"
@@ -107,7 +122,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
         trigger_target: {
           :amqp_trigger_target,
           %AMQPTriggerTarget{
-            routing_key: AMQPTestHelper.events_routing_key()
+            routing_key: AMQPTestHelper.events_routing_key(realm),
+            exchange: AMQPTestHelper.events_exchange_name(realm)
           }
         }
       }
@@ -145,7 +161,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     )
 
     DataUpdater.dump_state(realm, encoded_device_id)
-    {conn_event, conn_headers, _metadata} = AMQPTestHelper.wait_and_get_message()
+    {conn_event, conn_headers, _metadata} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert conn_headers["x_astarte_event_type"] == "device_connected_event"
     assert conn_headers["x_astarte_realm"] == realm
     assert conn_headers["x_astarte_device_id"] == encoded_device_id
@@ -170,7 +186,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
              simple_trigger_id: DatabaseTestHelper.group1_device_connected_trigger_id()
            }
 
-    {conn_event, conn_headers, _metadata} = AMQPTestHelper.wait_and_get_message()
+    {conn_event, conn_headers, _metadata} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert conn_headers["x_astarte_event_type"] == "device_connected_event"
     assert conn_headers["x_astarte_realm"] == realm
     assert conn_headers["x_astarte_device_id"] == encoded_device_id
@@ -244,7 +260,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
         trigger_target: {
           :amqp_trigger_target,
           %AMQPTriggerTarget{
-            routing_key: AMQPTestHelper.events_routing_key()
+            routing_key: AMQPTestHelper.events_routing_key(realm),
+            exchange: AMQPTestHelper.events_exchange_name(realm)
           }
         }
       }
@@ -272,7 +289,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
       make_timestamp("2017-10-09T14:00:32+00:00")
     )
 
-    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert incoming_headers["x_astarte_event_type"] == "incoming_introspection_event"
     assert incoming_headers["x_astarte_device_id"] == encoded_device_id
     assert incoming_headers["x_astarte_realm"] == realm
@@ -323,7 +340,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
         trigger_target: {
           :amqp_trigger_target,
           %AMQPTriggerTarget{
-            routing_key: AMQPTestHelper.events_routing_key()
+            routing_key: AMQPTestHelper.events_routing_key(realm),
+            exchange: AMQPTestHelper.events_exchange_name(realm)
           }
         }
       }
@@ -353,7 +371,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
       make_timestamp("2017-10-09T14:00:32+00:00")
     )
 
-    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert incoming_headers["x_astarte_event_type"] == "interface_added_event"
     assert incoming_headers["x_astarte_device_id"] == encoded_device_id
     assert incoming_headers["x_astarte_realm"] == realm
@@ -407,7 +425,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
         trigger_target: {
           :amqp_trigger_target,
           %AMQPTriggerTarget{
-            routing_key: AMQPTestHelper.events_routing_key()
+            routing_key: AMQPTestHelper.events_routing_key(realm),
+            exchange: AMQPTestHelper.events_exchange_name(realm)
           }
         }
       }
@@ -437,7 +456,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
       make_timestamp("2017-10-09T14:00:32+00:00")
     )
 
-    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert incoming_headers["x_astarte_event_type"] == "interface_minor_updated_event"
     assert incoming_headers["x_astarte_device_id"] == encoded_device_id
     assert incoming_headers["x_astarte_realm"] == realm
@@ -491,7 +510,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
         trigger_target: {
           :amqp_trigger_target,
           %AMQPTriggerTarget{
-            routing_key: AMQPTestHelper.events_routing_key()
+            routing_key: AMQPTestHelper.events_routing_key(realm),
+            exchange: AMQPTestHelper.events_exchange_name(realm)
           }
         }
       }
@@ -519,7 +539,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
       make_timestamp("2017-10-09T14:00:32+00:00")
     )
 
-    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert incoming_headers["x_astarte_event_type"] == "interface_removed_event"
     assert incoming_headers["x_astarte_device_id"] == encoded_device_id
     assert incoming_headers["x_astarte_realm"] == realm
@@ -580,7 +600,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
         trigger_target: {
           :amqp_trigger_target,
           %AMQPTriggerTarget{
-            routing_key: AMQPTestHelper.events_routing_key()
+            routing_key: AMQPTestHelper.events_routing_key(realm),
+            exchange: AMQPTestHelper.events_exchange_name(realm)
           }
         }
       }
@@ -658,7 +679,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
       timestamp_us_x_10
     )
 
-    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert incoming_headers["x_astarte_event_type"] == "incoming_data_event"
     assert incoming_headers["x_astarte_device_id"] == encoded_device_id
     assert incoming_headers["x_astarte_realm"] == realm
@@ -695,7 +716,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
       timestamp_us_x_10
     )
 
-    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert incoming_headers["x_astarte_event_type"] == "incoming_data_event"
     assert incoming_headers["x_astarte_device_id"] == encoded_device_id
     assert incoming_headers["x_astarte_realm"] == realm
@@ -763,7 +784,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
         trigger_target: {
           :amqp_trigger_target,
           %AMQPTriggerTarget{
-            routing_key: AMQPTestHelper.events_routing_key()
+            routing_key: AMQPTestHelper.events_routing_key(realm),
+            exchange: AMQPTestHelper.events_exchange_name(realm)
           }
         }
       }
@@ -854,7 +876,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
       timestamp_us_x_10
     )
 
-    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert incoming_headers["x_astarte_event_type"] == "incoming_data_event"
     assert incoming_headers["x_astarte_device_id"] == encoded_device_id
     assert incoming_headers["x_astarte_realm"] == realm
@@ -881,7 +903,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
              simple_trigger_id: DatabaseTestHelper.greater_than_incoming_trigger_id()
            }
 
-    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {incoming_event, incoming_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert incoming_headers["x_astarte_event_type"] == "value_change_applied_event"
     assert incoming_headers["x_astarte_device_id"] == encoded_device_id
     assert incoming_headers["x_astarte_realm"] == realm
@@ -926,7 +948,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     state = DataUpdater.dump_state(realm, encoded_device_id)
 
     {incoming_volatile_event, incoming_volatile_headers, _meta} =
-      AMQPTestHelper.wait_and_get_message()
+      AMQPTestHelper.wait_and_get_message(helper_name)
 
     assert incoming_volatile_headers["x_astarte_event_type"] == "incoming_data_event"
     assert incoming_volatile_headers["x_astarte_device_id"] == encoded_device_id
@@ -1178,7 +1200,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     )
 
     DataUpdater.dump_state(realm, encoded_device_id)
-    {remove_event, remove_headers, _meta} = AMQPTestHelper.wait_and_get_message()
+    {remove_event, remove_headers, _meta} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert remove_headers["x_astarte_event_type"] == "path_removed_event"
     assert remove_headers["x_astarte_device_id"] == encoded_device_id
     assert remove_headers["x_astarte_realm"] == realm
@@ -1306,40 +1328,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     value = Repo.one(value_query)
 
     assert value == nil
-
-    # Device disconnection sub-test
-    DataUpdater.handle_disconnection(
-      realm,
-      encoded_device_id,
-      gen_tracking_id(),
-      make_timestamp("2017-10-09T14:30:45+00:00")
-    )
-
-    DataUpdater.dump_state(realm, encoded_device_id)
-
-    device_row = Repo.one(device_query)
-
-    assert device_row == %{
-             connected: false,
-             total_received_msgs: 45018,
-             total_received_bytes: 4_501_007,
-             exchanged_msgs_by_interface: %{
-               {"com.example.TestObject", 1} => 5,
-               {"com.test.LCDMonitor", 1} => 6,
-               {"com.test.SimpleStreamTest", 1} => 1
-             },
-             exchanged_bytes_by_interface: %{
-               {"com.example.TestObject", 1} => 247,
-               {"com.test.LCDMonitor", 1} => 291,
-               {"com.test.SimpleStreamTest", 1} => 45
-             }
-           }
-
-    assert AMQPTestHelper.awaiting_messages_count() == 0
   end
 
-  test "empty introspection is updated correctly", %{realm: realm} do
-    AMQPTestHelper.clean_queue()
+  test "empty introspection is updated correctly", %{realm: realm, helper_name: helper_name} do
+    AMQPTestHelper.clean_queue(helper_name)
 
     keyspace_name = Realm.keyspace_name(realm)
 
@@ -1366,7 +1358,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
 
     DataUpdater.dump_state(realm, encoded_device_id)
 
-    {conn_event, conn_headers, _metadata} = AMQPTestHelper.wait_and_get_message()
+    {conn_event, conn_headers, _metadata} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert conn_headers["x_astarte_event_type"] == "device_connected_event"
     assert conn_headers["x_astarte_realm"] == realm
     assert conn_headers["x_astarte_device_id"] == encoded_device_id
@@ -1417,11 +1409,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
 
     assert new_device_introspection == new_introspection_map
 
-    assert AMQPTestHelper.awaiting_messages_count() == 0
+    assert AMQPTestHelper.awaiting_messages_count(helper_name) == 0
   end
 
-  test "test introspection with interface update", %{realm: realm} do
-    AMQPTestHelper.clean_queue()
+  test "test introspection with interface update", %{realm: realm, helper_name: helper_name} do
+    AMQPTestHelper.clean_queue(helper_name)
 
     encoded_device_id =
       :crypto.strong_rand_bytes(16)
@@ -1484,8 +1476,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
              {:ok, %{{"com.test.LCDMonitor", 1} => 0, {"com.test.SimpleStreamTest", 1} => 0}}
   end
 
-  test "fails to install volatile trigger on missing device", %{realm: realm} do
-    AMQPTestHelper.clean_queue()
+  test "fails to install volatile trigger on missing device", %{
+    realm: realm,
+    helper_name: helper_name
+  } do
+    AMQPTestHelper.clean_queue(helper_name)
 
     # Install a volatile device test trigger
     simple_trigger_data =
@@ -1528,8 +1523,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
            ) == {:error, :device_does_not_exist}
   end
 
-  test "fails to delete volatile trigger on missing device", %{realm: realm} do
-    AMQPTestHelper.clean_queue()
+  test "fails to delete volatile trigger on missing device", %{
+    realm: realm,
+    helper_name: helper_name
+  } do
+    AMQPTestHelper.clean_queue(helper_name)
 
     volatile_trigger_id = :crypto.strong_rand_bytes(16)
 
@@ -1543,10 +1541,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
            ) == {:error, :device_does_not_exist}
   end
 
-  test "heartbeat message of type internal is correctly handled", %{realm: realm} do
+  test "heartbeat message of type internal is correctly handled", %{
+    realm: realm,
+    helper_name: helper_name
+  } do
     alias Astarte.DataUpdaterPlant.DataUpdater.State
 
-    AMQPTestHelper.clean_queue()
+    AMQPTestHelper.clean_queue(helper_name)
 
     encoded_device_id =
       :crypto.strong_rand_bytes(16)
@@ -1583,10 +1584,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
   end
 
   # TODO remove this when all heartbeats will be moved to internal
-  test "heartbeat message of type heartbeat is correctly handled", %{realm: realm} do
+  test "heartbeat message of type heartbeat is correctly handled", %{
+    realm: realm,
+    helper_name: helper_name
+  } do
     alias Astarte.DataUpdaterPlant.DataUpdater.State
 
-    AMQPTestHelper.clean_queue()
+    AMQPTestHelper.clean_queue(helper_name)
 
     encoded_device_id =
       :crypto.strong_rand_bytes(16)
@@ -1622,8 +1626,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
 
   setup [:set_mox_from_context, :verify_on_exit!]
 
-  test "a disconnected device does not generate a disconnection trigger", %{realm: realm} do
-    AMQPTestHelper.clean_queue()
+  test "a disconnected device does not generate a disconnection trigger", %{
+    realm: realm,
+    helper_name: helper_name
+  } do
+    AMQPTestHelper.clean_queue(helper_name)
 
     encoded_device_id =
       :crypto.strong_rand_bytes(16)
@@ -1647,7 +1654,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
              volatile_trigger_parent_id,
              volatile_trigger_id,
              generate_disconnection_trigger_data(),
-             generate_trigger_target()
+             generate_trigger_target(realm)
            ) == :ok
 
     DataUpdater.handle_disconnection(
@@ -1658,7 +1665,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     )
 
     # Receive the first disconnection trigger
-    {event, headers, _metadata} = AMQPTestHelper.wait_and_get_message()
+    {event, headers, _metadata} = AMQPTestHelper.wait_and_get_message(helper_name)
     assert headers["x_astarte_event_type"] == "device_disconnected_event"
     assert headers["x_astarte_realm"] == realm
     assert headers["x_astarte_device_id"] == encoded_device_id
@@ -1688,7 +1695,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     )
 
     # The second disconnection trigger is not sent
-    assert AMQPTestHelper.awaiting_messages_count() == 0
+    assert AMQPTestHelper.awaiting_messages_count(helper_name) == 0
   end
 
   defp generate_disconnection_trigger_data() do
@@ -1704,11 +1711,16 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
   end
 
   defp generate_trigger_target() do
+    generate_trigger_target(nil)
+  end
+
+  defp generate_trigger_target(realm) do
     %TriggerTargetContainer{
       trigger_target: {
         :amqp_trigger_target,
         %AMQPTriggerTarget{
-          routing_key: AMQPTestHelper.events_routing_key()
+          routing_key: AMQPTestHelper.events_routing_key(realm),
+          exchange: AMQPTestHelper.events_exchange_name(realm)
         }
       }
     }

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/device_disconnection_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/device_disconnection_test.exs
@@ -1,0 +1,124 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2017 - 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataUpdaterPlant.DeviceDisconnectionTest do
+  use ExUnit.Case, async: true
+  import Mox
+
+  alias Astarte.DataUpdaterPlant.DatabaseTestHelper
+  alias Astarte.Core.Device
+  alias Astarte.DataUpdaterPlant.DataUpdater
+  alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.DataAccess.Repo
+  alias Astarte.DataAccess.Devices.Device, as: DeviceSchema
+  alias Astarte.DataUpdaterPlant.AMQPTestHelper
+
+  import Ecto.Query
+
+  setup :verify_on_exit!
+
+  setup do
+    realm_string = "autotestrealm#{System.unique_integer([:positive])}"
+    {:ok, _keyspace_name} = DatabaseTestHelper.create_test_keyspace(realm_string)
+
+    on_exit(fn ->
+      DatabaseTestHelper.destroy_local_test_keyspace(realm_string)
+    end)
+
+    helper_name = String.to_atom("helper_#{realm_string}")
+
+    consumer_name = String.to_atom("consumer_#{realm_string}")
+
+    {:ok, _pid} = AMQPTestHelper.start_link(name: helper_name, realm: realm_string)
+
+    {:ok, _consumer_pid} =
+      AMQPTestHelper.start_events_consumer(
+        name: consumer_name,
+        realm: realm_string,
+        helper_name: helper_name
+      )
+
+    {:ok, %{realm: realm_string, helper_name: helper_name}}
+  end
+
+  test "device disconnection test", %{realm: realm, helper_name: helper_name} do
+    AMQPTestHelper.clean_queue(helper_name)
+
+    keyspace_name = Realm.keyspace_name(realm)
+    encoded_device_id = "f0VMRgIBAQAAAAAAAAAAAA"
+    {:ok, device_id} = Device.decode_device_id(encoded_device_id)
+
+    received_msgs = 45000
+    received_bytes = 4_500_000
+    existing_introspection_map = %{"com.test.LCDMonitor" => 1, "com.test.SimpleStreamTest" => 1}
+
+    insert_opts = [
+      introspection: existing_introspection_map,
+      total_received_msgs: received_msgs,
+      total_received_bytes: received_bytes,
+      groups: ["group1"]
+    ]
+
+    DatabaseTestHelper.insert_device(realm, device_id, insert_opts)
+
+    DataUpdater.handle_disconnection(
+      realm,
+      encoded_device_id,
+      gen_tracking_id(),
+      make_timestamp("2017-10-09T14:30:45+00:00")
+    )
+
+    DataUpdater.dump_state(realm, encoded_device_id)
+
+    device_query =
+      from d in DeviceSchema,
+        prefix: ^keyspace_name,
+        where: d.device_id == ^device_id,
+        select: %{
+          connected: d.connected,
+          total_received_msgs: d.total_received_msgs,
+          total_received_bytes: d.total_received_bytes,
+          exchanged_msgs_by_interface: d.exchanged_msgs_by_interface,
+          exchanged_bytes_by_interface: d.exchanged_bytes_by_interface
+        }
+
+    device_row = Repo.one(device_query)
+
+    assert device_row == %{
+             connected: false,
+             total_received_msgs: received_msgs,
+             total_received_bytes: received_bytes,
+             exchanged_msgs_by_interface: %{},
+             exchanged_bytes_by_interface: %{}
+           }
+
+    assert AMQPTestHelper.awaiting_messages_count(helper_name) == 0
+  end
+
+  defp gen_tracking_id() do
+    message_id = :erlang.unique_integer([:monotonic]) |> Integer.to_string()
+    delivery_tag = {:injected_msg, make_ref()}
+    {message_id, delivery_tag}
+  end
+
+  defp make_timestamp(timestamp_string) do
+    {:ok, date_time, _} = DateTime.from_iso8601(timestamp_string)
+
+    DateTime.to_unix(date_time, :millisecond) * 10000
+  end
+end

--- a/apps/astarte_data_updater_plant/test/support/amqp_events_consumer.ex
+++ b/apps/astarte_data_updater_plant/test/support/amqp_events_consumer.ex
@@ -17,7 +17,6 @@
 #
 
 defmodule Astarte.DataUpdaterPlant.AMQPTestEventsConsumer do
-  require Logger
   use GenServer
 
   alias AMQP.Basic
@@ -31,8 +30,9 @@ defmodule Astarte.DataUpdaterPlant.AMQPTestEventsConsumer do
 
   # API
 
-  def start_link(args \\ []) do
-    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  def start_link(args) do
+    name = Keyword.fetch!(args, :name)
+    GenServer.start_link(__MODULE__, args, name: name)
   end
 
   def ack(delivery_tag) do
@@ -41,13 +41,24 @@ defmodule Astarte.DataUpdaterPlant.AMQPTestEventsConsumer do
 
   # Server callbacks
 
-  def init(_args) do
-    rabbitmq_connect(false)
+  def init(args) do
+    realm = Keyword.fetch!(args, :realm)
+    helper_name = Keyword.fetch!(args, :helper_name)
+
+    initial_state = %{realm: realm, helper_name: helper_name, conn: nil, chan: nil}
+
+    {:ok, state} = rabbitmq_connect(initial_state, false)
+
+    {:ok, state}
   end
 
-  def terminate(_reason, %Channel{conn: conn} = chan) do
+  def terminate(_reason, %{conn: conn, chan: chan}) when not is_nil(conn) and not is_nil(chan) do
     Channel.close(chan)
     Connection.close(conn)
+  end
+
+  def terminate(_reason, _state) do
+    :ok
   end
 
   def handle_call({:ack, delivery_tag}, _from, chan) do
@@ -71,66 +82,72 @@ defmodule Astarte.DataUpdaterPlant.AMQPTestEventsConsumer do
   end
 
   # Message consumed
-  def handle_info({:basic_deliver, payload, meta}, chan) do
+
+  def handle_info({:basic_deliver, payload, meta}, state) do
     {headers, other_meta} = Map.pop(meta, :headers, [])
     headers_map = amqp_headers_to_map(headers)
 
-    AMQPTestHelper.notify_deliver(payload, headers_map, other_meta)
+    # Pass the realm to find the correct helper
+    AMQPTestHelper.notify_deliver(state.helper_name, payload, headers_map, other_meta)
 
-    # TODO: should we ack manually?
-    Basic.ack(chan, meta.delivery_tag)
+    Basic.ack(state.chan, meta.delivery_tag)
 
-    {:noreply, chan}
+    {:noreply, state}
   end
 
-  def handle_info({:try_to_connect}, _state) do
-    {:ok, new_state} = rabbitmq_connect()
+  def handle_info({:try_to_connect}, state) do
+    {:ok, new_state} = rabbitmq_connect(state)
     {:noreply, new_state}
   end
 
-  def handle_info({:DOWN, _, :process, _pid, reason}, _state) do
-    Logger.warning("RabbitMQ connection lost: #{inspect(reason)}. Trying to reconnect...")
-    {:ok, new_state} = rabbitmq_connect()
+  def handle_info({:DOWN, _, :process, _pid, _reason}, state) do
+    {:ok, new_state} = rabbitmq_connect(state)
     {:noreply, new_state}
   end
 
-  defp rabbitmq_connect(retry \\ true) do
+  defp rabbitmq_connect(state, retry \\ true) do
     with {:ok, conn} <- Connection.open(AMQPTestHelper.amqp_consumer_options()),
-         # Get notifications when the connection goes down
-         Process.monitor(conn.pid),
+         # Now we can monitor the connection pid since `conn` is established
+         _monitor_ref <- Process.monitor(conn.pid),
          {:ok, chan} <- Channel.open(conn),
-         :ok <-
-           Exchange.declare(chan, AMQPTestHelper.events_exchange_name(), :direct, durable: true),
+         :ok <- setup_amqp_resources(chan, state.realm) do
+      # On success, put the connection and channel into the state
+      {:ok, %{state | conn: conn, chan: chan}}
+    else
+      {:error, _reason} ->
+        maybe_retry(retry)
+
+      :error ->
+        maybe_retry(retry)
+    end
+  end
+
+  defp setup_amqp_resources(chan, realm) do
+    with :ok <-
+           Exchange.declare(chan, AMQPTestHelper.events_exchange_name(realm), :direct,
+             durable: true
+           ),
          {:ok, _queue} <-
            Queue.declare(
              chan,
-             AMQPTestHelper.events_queue_name(),
-             durable: false,
-             auto_delete: true
+             AMQPTestHelper.events_queue_name(realm),
+             durable: true,
+             auto_delete: false
            ),
          :ok <-
            Queue.bind(
              chan,
-             AMQPTestHelper.events_queue_name(),
-             AMQPTestHelper.events_exchange_name(),
-             routing_key: AMQPTestHelper.events_routing_key()
+             AMQPTestHelper.events_queue_name(realm),
+             AMQPTestHelper.events_exchange_name(realm),
+             routing_key: AMQPTestHelper.events_routing_key(realm)
            ),
-         {:ok, _consumer_tag} <- Basic.consume(chan, AMQPTestHelper.events_queue_name()) do
-      {:ok, chan}
-    else
-      {:error, reason} ->
-        Logger.warning("RabbitMQ Connection error: #{inspect(reason)}")
-        maybe_retry(retry)
-
-      :error ->
-        Logger.warning("Unknown RabbitMQ connection error")
-        maybe_retry(retry)
+         {:ok, _consumer_tag} <- Basic.consume(chan, AMQPTestHelper.events_queue_name(realm)) do
+      :ok
     end
   end
 
   defp maybe_retry(retry) do
     if retry do
-      Logger.warning("Retrying connection in #{@connection_backoff} ms")
       :erlang.send_after(@connection_backoff, :erlang.self(), {:try_to_connect})
       {:ok, :not_connected}
     else

--- a/apps/astarte_data_updater_plant/test/support/database_test_helper.ex
+++ b/apps/astarte_data_updater_plant/test/support/database_test_helper.ex
@@ -460,7 +460,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
             trigger_target: {
               :amqp_trigger_target,
               %AMQPTriggerTarget{
-                routing_key: AMQPTestHelper.events_routing_key()
+                routing_key: AMQPTestHelper.events_routing_key(realm_name),
+                exchange: AMQPTestHelper.events_exchange_name(realm_name)
               }
             }
           }
@@ -493,7 +494,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
             trigger_target: {
               :amqp_trigger_target,
               %AMQPTriggerTarget{
-                routing_key: AMQPTestHelper.events_routing_key()
+                routing_key: AMQPTestHelper.events_routing_key(realm_name),
+                exchange: AMQPTestHelper.events_exchange_name(realm_name)
               }
             }
           }
@@ -529,7 +531,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
             trigger_target: {
               :amqp_trigger_target,
               %AMQPTriggerTarget{
-                routing_key: AMQPTestHelper.events_routing_key()
+                routing_key: AMQPTestHelper.events_routing_key(realm_name),
+                exchange: AMQPTestHelper.events_exchange_name(realm_name)
               }
             }
           }
@@ -564,7 +567,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
             trigger_target: {
               :amqp_trigger_target,
               %AMQPTriggerTarget{
-                routing_key: AMQPTestHelper.events_routing_key()
+                routing_key: AMQPTestHelper.events_routing_key(realm_name),
+                exchange: AMQPTestHelper.events_exchange_name(realm_name)
               }
             }
           }
@@ -599,7 +603,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
             trigger_target: {
               :amqp_trigger_target,
               %AMQPTriggerTarget{
-                routing_key: AMQPTestHelper.events_routing_key()
+                routing_key: AMQPTestHelper.events_routing_key(realm_name),
+                exchange: AMQPTestHelper.events_exchange_name(realm_name)
               }
             }
           }
@@ -641,7 +646,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
             trigger_target: {
               :amqp_trigger_target,
               %AMQPTriggerTarget{
-                routing_key: AMQPTestHelper.events_routing_key()
+                routing_key: AMQPTestHelper.events_routing_key(realm_name),
+                exchange: AMQPTestHelper.events_exchange_name(realm_name)
               }
             }
           }
@@ -693,7 +699,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
             trigger_target: {
               :amqp_trigger_target,
               %AMQPTriggerTarget{
-                routing_key: AMQPTestHelper.events_routing_key()
+                routing_key: AMQPTestHelper.events_routing_key(realm_name),
+                exchange: AMQPTestHelper.events_exchange_name(realm_name)
               }
             }
           }


### PR DESCRIPTION
Moves the device disconnection logic from the monolithic data_updater_test into its own dedicated test file.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
