### PR TITLE
fix(pairing): add headers to TO0.OwnerSign request

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/fdo.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/fdo.ex
@@ -22,10 +22,10 @@ defmodule Astarte.Pairing.FDO do
   alias Astarte.Pairing.Queries
 
   def claim_voucher(realm_name, device_id) do
-    with {:ok, nonce} <- hello(),
+    with {:ok, %{nonce: nonce, headers: headers}} <- hello(),
          {:ok, owner_private_key} <- Queries.get_owner_private_key(realm_name, device_id),
          {:ok, ownership_voucher} <- Queries.get_ownership_voucher(realm_name, device_id) do
-      owner_sign(nonce, ownership_voucher, owner_private_key, [])
+      owner_sign(nonce, ownership_voucher, owner_private_key, headers)
     end
   end
 
@@ -35,8 +35,9 @@ defmodule Astarte.Pairing.FDO do
   Returns decoded TO0.HelloAck (message 21) with rendezvous nonce.
   """
   def hello() do
-    with {:ok, body} <- Rendezvous.send_hello() do
-      RendezvousCore.get_body_nonce(body)
+    with {:ok, %{body: body, headers: headers}} <- Rendezvous.send_hello() do
+      {:ok, nonce} = RendezvousCore.get_body_nonce(body)
+      {:ok, %{nonce: nonce, headers: headers}}
     end
   end
 

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/rendezvous.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/rendezvous.ex
@@ -31,8 +31,8 @@ defmodule Astarte.Pairing.FDO.Rendezvous do
     request_body = CBORCore.empty_payload()
 
     case Client.post("/fdo/101/msg/20", request_body, headers) do
-      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
-        {:ok, body}
+      {:ok, %HTTPoison.Response{status_code: 200, headers: resp_headers, body: body}} ->
+        {:ok, %{body: body, headers: resp_headers}}
 
       {:ok, response} ->
         "error during hello message: unexpected response #{inspect(response)}"

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/rendezvous_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/rendezvous_test.exs
@@ -27,10 +27,11 @@ defmodule Astarte.Pairing.FDO.RendezvousTest do
     test "returns {:ok, body} on 200 response" do
       Client
       |> expect(:post, fn "/fdo/101/msg/20", _body, _headers ->
-        {:ok, %HTTPoison.Response{status_code: 200, body: "hello-response"}}
+        {:ok,
+         %HTTPoison.Response{status_code: 200, headers: "some_headers", body: "hello-response"}}
       end)
 
-      assert {:ok, "hello-response"} = Rendezvous.send_hello()
+      assert {:ok, %{body: "hello-response", headers: "some_headers"}} = Rendezvous.send_hello()
     end
 
     test "returns :error on non-200 response" do


### PR DESCRIPTION
Sending TO0.OwnerSign with empty headers fails.
Get headers from HelloAck and use it for sending TO0.OwnerSign message.
