### PR TITLE
feat(pairing): Implement FDO ProveOVHdr message 

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -17,11 +17,119 @@
 #
 
 defmodule Astarte.Pairing.FDO.OwnerOnboarding do
+  @moduledoc """
+  This module implements the logic for processing FDO (FIDO Device Onboarding) owner onboarding requests,
+  including decoding device hello messages, retrieving ownership vouchers, and building signed responses.
+  It manages cryptographic operations such as HMAC and COSE_Sign1 signing,
+  and supports key exchange parameter generation for secure device onboarding.
+  """
+
+  alias Astarte.Pairing.FDO.Rendezvous.Core, as: RendezvousCore
   alias Astarte.Pairing.FDO.OwnerOnboarding.Core, as: OwnerOnboardingCore
 
-  def hello_device(cbor_hello_device, _realm) do
-    OwnerOnboardingCore.decode_hello_device(cbor_hello_device)
-    # TODO: implement proper response
-    {:ok, []}
+  alias Astarte.Pairing.Queries
+
+  require Logger
+
+  @max_owner_message_size 65_535
+  @cupd_nonce_tag 256
+  @cuph_owner_pubkey_tag 257
+
+  def hello_device(cbor_hello_device, realm_name) do
+    with {:ok, hello_device} <- OwnerOnboardingCore.decode_hello_device(cbor_hello_device),
+         {:ok, ownership_voucher} <-
+           Queries.get_ownership_voucher(realm_name, hello_device.device_id),
+         {:ok, owner_private_key} <-
+           Queries.get_owner_private_key(realm_name, hello_device.device_id),
+         {:ok, xa_key_exchange, _private_key} <-
+           generate_key_exchange_param(hello_device.kex_name),
+         # TODO save hello_device.device_id, hello_device.cipher_name and _private_key into session for later use
+         cbor_ov_header <- OwnerOnboardingCore.ov_header(ownership_voucher),
+         num_ov_entries <- OwnerOnboardingCore.num_ov_entries(ownership_voucher),
+         hmac <- OwnerOnboardingCore.build_hmac(owner_private_key, cbor_ov_header),
+         hello_device_hash <- OwnerOnboardingCore.compute_hello_device_hash(cbor_hello_device),
+         unprotected_headers <- build_unprotected_headers(owner_private_key),
+         to2_proveovhdr_payload <-
+           build_to2_proveovhdr_payload(
+             cbor_ov_header,
+             num_ov_entries,
+             hmac,
+             hello_device.nonce,
+             nil,
+             xa_key_exchange,
+             hello_device_hash
+           ) do
+      RendezvousCore.build_cose_sign1(
+        to2_proveovhdr_payload,
+        unprotected_headers,
+        owner_private_key
+      )
+    else
+      {:error, reason} ->
+        Logger.error("Failed to process hello_device: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp build_to2_proveovhdr_payload(
+         cbor_ov_header,
+         num_ov_entries,
+         hmac,
+         nonce_hello_device,
+         eb_sig_info,
+         xa_key_exchange,
+         hello_device_hash
+       ) do
+    [
+      cbor_ov_header,
+      num_ov_entries,
+      hmac,
+      nonce_hello_device,
+      eb_sig_info,
+      xa_key_exchange,
+      hello_device_hash,
+      @max_owner_message_size
+    ]
+  end
+
+  defp build_unprotected_headers(ownership_voucher) do
+    %{
+      # TODO save nonce into session for later use
+      @cupd_nonce_tag => :crypto.strong_rand_bytes(16),
+      @cuph_owner_pubkey_tag => OwnerOnboardingCore.ov_last_entry_public_key(ownership_voucher)
+    }
+  end
+
+  # Do we need to support all kex suites?
+  defp generate_key_exchange_param(kex_suite_name) do
+    case kex_suite_name do
+      "ASYMKEX2048" ->
+        {:ok, private_key_record} = generate_rsa_2048_key()
+        {:ok, public_key_record} = get_public_key(private_key_record)
+        {:ok, public_key_record, private_key_record}
+
+      _ ->
+        Logger.error("Key exchange suite not supported: #{kex_suite_name}")
+        {:error, :unsupported_kex_suite}
+    end
+  end
+
+  def generate_rsa_2048_key() do
+    public_exponent = 65_537
+
+    options = {:rsa, 2048, public_exponent}
+
+    :public_key.generate_key(options)
+  end
+
+  def get_public_key(private_key_record) do
+    case private_key_record do
+      {:RSAPrivateKey, _, modulus, public_exponent, _, _, _, _, _, _, _} ->
+        public_key_record = {:RSAPublicKey, modulus, public_exponent}
+        {:ok, public_key_record}
+
+      _ ->
+        {:error, :invalid_private_key_format}
+    end
   end
 end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/core.ex
@@ -42,7 +42,7 @@ defmodule Astarte.Pairing.FDO.Rendezvous.Core do
     CBOR.encode([CBORCore.add_cbor_tag(to0d), signature])
   end
 
-  def build_cose_sign1(payload, owner_key) do
+  def build_cose_sign1(payload, owner_key, unprotected_header \\ %{}) do
     protected_header = %{@es256_identifier => @es256}
     protected_header_cbor = CBOR.encode(protected_header)
 
@@ -53,7 +53,7 @@ defmodule Astarte.Pairing.FDO.Rendezvous.Core do
 
     cose_sign1_array = [
       CBORCore.add_cbor_tag(protected_header_cbor),
-      %{},
+      unprotected_header,
       CBORCore.add_cbor_tag(payload),
       CBORCore.add_cbor_tag(raw_signature)
     ]

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/core_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/core_test.exs
@@ -25,7 +25,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.CoreTest do
   describe "decode_hello_device/1" do
     setup do
       valid_data = %{
-        max_size: 65535,
+        max_size: 65_535,
         device_id: <<1, 2, 3, 4>>,
         nonce: <<5, 6, 7, 8>>,
         kex_name: "DHKEXid14",


### PR DESCRIPTION

This PR adds the full implementation of the `ProveOVHdr` message, including all steps from voucher retrieval to COSE_Sign1 response generation. It introduces helper functions for OV header extraction, HMAC generation, payload assembly, and hashing of the incoming CBOR message.
