### PR TITLE
chore: rudimentary session management

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -241,6 +241,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
          :ok <- create_grouped_devices_table(keyspace_name),
          :ok <- create_deletion_in_progress_table(keyspace_name),
          :ok <- create_ownership_vouchers_table(keyspace_name),
+         :ok <- create_to2_sessions_table(keyspace_name),
          :ok <- insert_realm_public_key(keyspace_name, public_key_pem),
          :ok <- insert_realm_astarte_schema_version(keyspace_name),
          :ok <- insert_realm(realm_name, device_limit),
@@ -549,6 +550,22 @@ defmodule Astarte.Housekeeping.Realms.Queries do
       voucher_data blob,
       device_id uuid,
       PRIMARY KEY (device_id, voucher_data)
+    );
+    """
+
+    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
+      :ok
+    end
+  end
+
+  defp create_to2_sessions_table(keyspace_name) do
+    query = """
+    CREATE TABLE #{keyspace_name}.to2_sessions (
+      session_key blob,
+      device_id uuid,
+      private_key blob,
+      public_key blob,
+      PRIMARY KEY (session_key)
     );
     """
 

--- a/apps/astarte_housekeeping/priv/migrations/realm/0010_create_device_session_table.sql
+++ b/apps/astarte_housekeeping/priv/migrations/realm/0010_create_device_session_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE :keyspace.to2_sessions (
+  session_key blob,
+  device_id uuid,
+  private_key blob,
+  public_key blob,
+  PRIMARY KEY (session_key)
+);

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session.ex
@@ -1,0 +1,29 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
+  alias Astarte.Pairing.Queries
+
+  def new(realm_name, device_id, public_key, private_key) do
+    key = UUID.uuid4(:raw)
+
+    with :ok <- Queries.store_session(realm_name, key, device_id, public_key, private_key) do
+      {:ok, UUID.binary_to_string!(key)}
+    end
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
@@ -29,9 +29,11 @@ defmodule Astarte.PairingWeb.FDOOnboardingController do
     realm_name = Map.fetch!(conn.params, "realm_name")
     cbor_hello_device = conn.assigns.cbor_body
 
-    with {:ok, response_msg} <- OwnerOnboarding.hello_device(cbor_hello_device, realm_name) do
+    with {:ok, session_key, response_msg} <-
+           OwnerOnboarding.hello_device(realm_name, cbor_hello_device) do
       conn
       |> put_resp_content_type("application/cbor")
+      |> put_resp_header("authorization", session_key)
       |> send_resp(200, CBOR.encode(response_msg))
     end
   end

--- a/libs/astarte_data_access/lib/astarte_data_access/fdo/to2_session.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/fdo/to2_session.ex
@@ -1,0 +1,29 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataAccess.FDO.TO2Session do
+  use TypedEctoSchema
+
+  @primary_key false
+  typed_schema "to2_sessions" do
+    field :session_key, :binary, primary_key: true
+    field :device_id, Astarte.DataAccess.UUID, primary_key: true
+    field :private_key, :binary
+    field :public_key, :binary
+  end
+end


### PR DESCRIPTION
create a session as defined by section 4.3 of the FDO 1.1 spec using
a single identifier in the authorization header

the current implementation works but has a few caveats:
- it stores the private key to the database (we never did it!)
- uses `System.unique_integer` as the identifier. this is acceptable by
  the spec but not ideal

alternatives considered: storing the sessions in cache
unfortunately, we need the database to store sessions because we don't
have any guarantee the same pairing replica will handle subsequent
messages.

an horde registry might work tho!