### PR TITLE
build rv entries with fixed logic astarte urls

### DIFF
--- a/apps/astarte_pairing/config/test.exs
+++ b/apps/astarte_pairing/config/test.exs
@@ -96,6 +96,7 @@ config :astarte_pairing,
        System.get_env("CFSSL_API_URL") || "http://localhost:8080"
 
 config :astarte_pairing, :astarte_instance_id, "test"
+config :astarte_pairing, :base_domain, "api.astarte.localhost"
 
 config :bcrypt_elixir,
   log_rounds: 4

--- a/apps/astarte_pairing/lib/astarte_pairing/config.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/config.ex
@@ -32,6 +32,12 @@ defmodule Astarte.Pairing.Config do
     type: :binary,
     required: true
 
+  @envdoc "The astarte base domain, used for FDO authentication mechanism"
+  app_env :base_domain, :astarte_pairing, :base_domain,
+    os_env: "ASTARTE_BASE_DOMAIN",
+    type: :binary,
+    required: true
+
   @envdoc "URL to the running CFSSL instance for device certificate generation."
   app_env :cfssl_url, :astarte_pairing, :cfssl_url,
     os_env: "PAIRING_CFSSL_URL",

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/fdo.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/fdo.ex
@@ -19,10 +19,11 @@
 defmodule Astarte.Pairing.FDO do
   alias Astarte.Pairing.FDO.Rendezvous
   alias Astarte.Pairing.FDO.Rendezvous.Core, as: RendezvousCore
+  alias Astarte.Pairing.Config
 
-  def claim_ownership_voucher(decoded_ownership_voucher, owner_private_key) do
+  def claim_ownership_voucher(realm_name, decoded_ownership_voucher, owner_private_key) do
     with {:ok, %{nonce: nonce, headers: headers}} <- hello() do
-      owner_sign(nonce, decoded_ownership_voucher, owner_private_key, headers)
+      owner_sign(realm_name, nonce, decoded_ownership_voucher, owner_private_key, headers)
     end
   end
 
@@ -40,10 +41,9 @@ defmodule Astarte.Pairing.FDO do
   Sends ownership voucher and waits for response from rendezvous server.
   Returns decoded TO0.AcceptOwner (message 23) with negotiated wait time.
   """
-  def owner_sign(nonce, ownership_voucher, owner_private_key, headers) do
-    # TODO: not sure about this string "entries" content, is it something we want parametrized?
+  def owner_sign(realm_name, nonce, ownership_voucher, owner_private_key, headers) do
     with {:ok, addr_entries} <-
-           RendezvousCore.get_rv_to2_addr_entries("test1", "0.0.0.0", "test2", "0.0.0.0") do
+           RendezvousCore.get_rv_to2_addr_entry("#{realm_name}.#{Config.base_domain!()}") do
       request_body =
         RendezvousCore.build_owner_sign_message(
           ownership_voucher,

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/core.ex
@@ -24,11 +24,12 @@ defmodule Astarte.Pairing.FDO.Rendezvous.Core do
   @es256 -7
   @es256_identifier 1
   @cose_sign1_tag 18
+  @http 3
+  @load_balancer_port 4003
 
-  def get_rv_to2_addr_entries(first_entry, first_entry_ip, second_entry, second_entry_ip) do
-    rv_entry1 = CBORCore.build_rv_to2_addr_entry(first_entry_ip, first_entry, 8080, 3)
-    rv_entry2 = CBORCore.build_rv_to2_addr_entry(second_entry_ip, second_entry, 8080, 3)
-    {:ok, [rv_entry1, rv_entry2]}
+  def get_rv_to2_addr_entry(full_dns_name, pre_existing_entries \\ []) do
+    rv_entry = CBORCore.build_rv_to2_addr_entry(nil, full_dns_name, @load_balancer_port, @http)
+    {:ok, [rv_entry] ++ pre_existing_entries}
   end
 
   def build_owner_sign_message(decoded_ownership_voucher, owner_key, nonce, addr_entries) do

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/ownership_voucher_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/ownership_voucher_controller.ex
@@ -46,7 +46,12 @@ defmodule Astarte.PairingWeb.OwnershipVoucherController do
              device_guid,
              private_key
            ),
-         :ok <- FDO.claim_ownership_voucher(decoded_ownership_voucher, extracted_private_key) do
+         :ok <-
+           FDO.claim_ownership_voucher(
+             realm_name,
+             decoded_ownership_voucher,
+             extracted_private_key
+           ) do
       send_resp(conn, 200, "")
     end
   end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/core_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/core_test.exs
@@ -66,18 +66,36 @@ defmodule Astarte.Pairing.FDO.Rendezvous.CoreTest do
     end
   end
 
-  describe "get_rv_to2_addr_entries/0" do
-    test "returns a list of entries with correct types" do
-      {:ok, entries} = Core.get_rv_to2_addr_entries("test1", "0.0.0.0", "test2", "0.0.0.0")
+  describe "get_rv_to2_addr_entry/2" do
+    test "returns a list of entries with correct types and one element" do
+      {:ok, entries} = Core.get_rv_to2_addr_entry("test1")
       assert is_list(entries)
-      assert length(entries) >= 1
+      assert length(entries) == 1
 
       Enum.each(entries, fn entry ->
         assert is_binary(entry)
         {:ok, [decoded], _rest} = CBOR.decode(entry)
         assert is_list(decoded)
         assert length(decoded) == 4
-        assert is_binary(Enum.at(decoded, 0))
+        assert is_nil(Enum.at(decoded, 0))
+        assert is_binary(Enum.at(decoded, 1))
+        assert is_integer(Enum.at(decoded, 2))
+        assert is_integer(Enum.at(decoded, 3))
+      end)
+    end
+
+    test "add an entry to a list of entries, returns with correct types and one more entry" do
+      {:ok, entries} = Core.get_rv_to2_addr_entry("test1")
+      {:ok, entries} = Core.get_rv_to2_addr_entry("test2", entries)
+      assert is_list(entries)
+      assert length(entries) == 2
+
+      Enum.each(entries, fn entry ->
+        assert is_binary(entry)
+        {:ok, [decoded], _rest} = CBOR.decode(entry)
+        assert is_list(decoded)
+        assert length(decoded) == 4
+        assert is_nil(Enum.at(decoded, 0))
         assert is_binary(Enum.at(decoded, 1))
         assert is_integer(Enum.at(decoded, 2))
         assert is_integer(Enum.at(decoded, 3))
@@ -160,7 +178,7 @@ defmodule Astarte.Pairing.FDO.Rendezvous.CoreTest do
       nonce = <<32, 54, 127, 243, 66, 48, 228, 115, 59, 186, 230, 246, 198, 179, 113, 78>>
       owner_key = sample_extracted_rsa_private_key()
       ownership_voucher = sample_voucher()
-      {:ok, addr_entries} = Core.get_rv_to2_addr_entries("test1", "0.0.0.0", "test2", "0.0.0.0")
+      {:ok, addr_entries} = Core.get_rv_to2_addr_entry("test1")
 
       %{
         nonce: nonce,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
     environment:
       PAIRING_CFSSL_URL: "http://cfssl:8080"
       ASTARTE_EVENTS_PRODUCER_AMQP_HOST: "rabbitmq"
+      ASTARTE_BASE_DOMAIN: ${DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN}
     restart: on-failure
     depends_on:
       - "rabbitmq"


### PR DESCRIPTION
depends on https://github.com/astarte-platform/astarte/pull/1588

implements a logic for building rv entries  (realm name + astarte base url) , also removes ip addresses in rv entries

tests have been adjusted