### PR TITLE
fix: missing ca-certificates in astarte_e2e Dockerfile

### DIFF
--- a/tools/astarte_e2e/Dockerfile
+++ b/tools/astarte_e2e/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get -qq update
 ENV LANG C.UTF-8
 
 # We need SSL
-RUN apt-get -qq install libssl1.1
+RUN apt-get -qq install libssl1.1 ca-certificates
 
 # We have to redefine this here since it goes out of scope for each build stage
 ARG BUILD_ENV=prod


### PR DESCRIPTION
Adds ca-certificates to ensure HTTPS support for astarte_e2e.

Without this, running the container fails with a crash related to missing OS CA certs (:pubkey_os_cacerts.get/0 returns :enoent), breaking HTTPS requests during certificate provisioning.

## Tested with:
```bash
docker build -t astarte-e2e .
docker run --rm --env-file e2e.env astarte-e2e:latest
```

## Fixes:

- Ensures trusted root certificates are available at runtime
- Resolves the crash when requesting device certificates in e2e tests