### PR TITLE
refactor(dup): use common context for data triggers

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/trigger.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/trigger.ex
@@ -116,7 +116,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger do
 
   def execute_post_change_triggers(
         state,
-        {_, value_change_applied_triggers, _, _},
         interface_descriptor,
         mapping,
         path,
@@ -127,11 +126,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger do
     %{
       realm: realm,
       device_id: device_id,
-      groups: groups,
-      trigger_id_to_policy_name: trigger_id_to_policy_name_map
+      groups: groups
     } = state
 
-    hw_id = Device.encode_device_id(device_id)
     interface = interface_descriptor.name
     interface_id = interface_descriptor.interface_id
     endpoint_id = mapping.endpoint_id
@@ -169,24 +166,20 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger do
     end
 
     if previous_value != value do
-      Enum.each(value_change_applied_triggers, fn trigger ->
-        target_with_policy_list =
-          trigger.trigger_targets
-          |> Enum.map(fn target ->
-            {target, Map.get(trigger_id_to_policy_name_map, target.parent_trigger_id)}
-          end)
-
-        TriggersHandler.value_change_applied(
-          target_with_policy_list,
-          realm,
-          hw_id,
-          interface,
-          path,
-          old_bson_value,
-          payload,
-          timestamp
-        )
-      end)
+      TriggersHandler.value_change_applied(
+        realm,
+        device_id,
+        groups,
+        interface_id,
+        endpoint_id,
+        interface,
+        path,
+        value,
+        old_bson_value,
+        payload,
+        timestamp,
+        state
+      )
     end
 
     :ok

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/trigger.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/trigger.ex
@@ -77,38 +77,35 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger do
   end
 
   def execute_pre_change_triggers(
-        {value_change_triggers, _, _, _},
-        realm,
-        device_id_string,
-        interface_name,
+        state,
+        interface_descriptor,
+        mapping,
         path,
         previous_value,
         value,
-        timestamp,
-        trigger_id_to_policy_name_map
+        timestamp
       ) do
+    %{realm: realm, device_id: device_id, groups: groups} = state
+    %{interface_id: interface_id, name: interface_name} = interface_descriptor
+    endpoint_id = mapping.endpoint_id
     old_bson_value = Cyanide.encode!(%{v: previous_value})
     payload = Cyanide.encode!(%{v: value})
 
     if previous_value != value do
-      Enum.each(value_change_triggers, fn trigger ->
-        trigger_target_with_policy_list =
-          trigger.trigger_targets
-          |> Enum.map(fn target ->
-            {target, Map.get(trigger_id_to_policy_name_map, target.parent_trigger_id)}
-          end)
-
-        TriggersHandler.value_change(
-          trigger_target_with_policy_list,
-          realm,
-          device_id_string,
-          interface_name,
-          path,
-          old_bson_value,
-          payload,
-          timestamp
-        )
-      end)
+      TriggersHandler.value_change(
+        realm,
+        device_id,
+        groups,
+        interface_id,
+        endpoint_id,
+        interface_name,
+        path,
+        value,
+        old_bson_value,
+        payload,
+        timestamp,
+        state
+      )
     end
 
     :ok

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
@@ -112,21 +112,22 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
     )
   end
 
-  def incoming_data(
-        realm,
-        device_id,
-        groups,
-        interface_name,
-        interface_id,
-        endpoint_id,
-        path,
-        value,
-        bson_value,
-        timestamp,
-        state
-      ) do
+  def incoming_data(context) do
+    %{
+      hardware_id: hw_id,
+      interface_id: interface_id,
+      interface: interface_name,
+      endpoint_id: endpoint_id,
+      value_timestamp: timestamp,
+      state: state,
+      value: value,
+      payload: bson_value,
+      path: path
+    } = context
+
+    %{realm: realm, device_id: device_id, groups: groups} = state
+
     event = %IncomingDataEvent{interface: interface_name, path: path, bson_value: bson_value}
