### PR TITLE
Downcase http headers from rendezvous

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/client.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/client.ex
@@ -36,4 +36,12 @@ defmodule Astarte.Pairing.FDO.Rendezvous.Client do
 
     Keyword.merge(auth_opts, options)
   end
+
+  @impl true
+  def process_response_headers(headers) do
+    Enum.map(headers, fn
+      {key, value} ->
+        {String.downcase(key), value}
+    end)
+  end
 end


### PR DESCRIPTION
Since we get different responses from the rendezvous server, sometimes with a capital "A" in the authorization header, and sometimes with a lowercase letter.
This overrides the HTTPoison response function and sets all headers to lowercase.
