### PR TITLE
chore(dup): remove unused volatile trigger functions

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/trigger.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/trigger.ex
@@ -40,7 +40,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger do
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.DeviceTrigger, as: ProtobufDeviceTrigger
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.DataTrigger, as: ProtobufDataTrigger
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.Utils, as: SimpleTriggersProtobufUtils
-  alias Astarte.DataUpdaterPlant.MessageTracker
 
   def populate_triggers_for_object!(state, object_id, object_type) do
     %{realm: realm} = state
@@ -330,16 +329,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger do
   end
 
   def handle_install_volatile_trigger(
-        %State{discard_messages: true} = state,
-        _,
-        message_id,
-        _
-      ) do
-    MessageTracker.ack_delivery(state.message_tracker, message_id)
-    state
-  end
-
-  def handle_install_volatile_trigger(
         state,
         object_id,
         object_type,
@@ -428,11 +417,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Trigger do
           {:ok, load_trigger(new_state, trigger, target)}
       end
     end
-  end
-
-  def handle_delete_volatile_trigger(%State{discard_messages: true} = state, _, message_id, _) do
-    MessageTracker.discard(state.message_tracker, message_id)
-    state
   end
 
   def handle_delete_volatile_trigger(state, trigger_id) do

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/trigger_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/trigger_handler_test.exs
@@ -8,8 +8,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.TriggerHandlerTest do
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.AMQPTriggerTarget
   alias Astarte.DataUpdaterPlant.AMQPTestHelper
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.TriggerTargetContainer
-  alias Astarte.DataUpdaterPlant.DataUpdater.State
-  alias Astarte.DataUpdaterPlant.MessageTracker
 
   use Astarte.Cases.Data, async: true
   use Astarte.Cases.Device
@@ -295,18 +293,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.TriggerHandlerTest do
     end
   end
 
-  test "`handle_install_volatile_trigger/4` skips on `discard_messages: true`", context do
-    %{realm_name: realm_name, device: device} = context
-    state = DataUpdater.dump_state(realm_name, device.encoded_id)
-    %State{message_tracker: message_tracker} = state
-    state = Map.put(state, :discard_messages, true)
-    message_id = gen_message_id()
-    expect(MessageTracker, :ack_delivery, fn ^message_tracker, ^message_id -> :ok end)
-
-    assert ^state =
-             Trigger.handle_install_volatile_trigger(state, :dontcare, message_id, :dontcare)
-  end
-
   defp volatile_trigger(realm_name, encoded_device_id) do
     gen all object_id <- uuid(),
             object_type <- integer(),
@@ -324,5 +310,4 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.TriggerHandlerTest do
   end
 
   defp uuid, do: repeatedly(&Ecto.UUID.bingenerate/0)
-  defp gen_message_id, do: :erlang.unique_integer([:monotonic]) |> Integer.to_string()
 end


### PR DESCRIPTION
handle_install and handle_delete volatile triggers had branches supporting discard_messages states.

however
1. volatile triggers are not installed/deleted by the device
2. as such there is no tracking id
3. these bodies had a different number of arguments compared to the base body, so they were never actually executed
