### PR TITLE
feat(pairing): Expose endpoint for TO2.HelloDevice

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -1,0 +1,27 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnerOnboarding do
+  alias Astarte.Pairing.FDO.OwnerOnboarding.Core, as: OwnerOnboardingCore
+
+  def hello_device(cbor_hello_device, _realm) do
+    OwnerOnboardingCore.decode_hello_device(cbor_hello_device)
+    # TODO: implement proper response
+    {:ok, []}
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/core.ex
@@ -1,0 +1,51 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnerOnboarding.Core do
+  alias Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice
+
+  def decode_hello_device(cbor_hello_device) do
+    case CBOR.decode(cbor_hello_device) do
+      {:ok, decoded_hello_device, ""} ->
+        parse_hello_device(decoded_hello_device)
+
+      _ ->
+        {:error, :invalid_hello_device_message}
+    end
+  end
+
+  defp parse_hello_device(decoded_hello_device) do
+    case decoded_hello_device do
+      [max_size, device_id, nonce_hello_device, kex_name, cipher_name, easig_info] ->
+        hello_device =
+          %HelloDevice{
+            max_size: max_size,
+            device_id: device_id,
+            nonce: nonce_hello_device,
+            kex_name: kex_name,
+            cipher_name: cipher_name,
+            easig_info: easig_info
+          }
+
+        {:ok, hello_device}
+
+      _ ->
+        {:error, :invalid_hello_device_format}
+    end
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/hello_device.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/hello_device.ex
@@ -1,0 +1,37 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice do
+  @moduledoc """
+  HelloDevice structure as per FDO specification.
+  """
+  use TypedStruct
+
+  @type sign_info :: {String.t(), binary()}
+
+  typedstruct enforce: true do
+    @typedoc "A hello device message structure."
+
+    field :max_size, non_neg_integer()
+    field :device_id, binary()
+    field :nonce, binary()
+    field :kex_name, String.t()
+    field :cipher_name, String.t()
+    field :easig_info, sign_info()
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
@@ -1,0 +1,39 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.PairingWeb.FDOOnboardingController do
+  use Astarte.PairingWeb, :controller
+
+  alias Astarte.Pairing.FDO.OwnerOnboarding
+
+  require Logger
+
+  action_fallback Astarte.PairingWeb.FallbackController
+
+  def hello_device(conn, _params) do
+    realm_name = Map.fetch!(conn.params, "realm_name")
+    cbor_hello_device = conn.assigns.cbor_body
+
+    {:ok, response_msg} =
+      OwnerOnboarding.hello_device(cbor_hello_device, realm_name)
+
+    conn
+    |> put_resp_content_type("application/cbor")
+    |> send_resp(200, CBOR.encode(response_msg))
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/plug/verify_fdo.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/plug/verify_fdo.ex
@@ -1,0 +1,43 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.PairingWeb.Plug.VerifyFDO do
+  use Plug.Builder
+
+  import Plug.Conn
+
+  def init(_opts) do
+    nil
+  end
+
+  def call(conn, _opts) do
+    if get_req_header(conn, "content-type") == ["application/cbor"] do
+      case Plug.Conn.read_body(conn) do
+        {:ok, body, conn} ->
+          conn |> Plug.Conn.assign(:cbor_body, body)
+
+        _ ->
+          conn |> Plug.Conn.send_resp(400, "Could not read request body.") |> halt()
+      end
+    else
+      conn
+      |> Plug.Conn.send_resp(415, "Unsupported Media Type. Expected application/cbor.")
+      |> halt()
+    end
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
@@ -33,6 +33,10 @@ defmodule Astarte.PairingWeb.Router do
     plug Astarte.PairingWeb.Plug.LogHwId
   end
 
+  pipeline :fdo do
+    plug Astarte.PairingWeb.Plug.VerifyFDO
+  end
+
   scope "/v1/:realm_name", Astarte.PairingWeb do
     pipe_through :realm_api
 
@@ -41,6 +45,12 @@ defmodule Astarte.PairingWeb.Router do
     scope "/ownership" do
       pipe_through :agent_api
       post "/", OwnershipVoucherController, :create
+    end
+
+    scope "/fdo/101" do
+      pipe_through :fdo
+
+      post "/msg/60", FDOOnboardingController, :hello_device
     end
 
     scope "/agent" do

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/core_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/core_test.exs
@@ -1,0 +1,79 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnerOnboarding.CoreTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.Pairing.FDO.OwnerOnboarding.Core
+  alias Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice
+
+  describe "decode_hello_device/1" do
+    setup do
+      valid_data = %{
+        max_size: 65535,
+        device_id: <<1, 2, 3, 4>>,
+        nonce: <<5, 6, 7, 8>>,
+        kex_name: "DHKEXid14",
+        cipher_name: "AES256GCM",
+        easig_info: ["ES256", <<0x01, 0x02>>]
+      }
+
+      {:ok, valid_data: valid_data}
+    end
+
+    test "successfully decodes a valid hello device structure", %{valid_data: data} do
+      cbor_payload = CBOR.encode(hello_device_list(data))
+
+      assert {:ok, %HelloDevice{}} =
+               Core.decode_hello_device(cbor_payload)
+    end
+
+    test "successfully decodes a valid hello device CBOR payload", %{valid_data: data} do
+      cbor_payload = CBOR.encode(hello_device_list(data))
+
+      assert {:ok, %HelloDevice{} = hello_device} =
+               Core.decode_hello_device(cbor_payload)
+
+      assert hello_device.max_size == data.max_size
+      assert hello_device.device_id == data.device_id
+      assert hello_device.nonce == data.nonce
+      assert hello_device.kex_name == data.kex_name
+      assert hello_device.cipher_name == data.cipher_name
+      assert hello_device.easig_info == data.easig_info
+    end
+
+    test "returns error for invalid hello device format" do
+      invalid_payload = [1, 2, 3]
+
+      cbor_payload = CBOR.encode(invalid_payload)
+
+      assert Core.decode_hello_device(cbor_payload) ==
+               {:error, :invalid_hello_device_format}
+    end
+
+    test "returns error when CBOR decode fails" do
+      invalid_binary = "invalid_cbor"
+
+      assert {:error, :invalid_hello_device_message} == Core.decode_hello_device(invalid_binary)
+    end
+  end
+
+  defp hello_device_list(data) do
+    [data.max_size, data.device_id, data.nonce, data.kex_name, data.cipher_name, data.easig_info]
+  end
+end


### PR DESCRIPTION
This PR implements the POST endpoint for the FDO TO2.HelloDevice message, enabling the secure establishment of communication between the new owner and the device. 
It integrates a dedicated CBOR Plug pipeline to handle the application/cbor request body, ensuring the raw binary data is passed correctly to the controller. 
The controller then decodes the required array of six elements.