### PR TITLE
fix: Don't crash on newer docker apis using docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,7 @@ services:
       - "traefik.http.services.astarte-grafana.loadbalancer.server.port=3000"
 
   traefik:
-    image: traefik:v2.9
+    image: traefik:v3.6
     restart: on-failure
     command:
       # Uncomment this if you want to enable Traefik's web UI


### PR DESCRIPTION
Traefik v2.9 was incompatible with newer Docker daemon versions that require minimum API version 1.44.
This fixes the recurring "client version 1.24 is too old" errors that prevented Traefik from discovering and routing to Docker containers.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
