### PR TITLE
feat: Handle the first TO0 message

### DIFF
--- a/apps/astarte_pairing/README.md
+++ b/apps/astarte_pairing/README.md
@@ -33,7 +33,8 @@ database, (we suggest scylla)
 
 ``` shell
 docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
-docker run --rn -d --net=host -p 8080/tcp ispirata/docker-alpine-cfssl-autotest:astarte
+docker run --rm  -d -p 5672:5672 -p 15672:15672 --name rabbit rabbitmq:3.12.0-management
+docker run --rm -d --net=host -p 8080/tcp ispirata/docker-alpine-cfssl-autotest:astarte
 ```
 
 
@@ -49,3 +50,29 @@ these resources are located.
 ``` shell
 CASSANDRA_NODES=localhost CFSSL_API_URL=http://localhost:8080 mix test
 ```
+
+# Test FDO
+
+To test FDO, the manufacturer and Device CA keys are required and
+can be generated from the following tools:
+
+# Generate manufacturer keys
+docker run --rm \
+  -v $(pwd)/compose/fdo-keys:/keys \
+  quay.io/fido-fdo/admin-cli:latest \
+  generate-key-and-cert manufacturer \
+  --destination-dir /keys
+
+# Generate device CA keys
+docker run --rm \
+  -v $(pwd)/compose/fdo-keys:/keys \
+  quay.io/fido-fdo/admin-cli:latest \
+  generate-key-and-cert device-ca \
+  --destination-dir /keys
+
+# Set permissions
+chmod 644 compose/fdo-keys/*.pem
+chmod 600 compose/fdo-keys/*.der
+
+An ownership voucher and owner private key are also required.
+For testing purposes, a mock key and voucher have been stored in the priv folder of the Pairing Service.

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo_client.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo_client.ex
@@ -1,0 +1,69 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2017-2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDOClient do
+  alias Astarte.Pairing.Config
+  alias Astarte.Pairing.TO0Util
+
+  require Logger
+
+  @doc """
+  TO0.Hello - Type 20 message to initiate TO0 protocol
+  Sends an empty array as per FDO specification section 5.3.1
+  Returns decoded TO0.HelloAck (message 21) with rendezvous nonce
+  """
+  def to0_hello() do
+    url = "#{fdo_rendezvous_url!()}/fdo/101/msg/20"
+    headers = [{"Content-Type", "application/cbor"}, {"Content-Length", "0"}]
+    request_body = CBOR.encode([])
+
+    Logger.debug("Sending TO0.Hello to FDO rendezvous server...", url: url)
+
+    case http_client().post(url, request_body, headers) do
+      {:ok, %{status_code: 200, headers: headers, body: body}} ->
+        Logger.debug("TO0.Hello completed successfully")
+        Logger.debug(inspect(headers))
+
+        case TO0Util.get_nonce_from_hello_ack(body) do
+          {:ok, nonce} ->
+            # TODO: to0owner_sign
+            {:ok, nonce}
+
+          {:error, reason} ->
+            Logger.error("Failed to get nonce from TO0.HelloAck", reason: reason)
+        end
+
+      {:ok, %{status_code: status_code, body: body}} ->
+        Logger.error("TO0.Hello failed with:",
+          status_code: status_code,
+          response_body: body
+        )
+
+      {:error, reason} ->
+        Logger.error("TO0.Hello HTTP request failed", reason: inspect(reason))
+    end
+  end
+
+  defp fdo_rendezvous_url! do
+    Config.fdo_rendezvous_url!()
+  end
+
+  defp http_client do
+    Application.get_env(:astarte_pairing, :fdo_http_client, HTTPoison)
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing/to0_util.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/to0_util.ex
@@ -1,0 +1,44 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2017-2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.TO0Util do
+  require Logger
+
+  @doc """
+  Decodes the TO0.HelloAck CBOR body and returns the extracted nonce.
+  """
+  def get_nonce_from_hello_ack(body) do
+    Logger.info("Decoding TO0.HelloAck CBOR body: #{inspect(body)}")
+
+    case CBOR.decode(body) do
+      {:ok, [%CBOR.Tag{tag: :bytes, value: nonce}], _rest}
+      when is_binary(nonce) and byte_size(nonce) == 16 ->
+        {:ok, nonce}
+
+      {:ok, [%CBOR.Tag{tag: :bytes, value: nonce}], _rest}
+      when is_binary(nonce) and byte_size(nonce) != 16 ->
+        {:error, {:wrong_cbor_size, nonce}}
+
+      {:ok, decoded, _rest} ->
+        {:error, {:unexpected_body_format, decoded}}
+
+      {:error, reason} ->
+        {:error, {:cbor_decode_error, reason}}
+    end
+  end
+end

--- a/apps/astarte_pairing/mix.exs
+++ b/apps/astarte_pairing/mix.exs
@@ -87,6 +87,7 @@ defmodule Astarte.Pairing.Mixfile do
       {:phoenix_ecto, "~> 4.0"},
       {:phoenix_view, "~> 2.0"},
       {:jason, "~> 1.2"},
+      {:cbor, "~> 1.0"},
       {:guardian, "~> 2.3.2"},
       {:remote_ip, "~> 1.0"},
       {:excoveralls, "~> 0.15", only: :test},
@@ -105,6 +106,7 @@ defmodule Astarte.Pairing.Mixfile do
       # See also: https://github.com/deadtrickster/ssl_verify_fun.erl/pull/27
       {:ssl_verify_fun, "~> 1.1.0", manager: :rebar3, override: true},
       {:cfxxl, github: "ispirata/cfxxl"},
+      {:httpoison, "~> 1.6"},
       {:astarte_data_access, path: astarte_lib("astarte_data_access")},
       {:bcrypt_elixir, "~> 2.2"},
       {:xandra, "~> 0.19"},

--- a/apps/astarte_pairing/mix.lock
+++ b/apps/astarte_pairing/mix.lock
@@ -7,6 +7,7 @@
   "bcrypt_elixir": {:hex, :bcrypt_elixir, "2.3.1", "5114d780459a04f2b4aeef52307de23de961b69e13a5cd98a911e39fda13f420", [:make, :mix], [{:comeonin, "~> 5.3", [hex: :comeonin, repo: "hexpm", optional: false]}, {:elixir_make, "~> 0.6", [hex: :elixir_make, repo: "hexpm", optional: false]}], "hexpm", "42182d5f46764def15bf9af83739e3bf4ad22661b1c34fc3e88558efced07279"},
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "castore": {:hex, :castore, "1.0.15", "8aa930c890fe18b6fe0a0cff27b27d0d4d231867897bd23ea772dee561f032a3", [:mix], [], "hexpm", "96ce4c69d7d5d7a0761420ef743e2f4096253931a3ba69e5ff8ef1844fe446d3"},
+  "cbor": {:hex, :cbor, "1.0.1", "39511158e8ea5a57c1fcb9639aaa7efde67129678fee49ebbda780f6f24959b0", [:mix], [], "hexpm", "5431acbe7a7908f17f6a9cd43311002836a34a8ab01876918d8cfb709cd8b6a2"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "cfxxl": {:git, "https://github.com/ispirata/cfxxl.git", "98dc50b1cfe5a682b051b38b83cebc644bc08488", []},
   "combine": {:hex, :combine, "0.10.0", "eff8224eeb56498a2af13011d142c5e7997a80c8f5b97c499f84c841032e429f", [:mix], [], "hexpm", "1b1dbc1790073076580d0d1d64e42eae2366583e7aecd455d1215b0d16f2451b"},

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/to0util_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/to0util_test.exs
@@ -1,0 +1,43 @@
+defmodule Astarte.Pairing.TO0UtilTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.Pairing.TO0Util
+
+  describe "get_nonce_from_hello_ack/1" do
+    test "returns nonce for actual FDO HelloAck CBOR payload (binary nonce)" do
+      valid_nonce = <<32, 54, 127, 243, 66, 48, 228, 115, 59, 186, 230, 246, 198, 179, 113, 78>>
+      hello_ack_cbor = CBOR.encode([%CBOR.Tag{tag: :bytes, value: valid_nonce}])
+      assert {:ok, ^valid_nonce} = TO0Util.get_nonce_from_hello_ack(hello_ack_cbor)
+    end
+
+    test "fails with wrong length CBOR body" do
+      invalid_nonce = <<1, 2, 3, 4, 5, 6, 7, 8>>
+      hello_ack_cbor = CBOR.encode([%CBOR.Tag{tag: :bytes, value: invalid_nonce}])
+
+      assert {:error, {:wrong_cbor_size, ^invalid_nonce}} =
+               TO0Util.get_nonce_from_hello_ack(hello_ack_cbor)
+    end
+
+    test "fails with non-CBOR binary" do
+      invalid_nonce = <<1, 2, 3, 4, 5, 6, 7, 8>>
+
+      assert {:error, {:unexpected_body_format, _}} =
+               TO0Util.get_nonce_from_hello_ack(invalid_nonce)
+
+      wrong_cbor2 =
+        CBOR.encode([
+          %CBOR.Tag{
+            tag: :bytes,
+            value: <<32, 54, 127, 243, 66, 48, 228, 115, 59, 186, 230, 246, 198, 179, 113, 78>>
+          },
+          %CBOR.Tag{
+            tag: :bytes,
+            value: <<32, 54, 127, 243, 66, 48, 228, 115, 59, 186, 230, 246, 198, 179, 113, 78>>
+          }
+        ])
+
+      assert {:error, {:unexpected_body_format, _}} =
+               TO0Util.get_nonce_from_hello_ack(wrong_cbor2)
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the logic for the Pairing Service to send the first TO0 Protocol message to the Rendezvous Server and to receive the associated HelloAck as response.
An associated module to test the added logic is also included.