### PR TITLE
fix(pairing): correctly build rv_to2_addr entries

### DIFF
--- a/apps/astarte_pairing/config/test.exs
+++ b/apps/astarte_pairing/config/test.exs
@@ -21,7 +21,7 @@ import Config
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :astarte_pairing, Astarte.PairingWeb.Endpoint,
-  http: [port: 4001],
+  http: [port: 4003],
   server: false
 
 config :logger, :console,

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/cbor/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/cbor/core.ex
@@ -22,28 +22,6 @@ defmodule Astarte.Pairing.FDO.Cbor.Core do
     CBOR.encode([])
   end
 
-  @doc """
-  build rendezvous entries for TO, those are not mutually exclusive
-  each entry is composed of:
-  - ip of the rendezvous server
-  - dns entry of the rendezvous server
-  - exposed port of the rendezvous server
-  - transport protocol
-
-  available transport protocols are (from FDO docs)
-    ProtTCP:    1,     ;; bare TCP stream
-    ProtTLS:    2,     ;; bare TLS stream
-    ProtHTTP:   3,
-    ProtCoAP:   4,
-    ProtHTTPS:  5,
-    ProtCoAPS:  6,
-
-  """
-  def build_rv_to2_addr_entry(ip, dns, port, protocol) do
-    rv_entry = [ip, dns, port, protocol]
-    CBOR.encode([rv_entry])
-  end
-
   def build_to1d_rv(entries) do
     CBOR.encode([entries])
   end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/fdo.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/fdo.ex
@@ -19,7 +19,7 @@
 defmodule Astarte.Pairing.FDO do
   alias Astarte.Pairing.FDO.Rendezvous
   alias Astarte.Pairing.FDO.Rendezvous.Core, as: RendezvousCore
-  alias Astarte.Pairing.Config
+  alias Astarte.Pairing.FDO.Rendezvous.RvTO2Addr
 
   def claim_ownership_voucher(realm_name, decoded_ownership_voucher, owner_private_key) do
     with {:ok, %{nonce: nonce, headers: headers}} <- hello() do
@@ -42,17 +42,17 @@ defmodule Astarte.Pairing.FDO do
   Returns decoded TO0.AcceptOwner (message 23) with negotiated wait time.
   """
   def owner_sign(realm_name, nonce, ownership_voucher, owner_private_key, headers) do
-    with {:ok, addr_entries} <-
-           RendezvousCore.get_rv_to2_addr_entry("#{realm_name}.#{Config.base_domain!()}") do
-      request_body =
-        RendezvousCore.build_owner_sign_message(
-          ownership_voucher,
-          owner_private_key,
-          nonce,
-          addr_entries
-        )
+    realm_rv_to2_addr_entry = RvTO2Addr.for_realm(realm_name)
+    rv_to2_addr = [realm_rv_to2_addr_entry]
 
-      Rendezvous.register_ownership(request_body, headers)
-    end
+    request_body =
+      RendezvousCore.build_owner_sign_message(
+        ownership_voucher,
+        owner_private_key,
+        nonce,
+        rv_to2_addr
+      )
+
+    Rendezvous.register_ownership(request_body, headers)
   end
 end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -31,7 +31,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
   alias Astarte.Pairing.FDO.OwnerOnboarding.Session
   alias Astarte.Pairing.FDO.OwnershipVoucher
   alias Astarte.Pairing.FDO.OwnershipVoucher.Core, as: OwnershipVoucherCore
-  alias Astarte.Pairing.FDO.Rendezvous.Core, as: RendezvousCore
+  alias Astarte.Pairing.FDO.Rendezvous.RvTO2Addr
   alias Astarte.Pairing.FDO.Types.Hash
   alias Astarte.Pairing.Queries
   alias COSE.Messages.Sign1
@@ -113,8 +113,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
     nonce = session.nonce
     device_pub_key = session.device_public_key
 
-    {:ok, current_rendezvous_info} =
-      RendezvousCore.get_rv_to2_addr_entry("#{realm_name}.#{Config.base_domain!()}")
+    current_rendezvous_info = RvTO2Addr.for_realm(realm_name)
 
     {:ok, ownership_voucher} =
       OwnershipVoucher.fetch(realm_name, device_guid)

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -25,6 +25,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
   """
 
   alias Astarte.Pairing.Config
