### PR TITLE
build: fix astarte_events docker build

### DIFF
--- a/libs/astarte_events/mix.exs
+++ b/libs/astarte_events/mix.exs
@@ -65,7 +65,7 @@ defmodule Astarte.Events.Mixfile do
       # Workaround for Elixir 1.15 / ssl_verify_fun issue
       # See also: https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27
       {:ssl_verify_fun, "~> 1.1.0", manager: :rebar3, override: true},
-      {:astarte_data_access, path: "../../libs/astarte_data_access"},
+      {:astarte_data_access, path: "../astarte_data_access"},
       {:astarte_core, github: "astarte-platform/astarte_core", branch: "release-1.3"},
       {:elixir_uuid, "~> 1.2"}
     ]


### PR DESCRIPTION
correctly reference astarte_data_access to be part of the libraries in
the shared parent folder