### PR TITLE
fix(pairing): Add CBOR tag to FDO nonce

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/cbor/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/cbor/core.ex
@@ -32,7 +32,7 @@ defmodule Astarte.Pairing.FDO.Cbor.Core do
   end
 
   def build_to0d(ov, wait_seconds, nonce) do
-    CBOR.encode([ov, wait_seconds, nonce])
+    CBOR.encode([ov, wait_seconds, add_cbor_tag(nonce)])
   end
 
   def add_cbor_tag(payload) do

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/cbor/core_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/cbor/core_test.exs
@@ -67,7 +67,7 @@ defmodule Astarte.Pairing.FDO.Cbor.CoreTest do
       encoded = Core.build_to0d(ov, wait_seconds, nonce)
       {:ok, decoded, ""} = CBOR.decode(encoded)
 
-      assert decoded == [ov, wait_seconds, nonce]
+      assert decoded == [ov, wait_seconds, %CBOR.Tag{tag: :bytes, value: nonce}]
     end
   end
 


### PR DESCRIPTION
Add CBOR tag to the nonce according to the FDO protocol.