-    hw_id = Device.encode_device_id(device_id)
 
     Triggers.find_all_data_trigger_targets(
       realm,
@@ -326,21 +327,21 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
     )
   end
 
-  def path_created(
-        realm,
-        device_id,
-        groups,
-        interface_id,
-        endpoint_id,
-        interface,
-        path,
-        value,
-        bson_value,
-        timestamp,
-        state
-      ) do
+  def path_created(context, bson_value) do
+    %{
+      hardware_id: hw_id,
+      interface: interface,
+      interface_id: interface_id,
+      endpoint_id: endpoint_id,
+      value_timestamp: timestamp,
+      state: state,
+      value: value,
+      path: path
+    } = context
+
+    %{realm: realm, device_id: device_id, groups: groups} = state
+
     event = %PathCreatedEvent{interface: interface, path: path, bson_value: bson_value}
-    hw_id = Device.encode_device_id(device_id)
 
     Triggers.find_all_data_trigger_targets(
       realm,
@@ -366,19 +367,20 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
     end)
   end
 
-  def path_removed(
-        realm,
-        device_id,
-        groups,
-        interface_id,
-        endpoint_id,
-        interface,
-        path,
-        timestamp,
-        state
-      ) do
+  def path_removed(context) do
+    %{
+      hardware_id: hw_id,
+      interface: interface,
+      interface_id: interface_id,
+      endpoint_id: endpoint_id,
+      value_timestamp: timestamp,
+      state: state,
+      path: path
+    } = context
+
+    %{realm: realm, device_id: device_id, groups: groups} = state
+
     event = %PathRemovedEvent{interface: interface, path: path}
