### PR TITLE
test: solve trigger cache flakiness

### DIFF
--- a/libs/astarte_events/lib/astarte_events/triggers/cache.ex
+++ b/libs/astarte_events/lib/astarte_events/triggers/cache.ex
@@ -525,7 +525,7 @@ defmodule Astarte.Events.Triggers.Cache do
   """
   def reset_realm_cache(realm_name) do
     ConCache.ets(@event_targets)
-    |> :ets.select_delete([{{{realm_name, :"$1", :"$2", :"$3"}, :"$4"}, [], [true]}])
+    |> :ets.select_delete([{{{realm_name, :"$1", :"$2"}, :"$3"}, [], [true]}])
 
     ConCache.ets(@event_volatile_targets)
     |> :ets.select_delete([{{{realm_name, :"$1", :"$2"}, :"$3"}, [], [true]}])


### PR DESCRIPTION
the delete was using an outdated key for the events cache, resulting
in entries not being deleted correcctly

cherry-picked from the trigger installation pr, needed in order to not have to launch the ci 10 times before it succeeds once