### PR TITLE
fix(dup): fix possible crash on interface-specific volatile triggers

### DIFF
--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/trigger_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/trigger_handler_test.exs
@@ -68,18 +68,24 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.TriggerHandlerTest do
   property "successfully install volatile data trigger for specific interface", %{
     state: state,
     realm_name: realm_name,
-    device: device
+    device: device,
+    individual_datastream_device_interface: interface,
+    registered_paths: registered_paths
   } do
+    path =
+      registered_paths[{interface.name, interface.major_version}]
+      |> Enum.random()
+
     simple_trigger =
       %SimpleTriggerContainer{
         simple_trigger: {
           :data_trigger,
           %DataTrigger{
             version: 1,
-            interface_name: "com.test.SimpleStreamTest",
-            interface_major: 1,
+            interface_name: interface.name,
+            interface_major: interface.major_version,
             data_trigger_type: :INCOMING_DATA,
-            match_path: "/0/value",
+            match_path: path,
             value_match_operator: :LESS_THAN,
             known_value: Cyanide.encode!(%{v: 100})
           }

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
@@ -1710,10 +1710,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     |> SimpleTriggerContainer.encode()
   end
 
-  defp generate_trigger_target() do
-    generate_trigger_target(nil)
-  end
-
   defp generate_trigger_target(realm) do
     %TriggerTargetContainer{
       trigger_target: {


### PR DESCRIPTION
previously, when
1. installing a volatile trigger for a specific interface
2. the interface results in a cache miss but is valid for the device

the volatile trigger would be installed but the device status would not be updated.

this results in a crash when the trigger generated events, as the logic expects the interfaces to be in the data updater state.

by just loading the interfaces normally, we avoid this possible crash
