### PR TITLE
ci: build images with the right Dockerfile

### DIFF
--- a/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
@@ -124,8 +124,8 @@ jobs:
         id: push
         uses: docker/build-push-action@v6.18.0
         with:
-          context: apps/${{ matrix.app }}
-          file: Dockerfile
+          context: .
+          file: apps/${{ matrix.app }}/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Dockerfile was not referenced in the right path. Fix it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
Docker images do not build in CI. See e.g. this run: https://github.com/astarte-platform/astarte/actions/runs/19702001245/job/56471567236

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