-    hw_id = Device.encode_device_id(device_id)
 
     Triggers.find_all_data_trigger_targets(
       realm,
@@ -404,20 +406,22 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
   end
 
   def value_change(
-        realm,
-        device_id,
-        groups,
-        interface_id,
-        endpoint_id,
-        interface,
-        path,
-        new_value,
+        context,
         old_bson_value,
-        new_bson_value,
-        timestamp,
-        state
+        new_bson_value
       ) do
-    hw_id = Device.encode_device_id(device_id)
+    %{
+      hardware_id: hw_id,
+      interface: interface,
+      interface_id: interface_id,
+      endpoint_id: endpoint_id,
+      value_timestamp: timestamp,
+      state: state,
+      value: value,
+      path: path
+    } = context
+
+    %{realm: realm, device_id: device_id, groups: groups} = state
 
     event = %ValueChangeEvent{
       interface: interface,
@@ -434,7 +438,7 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
       interface_id,
       endpoint_id,
       path,
-      new_value,
+      value,
       Map.from_struct(state)
     )
     |> execute_all_ok(fn {target, policy} ->
@@ -451,27 +455,29 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
   end
 
   def value_change_applied(
-        realm,
-        device_id,
-        groups,
-        interface_id,
-        endpoint_id,
-        interface,
-        path,
-        new_value,
+        context,
         old_bson_value,
-        new_bson_value,
-        timestamp,
-        state
+        new_bson_value
       ) do
+    %{
+      hardware_id: hw_id,
+      interface: interface,
+      interface_id: interface_id,
+      endpoint_id: endpoint_id,
+      value_timestamp: timestamp,
+      state: state,
+      value: value,
+      path: path
+    } = context
+
+    %{realm: realm, device_id: device_id, groups: groups} = state
+
     event = %ValueChangeAppliedEvent{
       interface: interface,
       path: path,
       old_bson_value: old_bson_value,
       new_bson_value: new_bson_value
     }
-
-    hw_id = Device.encode_device_id(device_id)
 
     Triggers.find_all_data_trigger_targets(
       realm,
@@ -481,7 +487,7 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
       interface_id,
       endpoint_id,
       path,
-      new_value,
+      value,
       Map.from_struct(state)
     )
     |> execute_all_ok(fn {target, policy} ->

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/triggers_handler.ex
@@ -458,56 +458,50 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandler do
   end
 
   def value_change_applied(
-        targets,
         realm,
         device_id,
+        groups,
+        interface_id,
+        endpoint_id,
         interface,
         path,
-        old_bson_value,
-        new_bson_value,
-        timestamp
-      )
-      when is_list(targets) do
-    execute_all_ok(targets, fn {target, policy} ->
-      value_change_applied(
-        target,
-        realm,
-        device_id,
-        interface,
-        path,
+        new_value,
         old_bson_value,
         new_bson_value,
         timestamp,
-        policy
-      ) == :ok
-    end)
-  end
-
-  def value_change_applied(
-        target,
-        realm,
-        device_id,
-        interface,
-        path,
-        old_bson_value,
-        new_bson_value,
-        timestamp,
-        policy
+        state
       ) do
-    %ValueChangeAppliedEvent{
+    event = %ValueChangeAppliedEvent{
       interface: interface,
       path: path,
       old_bson_value: old_bson_value,
       new_bson_value: new_bson_value
     }
-    |> dispatch_event_with_telemetry(
-      :value_change_applied_event,
-      target,
+
+    hw_id = Device.encode_device_id(device_id)
+
+    Triggers.find_all_data_trigger_targets(
       realm,
       device_id,
-      timestamp,
-      policy
+      groups,
+      :on_value_change_applied,
+      interface_id,
+      endpoint_id,
+      path,
+      new_value,
+      Map.from_struct(state)
     )
+    |> execute_all_ok(fn {target, policy} ->
+      dispatch_event_with_telemetry(
+        event,
+        :value_change_applied_event,
+        target,
+        realm,
+        hw_id,
+        timestamp,
+        policy
+      )
+    end)
   end
 
   defp introspection_string_to_introspection_proto_map!(introspection_string) do

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_error_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_error_test.exs
@@ -64,7 +64,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerErrorTest do
         |> Enum.at(0)
         |> Map.put(:interface, invalid_name)
 
-      expect(Core.Error, :handle_error, fn ^context, _error, [update_stats: false] ->
+      expect(Core.Error, :handle_error, fn rec_context, _error, [update_stats: false] ->
+        assert similar_context?(context, rec_context)
         state
       end)
 
@@ -91,7 +92,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerErrorTest do
         |> Enum.at(0)
         |> Map.put(:path, invalid_path)
 
-      expect(Core.Error, :handle_error, fn ^context, _error -> state end)
+      expect(Core.Error, :handle_error, fn rec_context, _error ->
+        assert similar_context?(context, rec_context)
+        state
+      end)
 
       assert ^state =
                DataHandler.handle_data(state, interface, path, payload, message_id, timestamp)
@@ -116,7 +120,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerErrorTest do
         |> Enum.at(0)
         |> Map.put(:path, invalid_path)
 
-      expect(Core.Error, :handle_error, fn ^context, _error -> state end)
+      expect(Core.Error, :handle_error, fn rec_context, _error ->
+        assert similar_context?(context, rec_context)
+        state
+      end)
 
       assert ^state =
                DataHandler.handle_data(
@@ -144,7 +151,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerErrorTest do
         gen_context(state, interfaces)
         |> Enum.at(0)
 
-      expect(Core.Error, :handle_error, fn ^context, _error -> state end)
+      expect(Core.Error, :handle_error, fn rec_context, _error ->
+        assert similar_context?(context, rec_context)
+        state
+      end)
 
       expect(Core.Interface, :maybe_handle_cache_miss, fn nil, ^interface, ^state ->
         {:error, :interface_loading_failed}
@@ -489,4 +499,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerErrorTest do
   end
 
   defp valid_value?(payload_value, value), do: payload_value == value
+
+  defp similar_context?(base_context, rec_context) do
+    # checks if common keys are equal
+    Map.intersect(base_context, rec_context) == Map.intersect(rec_context, base_context)
+  end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/trigger_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/trigger_test.exs
@@ -193,7 +193,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.TriggerTest do
       path = "/test/path"
       mapping = mapping(descriptor, path, :string)
 
-      Mimic.reject(&TriggersHandler.path_created/7)
+      Mimic.reject(&TriggersHandler.path_created/11)
       Mimic.reject(&TriggersHandler.path_removed/9)
       Mimic.reject(&TriggersHandler.value_change_applied/8)
 
@@ -213,26 +213,33 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.TriggerTest do
     test "execute_post_change_triggers/9 executes path_created triggers when value changes from nil",
          context do
       state = context.state
-      triggers = {[], [], [%{trigger_targets: [mock_trigger_target()]}], []}
+      triggers = {[], [], [], []}
       realm = state.realm
       interface = "test_interface"
       descriptor = interface_descriptor(interface, 1)
+      interface_id = descriptor.interface_id
       path = "/test/path"
       mapping = mapping(descriptor, path, :integer)
+      endpoint_id = mapping.endpoint_id
       previous_value = nil
       value = 42
       timestamp = DateTime.utc_now()
 
-      Mimic.expect(TriggersHandler, :path_created, fn _target_with_policy_list,
-                                                      ^realm,
+      Mimic.expect(TriggersHandler, :path_created, fn ^realm,
                                                       device,
+                                                      _groups,
+                                                      ^interface_id,
+                                                      ^endpoint_id,
                                                       interface,
                                                       path,
+                                                      val,
                                                       _payload,
-                                                      ^timestamp ->
-        assert device == Astarte.Core.Device.encode_device_id(state.device_id)
+                                                      ^timestamp,
+                                                      _state ->
+        assert device == state.device_id
         assert interface == "test_interface"
         assert path == "/test/path"
+        assert val == value
         :ok
       end)
 

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/triggers_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/triggers_handler_test.exs
@@ -62,7 +62,8 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandlerTest do
   @major_version 1
   @minor_version 1
   @path "/some/path"
-  @bson_value %{v: "testvalue"} |> Cyanide.encode!()
+  @value "testvalue"
+  @bson_value %{v: @value} |> Cyanide.encode!()
   @ip_address "2.3.4.5"
 
   @default_policy_name "@default"
@@ -590,15 +591,30 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandlerTest do
         routing_key: @routing_key
       }
 
+      Mimic.expect(Astarte.Events.Triggers, :find_all_data_trigger_targets, fn _realm,
+                                                                               _device_id,
+                                                                               _groups,
+                                                                               :on_path_created,
+                                                                               _interface_id,
+                                                                               _endpoint_id,
+                                                                               _path,
+                                                                               _value,
+                                                                               _data ->
+        [{target, nil}]
+      end)
+
       TriggersHandler.path_created(
-        target,
         @realm,
-        @device_id,
+        @decoded_device_id,
+        _groups = [],
+        _interface_id = <<>>,
+        _endpoint_id = <<>>,
         @interface,
         @path,
+        @value,
         @bson_value,
         timestamp,
-        nil
+        %State{}
       )
 
       assert_receive {:event, payload, meta}

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/triggers_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/triggers_handler_test.exs
@@ -699,16 +699,21 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandlerTest do
         routing_key: @routing_key
       }
 
+      register_target(:on_value_change, target)
+
       TriggersHandler.value_change(
-        target,
         @realm,
-        @device_id,
+        @decoded_device_id,
+        [],
+        _interface_id = <<>>,
+        _endpoint_id = <<>>,
         @interface,
         @path,
+        42,
         old_bson_value,
         new_bson_value,
         timestamp,
-        nil
+        %State{}
       )
 
       assert_receive {:event, payload, meta}


### PR DESCRIPTION
expand existing context concept to add trigger information.
for now, this is used for data triggers, as they all had signatures
of around 10 parameters