### PR TITLE
Add missing tag to nonce

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/to0_util.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/to0_util.ex
@@ -128,7 +128,7 @@ defmodule Astarte.Pairing.TO0Util do
   end
 
   defp build_to0d(ov, wait_seconds, nonce) do
-    to0d = CBOR.encode([ov, wait_seconds, nonce])
+    to0d = CBOR.encode([ov, wait_seconds, add_cbor_tag(nonce)])
     {:ok, to0d}
   end
 


### PR DESCRIPTION
Added Cbor tag to nonce to solve `InvalidUtf8` error on Rendezvous server.
TO0.OwnerSign is acceptable by Rendezvous server.