### PR TITLE
doc(events): better document expected event type

### DIFF
--- a/libs/astarte_events/lib/astarte_events/triggers/triggers.ex
+++ b/libs/astarte_events/lib/astarte_events/triggers/triggers.ex
@@ -38,9 +38,10 @@ defmodule Astarte.Events.Triggers do
             interface_ids_to_name: %{Astarte.DataAccess.UUID.t() => String.t()}
           }
 
-  @type event_type() :: atom()
+  @typedoc "event type in the pretty format (eg `:on_device_connected`)"
+  @type pretty_event_type() :: atom()
   @type event_condition() :: :any_device | {:device_id, binary()} | {:group_name, String.t()}
-  @type realm_device_trigger_key() :: {event_type(), event_condition()}
+  @type realm_device_trigger_key() :: {pretty_event_type(), event_condition()}
   @type policy_name() :: String.t() | nil
   @type target_and_policy() :: {AMQPTriggerTarget.t(), policy_name()}
   @type realm_device_trigger_map() :: %{realm_device_trigger_key() => [target_and_policy()]}
@@ -127,7 +128,7 @@ defmodule Astarte.Events.Triggers do
           realm_device_trigger_map(),
           String.t(),
           Astarte.DataAccess.UUID.t(),
-          event_type(),
+          pretty_event_type(),
           [String.t()] | nil
         ) :: [target_and_policy()]
   def find_trigger_targets_for_device(

--- a/libs/astarte_events/lib/astarte_events/triggers_handler/triggers_handler.ex
+++ b/libs/astarte_events/lib/astarte_events/triggers_handler/triggers_handler.ex
@@ -22,20 +22,34 @@ defmodule Astarte.Events.TriggersHandler do
   by the Trigger targets
   """
 
+  alias Astarte.Core.Device
+  alias Astarte.Core.Triggers.SimpleTriggersProtobuf.AMQPTriggerTarget
   alias Astarte.Core.Triggers.SimpleEvents.SimpleEvent
   alias Astarte.Events.TriggersHandler.Core
 
+  @typedoc "event type as defined in simple event (eg `:device_connected_event`)"
+  @type event_type() :: atom()
+
   defdelegate register_target(realm_name, trigger_target), to: Core
 
-  def dispatch_event(event, event_type, target, realm, device_id, timestamp, policy) do
+  @spec dispatch_event(
+          struct(),
+          event_type(),
+          AMQPTriggerTarget.t(),
+          String.t(),
+          Device.encoded_device_id(),
+          integer(),
+          String.t()
+        ) :: :ok
+  def dispatch_event(event, event_type, target, realm, hw_id, timestamp, policy_name) do
     %SimpleEvent{
       simple_trigger_id: target.simple_trigger_id,
       parent_trigger_id: target.parent_trigger_id,
       realm: realm,
-      device_id: device_id,
+      device_id: hw_id,
       timestamp: timestamp,
       event: {event_type, event}
     }
-    |> Core.dispatch_event(target, policy)
+    |> Core.dispatch_event(target, policy_name)
   end
 end


### PR DESCRIPTION
`find_trigger_targets_for_device/5` and `fetch_realm_device_trigger/1`
expect the pretty event type, while `dispatch_event/7` expects the same
as defined in the simple event struct.

`dispatch_event/7` also expects the device id to be encoded