### PR TITLE
feat: Dockerize FDO Rendezvous server

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/config.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/config.ex
@@ -49,6 +49,12 @@ defmodule Astarte.Pairing.Config do
     type: CQExNodes,
     default: [{"localhost", 9042}]
 
+  @envdoc "The URL to access the FDO Rendezvous Server."
+  app_env :fdo_rendezvous_url, :astarte_pairing, :fdo_rendezvous_url,
+    os_env: "PAIRING_FDO_RENDEZVOUS_URL",
+    type: :binary,
+    default: "http://rendezvous:8041"
+
   def init! do
     if {:ok, nil} == ca_cert() do
       case CFSSLCredentials.ca_cert() do

--- a/compose/fdo-config/rendezvous-server.yml
+++ b/compose/fdo-config/rendezvous-server.yml
@@ -1,0 +1,11 @@
+---
+storage_driver:
+  Directory:
+    path: /var/lib/fdo/rendezvous_registered
+session_store_driver:
+  Directory:
+    path: /var/lib/fdo/rendezvous_sessions
+trusted_manufacturer_keys_path: /etc/fdo/keys/manufacturer_cert.pem
+trusted_device_keys_path: /etc/fdo/keys/device_ca_cert.pem
+max_wait_seconds: 2592000
+bind: "0.0.0.0:8041"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - ./.env
     environment:
       APPENGINE_API_ROOMS_AMQP_CLIENT_HOST: "rabbitmq"
+      PAIRING_FDO_RENDEZVOUS_URL: "http://rendezvous:8041"
     restart: on-failure
     depends_on:
       - "rabbitmq"
@@ -199,6 +200,24 @@ services:
           - dashboard.${DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN}
           - grafana.${DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN}
           - broker.${DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN}
+  
+  rendezvous:
+    image: quay.io/fido-fdo/rendezvous-server:latest
+    restart: on-failure
+    ports:
+      - "8041:8041"
+    volumes:
+      - ./compose/fdo-config/rendezvous-server.yml:/etc/fdo/rendezvous-server.yml:z
+      - ./compose/fdo-keys:/etc/fdo/keys:z
+      - fdo-rendezvous-data:/var/lib/fdo
+    environment:
+      RENDEZVOUS_SERVER_CONF: "/etc/fdo/rendezvous-server.yml"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.fdo-rendezvous.rule=Host(`fdo.${DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN}`)"
+      - "traefik.http.routers.fdo-rendezvous.entrypoints=web"
+      - "traefik.http.routers.fdo-rendezvous.service=fdo-rendezvous"
+      - "traefik.http.services.fdo-rendezvous.loadbalancer.server.port=8041"
 
   # RabbitMQ
   rabbitmq:
@@ -263,6 +282,7 @@ volumes:
   scylla-data:
   vernemq-data:
   cfssl-data:
+  fdo-rendezvous-data:
 
 networks:
   default:


### PR DESCRIPTION
This PR introduce support for the FDO Rendezvous Server, which can now be started and communicate with the other Astarte services via Docker. In particular the Pairing Service, which will be the one responbile for communicating with the Rendezvous Server to perform the FDO protocols.