+  alias Astarte.Pairing.FDO.OwnerOnboarding.DeviceAttestation
   alias Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice
   alias Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdr
   alias Astarte.Pairing.FDO.OwnerOnboarding.Session
@@ -49,6 +50,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
            Session.new(realm_name, hello_device, ownership_voucher, owner_private_key) do
       num_ov_entries = Enum.count(ownership_voucher.entries)
       hello_device_hash = Hash.new(:sha256, cbor_hello_device)
+      eb_sig_info = DeviceAttestation.eb_sig_info(session.device_signature)
 
       prove_ovh =
         %ProveOVHdr{
@@ -56,6 +58,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
           cbor_hmac: ownership_voucher.cbor_hmac,
           num_ov_entries: num_ov_entries,
           nonce_to2_prove_ov: hello_device.nonce,
+          eb_sig_info: eb_sig_info,
           xa_key_exchange: session.xa,
           hello_device_hash: hello_device_hash,
           max_owner_message_size: @max_owner_message_size

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/core.ex
@@ -17,47 +17,6 @@
 #
 
 defmodule Astarte.Pairing.FDO.OwnerOnboarding.Core do
-  @sha256 -16
-  # @sha384 -43
-  # @hmac_sha256 5
-  # @hmac_sha384 6
-
-  def compute_hello_device_hash(cbor_hello_device) do
-    hash = :crypto.hash(:sha256, cbor_hello_device)
-    [@sha256, hash]
-  end
-
-  def hmac(ownership_voucher) do
-    [_, _, hmac, _, _] = ownership_voucher
-    hmac
-  end
-
-  def ov_last_entry_public_key(ownership_voucher) do
-    ownership_voucher.entries
-    |> List.last()
-    |> extract_entry_public_key()
-    |> decode_public_key()
-  end
-
-  defp extract_entry_public_key(%CBOR.Tag{
-         tag: 18,
-         value: [
-           _protected,
-           _unprotected,
-           %CBOR.Tag{value: public_key},
-           _signature
-         ]
-       }) do
-    public_key
-  end
-
-  defp decode_public_key(cbor_public_key) do
-    {:ok, [_, _, _, [_, _, %CBOR.Tag{tag: _, value: public_key}]], ""} =
-      CBOR.decode(cbor_public_key)
-
-    public_key
-  end
-
   def counter_mode_kdf(mac_type, mac_subtype, n, secret, context, l) do
     do_counter_mode_kdf(mac_type, mac_subtype, n, secret, context, l, <<>>)
   end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/device_attestation.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/device_attestation.ex
@@ -1,0 +1,23 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnerOnboarding.DeviceAttestation do
+  @empty_binary COSE.tag_as_byte(<<>>)
+
+  def eb_sig_info({ecc, _}) when ecc in [:es256, :es384], do: @empty_binary
+end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/eatoken.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/eatoken.ex
@@ -1,0 +1,71 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnerOnboarding.EAToken do
+  alias COSE.Messages.Sign1
+
+  @known_payload_claims %{
+    10 => :nonce,
+    256 => :ueid,
+    -257 => :fdo,
+    -259 => :euphnonce
+  }
+
+  @known_unprotected_header_claims %{
+    -258 => :maroeprefix
+  }
+
+  def verify_decode_cbor(
+        eatoken_cbor,
+        device_public_key,
+        extra_payload_claims \\ %{},
+        extra_unprotected_header_claims \\ %{}
+      ) do
+    with {:ok, eatoken_message} <- Sign1.verify_decode(eatoken_cbor, device_public_key),
+         {:ok, payload} <- verify_payload(eatoken_message.payload, extra_payload_claims) do
+      unprotected_headers =
+        translate_unprotected_headers(eatoken_message.uhdr, extra_unprotected_header_claims)
+
+      {:ok, %{eatoken_message | payload: payload, uhdr: unprotected_headers}}
+    else
+      _ -> :error
+    end
+  end
+
+  defp translate_unprotected_headers(unprotected_headers, extra_claims) do
+    known_claims = Map.merge(@known_unprotected_header_claims, extra_claims)
+    translate_claims(unprotected_headers, known_claims)
+  end
+
+  defp verify_payload(payload, extra_claims) do
+    known_claims = Map.merge(@known_payload_claims, extra_claims)
+
+    case CBOR.decode(payload) do
+      {:ok, raw_claims = %{}, _} -> {:ok, translate_claims(raw_claims, known_claims)}
+      _ -> :error
+    end
+  end
+
+  defp translate_claims(claims, known_claims) do
+    claims
+    |> Map.new(fn {claim_id, value} ->
+      claim = Map.get(known_claims, claim_id, claim_id)
+      {claim, value}
+    end)
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/prove_ov_hdr.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/prove_ov_hdr.ex
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdrPayload do
+defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdr do
   @moduledoc """
   Represents the internal payload for TO2.ProveOVHdr (Type 61).
 
@@ -32,10 +32,16 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdrPayload do
   Reference Section: 5.5.3 TO2.ProveOVHdr
   """
   use TypedStruct
-  alias Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdrPayload
 
-  typedstruct enforce: true do
-    @typedoc "The 8-element payload to be signed inside COSE_Sign1."
+  alias Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdr
+  alias Astarte.Pairing.FDO.Types.Hash
+  alias COSE.Messages.Sign1
+
+  @cupd_nonce_tag 256
+  @cuph_owner_pubkey_tag 257
+
+  typedstruct do
+    @typedoc "The payload to be signed inside COSE_Sign1."
 
     # 1. OVHeader
     # The header of the Ownership Voucher. 
@@ -56,7 +62,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdrPayload do
     # 4. NonceTO2ProveOV
     # The nonce received from the Device in TO2.HelloDevice.
     # Proves liveness and prevents replay attacks of the HelloDevice message.
-    field :nonce_hello_device, binary()
+    field :nonce_to2_prove_ov, binary()
 
     # 5. eBSigInfo
     # Contains information about the signature scheme used by the Device 
@@ -78,21 +84,27 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdrPayload do
     # Indicates the maximum message size the Owner Service can handle.
     # The Device uses this to fragment large responses if necessary.
     field :max_owner_message_size, non_neg_integer()
+
+    # CBOR encoded ov header
+    field :cbor_ov_header, binary()
+
+    # CBOR encoded hmac
+    field :cbor_hmac, binary()
   end
 
   @doc """
   Converts the struct into the raw CBOR list required for the COSE payload.
   Order: [OVHeader, NumOVEntries, HMac, NonceTO2ProveOV, eBSigInfo, xAKeyExchange, HelloDeviceHash, MaxOwnerMessageSize]
   """
-  def build_to2_proveovhdr_payload(%ProveOVHdrPayload{} = p) do
+  def encode(%ProveOVHdr{} = p) do
     [
-      p.ov_header,
+      ov_header(p),
       p.num_ov_entries,
-      p.hmac,
-      p.nonce_hello_device,
+      hmac(p),
+      p.nonce_to2_prove_ov,
       p.eb_sig_info,
       p.xa_key_exchange,
-      p.hello_device_hash,
+      Hash.encode(p.hello_device_hash),
       p.max_owner_message_size
     ]
   end
@@ -101,10 +113,37 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveOVHdrPayload do
   Encodes the ProveOVHdrPayload struct into CBOR format (binary).
   This binary is what will be subsequently signed and wrapped in the COSE_Sign1 structure.
   """
-  @spec encode(t()) :: binary()
-  def encode(%ProveOVHdrPayload{} = p) do
+  def encode_cbor(p) do
     p
-    |> build_to2_proveovhdr_payload()
+    |> encode()
     |> CBOR.encode()
+  end
+
+  def encode_sign(p, dv_nonce, owner_public_key, owner_private_key) do
+    payload = encode_cbor(p)
+
+    uhdr = %{
+      @cupd_nonce_tag => dv_nonce,
+      @cuph_owner_pubkey_tag => owner_public_key
+    }
+
+    %Sign1{payload: payload, uhdr: uhdr}
+    |> Sign1.sign_encode_cbor(owner_private_key)
+  end
+
+  defp ov_header(prove_ovhdr) do
+    case {prove_ovhdr.cbor_ov_header, prove_ovhdr.ov_header} do
+      {nil, nil} -> raise "invalid proveovh message #{inspect(prove_ovhdr)}"
+      {cbor, nil} -> cbor
+      {_, _ov_header} -> raise "todo: convert ov header"
+    end
+  end
+
+  defp hmac(prove_ovhdr) do
+    case {prove_ovhdr.cbor_hmac, prove_ovhdr.hmac} do
+      {nil, nil} -> raise "invalid proveovh message #{inspect(prove_ovhdr)}"
+      {cbor, nil} -> cbor
+      {_, _hmac} -> raise "todo: convert hmac"
+    end
   end
 end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/core.ex
@@ -55,6 +55,17 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher.Core do
     end
   end
 
+  def entry_private_key(entry) do
+    with {:ok, entry} <- COSE.Messages.Sign1.decode(entry),
+         %CBOR.Tag{tag: :bytes, value: entry} <- entry.payload,
+         {:ok, entry, _} <- CBOR.decode(entry),
+         [_hash_prev, _hash_hdr, _extra, pub_key] <- entry do
+      {:ok, pub_key}
+    else
+      _ -> :error
+    end
+  end
+
   defp header_tag(decoded_voucher) do
     with [_protocol_version, header_tag, _header_hmac, _dev_cert_chain, _entry_array] <-
            decoded_voucher,

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/ownership_voucher.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/ownership_voucher.ex
@@ -53,6 +53,12 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher do
     end
   end
 
+  def owner_public_key(ownership_voucher) do
+    # TODO: handle ownership vouchers without entries
+    List.last(ownership_voucher.entries)
+    |> Core.entry_private_key()
+  end
+
   def device_public_key(ownership_voucher) do
     # The FIDO Device Onboard public key is in the leaf certificate (the "end-entity" key),
     # which is the first element of the x5chain sequence

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/core.ex
@@ -20,20 +20,13 @@ defmodule Astarte.Pairing.FDO.Rendezvous.Core do
   require Logger
 
   alias Astarte.Pairing.FDO.Cbor.Core, as: CBORCore
+  alias Astarte.Pairing.FDO.Rendezvous.RvTO2Addr
   alias COSE.Messages.Sign1
-
-  @http 3
-  @load_balancer_port 4003
-
-  def get_rv_to2_addr_entry(full_dns_name, pre_existing_entries \\ []) do
-    rv_entry = CBORCore.build_rv_to2_addr_entry(nil, full_dns_name, @load_balancer_port, @http)
-    {:ok, [rv_entry] ++ pre_existing_entries}
-  end
 
   def build_owner_sign_message(decoded_ownership_voucher, owner_key, nonce, addr_entries) do
     to0d = CBORCore.build_to0d(decoded_ownership_voucher, 3600, nonce)
     to1d_to0d_hash = CBORCore.build_to1d_to0d_hash(to0d)
-    to1d_rv = CBORCore.build_to1d_rv(addr_entries)
+    to1d_rv = RvTO2Addr.encode_list(addr_entries)
     blob_payload = CBORCore.build_to1d_blob_payload(to1d_rv, to1d_to0d_hash) |> COSE.tag_as_byte()
     signature = build_cose_sign1(blob_payload, owner_key)
 

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/rv_to2_addr.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/rv_to2_addr.ex
@@ -1,0 +1,80 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.Rendezvous.RvTO2Addr do
+  use TypedStruct
+
+  alias Astarte.Pairing.Config
+  alias Astarte.Pairing.FDO.Rendezvous.RvTO2Addr
+  alias Astarte.PairingWeb.Endpoint
+
+  @protocol_to_id %{
+    tcp: 1,
+    tls: 2,
+    http: 3,
+    coap: 4,
+    https: 5,
+    coaps: 6
+  }
+
+  @type protocol :: :tcp | :tls | :http | :coap | :https | :coaps
+
+  typedstruct do
+    field :ip, binary() | nil
+    field :dns, String.t() | nil
+    field :port, non_neg_integer()
+    field :protocol, protocol()
+  end
+
+  def for_realm(realm_name) do
+    base_domain = Config.base_domain!()
+    dns = "#{realm_name}.#{base_domain}"
+    {protocol, port} = default_endpoint_config()
+
+    %RvTO2Addr{dns: dns, port: port, protocol: protocol}
+  end
+
+  def encode(rv_to2_addr) do
+    %RvTO2Addr{ip: ip, dns: dns, port: port, protocol: protocol} = rv_to2_addr
+    protocol_id = encode_protocol(protocol)
+
+    [ip, dns, port, protocol_id]
+  end
+
+  def encode_list(rv_to2_addr_list) do
+    rv_to2_addr_list
+    |> Enum.map(&encode/1)
+  end
+
+  @doc false
+  def encode_protocol(protocol) do
+    Map.fetch!(@protocol_to_id, protocol)
+  end
+
+  defp default_endpoint_config do
+    cond do
+      http = Endpoint.config(:http) ->
+        port = Keyword.fetch!(http, :port)
+        {:http, port}
+
+      https = Endpoint.config(:https) ->
+        port = Keyword.fetch!(https, :port)
+        {:https, port}
+    end
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/types/hash.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/types/hash.ex
@@ -23,9 +23,31 @@ defmodule Astarte.Pairing.FDO.Types.Hash do
 
   @type type() :: :sha256 | :sha384 | :hmac_sha256 | :hmac_sha384
 
+  @sha256 -16
+  @sha384 -43
+  @hmac_sha256 5
+  @hmac_sha384 6
+
   typedstruct do
     field :type, type()
     field :hash, binary()
+  end
+
+  def new(hash_type, value) do
+    hash = :crypto.hash(hash_type, value)
+    %Hash{type: hash_type, hash: hash}
+  end
+
+  def encode(hash) do
+    %Hash{type: hash_type, hash: hash} = hash
+
+    type_id = encode_type(hash_type)
+    [type_id, hash]
+  end
+
+  def encode_cbor(hash) do
+    encode(hash)
+    |> CBOR.encode()
   end
 
   def decode(cbor_list) do
@@ -46,11 +68,20 @@ defmodule Astarte.Pairing.FDO.Types.Hash do
 
   defp decode_type(type_int) do
     case type_int do
-      -16 -> {:ok, :sha256}
-      -43 -> {:ok, :sha384}
-      5 -> {:ok, :hmac_sha256}
-      6 -> {:ok, :hmac_sha384}
+      @sha256 -> {:ok, :sha256}
+      @sha384 -> {:ok, :sha384}
+      @hmac_sha256 -> {:ok, :hmac_sha256}
+      @hmac_sha384 -> {:ok, :hmac_sha384}
       _ -> :error
+    end
+  end
+
+  defp encode_type(type) do
+    case type do
+      :sha256 -> @sha256
+      :sha384 -> @sha384
+      :hmac_sha256 -> @hmac_sha256
+      :hmac_sha384 -> @hmac_sha384
     end
   end
 end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/cbor/core_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/cbor/core_test.exs
@@ -28,22 +28,6 @@ defmodule Astarte.Pairing.FDO.Cbor.CoreTest do
     end
   end
 
-  describe "build_rv_to2_addr_entry/4" do
-    test "encodes a single rendezvous entry correctly" do
-      ip = "192.168.1.10"
-      dns = "example.com"
-      port = 8080
-      protocol = "https"
-
-      encoded = Core.build_rv_to2_addr_entry(ip, dns, port, protocol)
-      {:ok, decoded, ""} = CBOR.decode(encoded)
-
-      assert is_list(decoded)
-      [entry] = decoded
-      assert entry == [ip, dns, port, protocol]
-    end
-  end
-
   describe "build_to1d_rv/1" do
     test "encodes a list of rendezvous entries" do
       entries = [

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/core_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/core_test.exs
@@ -20,6 +20,7 @@ defmodule Astarte.Pairing.FDO.Rendezvous.CoreTest do
   use ExUnit.Case, async: true
 
   alias Astarte.Pairing.FDO.Rendezvous.Core
+  alias Astarte.Pairing.FDO.Rendezvous.RvTO2Addr
 
   import Astarte.Helpers.FDO
 
@@ -63,43 +64,6 @@ defmodule Astarte.Pairing.FDO.Rendezvous.CoreTest do
 
     test "fails for cbors with unexpected format", %{not_hello_ack_cbor: cbor} do
       assert {:error, :unexpected_body_format} == Core.get_body_nonce(cbor)
-    end
-  end
-
-  describe "get_rv_to2_addr_entry/2" do
-    test "returns a list of entries with correct types and one element" do
-      {:ok, entries} = Core.get_rv_to2_addr_entry("test1")
-      assert is_list(entries)
-      assert length(entries) == 1
-
-      Enum.each(entries, fn entry ->
-        assert is_binary(entry)
-        {:ok, [decoded], _rest} = CBOR.decode(entry)
-        assert is_list(decoded)
-        assert length(decoded) == 4
-        assert is_nil(Enum.at(decoded, 0))
-        assert is_binary(Enum.at(decoded, 1))
-        assert is_integer(Enum.at(decoded, 2))
-        assert is_integer(Enum.at(decoded, 3))
-      end)
-    end
-
-    test "add an entry to a list of entries, returns with correct types and one more entry" do
-      {:ok, entries} = Core.get_rv_to2_addr_entry("test1")
-      {:ok, entries} = Core.get_rv_to2_addr_entry("test2", entries)
-      assert is_list(entries)
-      assert length(entries) == 2
-
-      Enum.each(entries, fn entry ->
-        assert is_binary(entry)
-        {:ok, [decoded], _rest} = CBOR.decode(entry)
-        assert is_list(decoded)
-        assert length(decoded) == 4
-        assert is_nil(Enum.at(decoded, 0))
-        assert is_binary(Enum.at(decoded, 1))
-        assert is_integer(Enum.at(decoded, 2))
-        assert is_integer(Enum.at(decoded, 3))
-      end)
     end
   end
 
@@ -178,7 +142,7 @@ defmodule Astarte.Pairing.FDO.Rendezvous.CoreTest do
       nonce = <<32, 54, 127, 243, 66, 48, 228, 115, 59, 186, 230, 246, 198, 179, 113, 78>>
       owner_key = sample_extracted_rsa_private_key()
       ownership_voucher = sample_voucher()
-      {:ok, addr_entries} = Core.get_rv_to2_addr_entry("test1")
+      addr_entries = [RvTO2Addr.for_realm("test1")]
 
       %{
         nonce: nonce,

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/rv_to2_addr_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/rv_to2_addr_test.exs
@@ -1,0 +1,60 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.Rendezvous.RvTO2AddrTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.Pairing.FDO.Rendezvous.RvTO2Addr
+  alias Astarte.Pairing.Config
+
+  setup_all do
+    realm = "realm#{System.unique_integer([:positive])}"
+    addr = RvTO2Addr.for_realm(realm)
+
+    %{rv_to2_addr: addr, realm_name: realm}
+  end
+
+  describe "for_realm/1" do
+    test "returns the default configuration for the realm", %{realm_name: realm_name} do
+      realm_config = RvTO2Addr.for_realm(realm_name)
+
+      expected_dns = "#{realm_name}.#{Config.base_domain!()}"
+
+      assert realm_config.port == 4003
+      assert realm_config.protocol == :http
+      assert realm_config.dns == expected_dns
+    end
+  end
+
+  describe "encode/1" do
+    test "returns the list in the expected format", %{rv_to2_addr: addr} do
+      assert [ip, dns, port, protocol] = RvTO2Addr.encode(addr)
+      assert ip == addr.ip
+      assert dns == addr.dns
+      assert port == addr.port
+      assert protocol == RvTO2Addr.encode_protocol(addr.protocol)
+    end
+  end
+
+  describe "encode_list/1" do
+    test "encodes a list of entries", %{rv_to2_addr: addr} do
+      expected = [RvTO2Addr.encode(addr)]
+      assert RvTO2Addr.encode_list([addr]) == expected
+    end
+  end
+end


### PR DESCRIPTION
before, they were cbor encoded twice (!) while the spec does not
encode the entries a single time

reworked the structure a little to divide responsibilities

fetch protocol and port from the endpoint configuration

depends on #1633