### PR TITLE
fix(pairing): add appropriate variables for rv entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - Unreleased
+- [astarte_pairing] FDO authentication. New environment variables are needed in order to use FDO:
+  - `PAIRING_FDO_RENDEZVOUS_URL` - url of the rendezvous server (default: "http://rendezvous:8041")
+  - `ASTARTE_BASE_URL_DOMAIN` - domain part of the base url of astarte, used by devices to connect during to2 (required)
+  - `ASTARTE_BASE_URL_PORT` - port of the base url of astarte (required)
+  - `ASTARTE_BASE_URL_PROTOCOL` - protocol of the base url of astarte (required)
+
 ## [1.3.0-rc.0] - 2025-11-21
 ### Added
 - [astarte_housekeeping] support network topology replication strategy for the `astarte` keyspace, with the following env vars:

--- a/apps/astarte_pairing/config/dev.exs
+++ b/apps/astarte_pairing/config/dev.exs
@@ -70,3 +70,7 @@ config :phoenix, :stacktrace_depth, 20
 config :astarte_pairing, :broker_url, "mqtts://broker.beta.astarte.cloud:8883/"
 
 config :astarte_pairing, :cfssl_url, "http://localhost:8888"
+
+config :astarte_pairing, :base_url_domain, "api.astarte.localhost"
+config :astarte_pairing, :base_url_port, 4003
+config :astarte_pairing, :base_url_protocol, :http

--- a/apps/astarte_pairing/config/test.exs
+++ b/apps/astarte_pairing/config/test.exs
@@ -96,7 +96,9 @@ config :astarte_pairing,
        System.get_env("CFSSL_API_URL") || "http://localhost:8080"
 
 config :astarte_pairing, :astarte_instance_id, "test"
-config :astarte_pairing, :base_domain, "api.astarte.localhost"
+config :astarte_pairing, :base_url_domain, "api.astarte.localhost"
+config :astarte_pairing, :base_url_port, 4003
+config :astarte_pairing, :base_url_protocol, :http
 
 config :bcrypt_elixir,
   log_rounds: 4

--- a/apps/astarte_pairing/lib/astarte_pairing/config.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/config.ex
@@ -24,6 +24,7 @@ defmodule Astarte.Pairing.Config do
   use Skogsra
 
   alias Astarte.Pairing.CFSSLCredentials
+  alias Astarte.Pairing.Config.BaseURLProtocol
   alias Astarte.Pairing.Config.CQExNodes
 
   @envdoc "The external broker URL which should be used by devices."
@@ -32,9 +33,21 @@ defmodule Astarte.Pairing.Config do
     type: :binary,
     required: true
 
+  @envdoc "The port the ingress is listening on, used for FDO authentication mechanism"
+  app_env :base_url_port, :astarte_pairing, :base_url_port,
+    os_env: "ASTARTE_BASE_URL_PORT",
+    type: :integer,
+    required: true
+
+  @envdoc "The protocol the ingress is listening on, used for FDO authentication mechanism"
+  app_env :base_url_protocol, :astarte_pairing, :base_url_protocol,
+    os_env: "ASTARTE_BASE_URL_PROTOCOL",
+    type: BaseURLProtocol,
+    required: true
+
   @envdoc "The astarte base domain, used for FDO authentication mechanism"
-  app_env :base_domain, :astarte_pairing, :base_domain,
-    os_env: "ASTARTE_BASE_DOMAIN",
+  app_env :base_url_domain, :astarte_pairing, :base_url_domain,
+    os_env: "ASTARTE_BASE_URL_DOMAIN",
     type: :binary,
     required: true
 

--- a/apps/astarte_pairing/lib/astarte_pairing/config/base_url_protocol.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/config/base_url_protocol.ex
@@ -1,0 +1,41 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.Pairing.Config.BaseURLProtocol do
+  @moduledoc """
+  The telemetry type that the node should use to report metrics.
+  """
+
+  use Skogsra.Type
+
+  @protocols [:tcp, :tls, :http, :coap, :https, :coaps]
+  @protocol_map Map.new(@protocols, &{Atom.to_string(&1), &1})
+
+  @impl Skogsra.Type
+  def cast(value) when is_binary(value) do
+    Map.fetch(@protocol_map, value)
+  end
+
+  @impl Skogsra.Type
+  def cast(value) when value in @protocols, do: {:ok, value}
+
+  @impl Skogsra.Type
+  def cast(_), do: :error
+end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -128,7 +128,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
       rendezvous_info: current_rendezvous_info,
       owner_pub_key: OwnershipVoucher.owner_public_key(ownership_voucher),
       owner_private_key: private_key,
-      device_info: "owned by astarte - realm #{realm_name}.#{Config.base_domain!()}"
+      device_info: "owned by astarte - realm #{realm_name}.#{Config.base_url_domain!()}"
     }
 
     with {:ok, setup_device_message} <-

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/rv_to2_addr.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/rv_to2_addr.ex
@@ -21,7 +21,6 @@ defmodule Astarte.Pairing.FDO.Rendezvous.RvTO2Addr do
 
   alias Astarte.Pairing.Config
   alias Astarte.Pairing.FDO.Rendezvous.RvTO2Addr
-  alias Astarte.PairingWeb.Endpoint
 
   @protocol_to_id %{
     tcp: 1,
@@ -42,9 +41,10 @@ defmodule Astarte.Pairing.FDO.Rendezvous.RvTO2Addr do
   end
 
   def for_realm(realm_name) do
-    base_domain = Config.base_domain!()
-    dns = "#{realm_name}.#{base_domain}"
-    {protocol, port} = default_endpoint_config()
+    domain = Config.base_url_domain!()
+    port = Config.base_url_port!()
+    protocol = Config.base_url_protocol!()
+    dns = "#{realm_name}.#{domain}"
 
     %RvTO2Addr{dns: dns, port: port, protocol: protocol}
   end
@@ -64,17 +64,5 @@ defmodule Astarte.Pairing.FDO.Rendezvous.RvTO2Addr do
   @doc false
   def encode_protocol(protocol) do
     Map.fetch!(@protocol_to_id, protocol)
-  end
-
-  defp default_endpoint_config do
-    cond do
-      http = Endpoint.config(:http) ->
-        port = Keyword.fetch!(http, :port)
-        {:http, port}
-
-      https = Endpoint.config(:https) ->
-        port = Keyword.fetch!(https, :port)
-        {:https, port}
-    end
   end
 end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/rv_to2_addr_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/rendezvous/rv_to2_addr_test.exs
@@ -33,10 +33,12 @@ defmodule Astarte.Pairing.FDO.Rendezvous.RvTO2AddrTest do
     test "returns the default configuration for the realm", %{realm_name: realm_name} do
       realm_config = RvTO2Addr.for_realm(realm_name)
 
-      expected_dns = "#{realm_name}.#{Config.base_domain!()}"
+      expected_port = Config.base_url_port!()
+      expected_protocol = Config.base_url_protocol!()
+      expected_dns = "#{realm_name}.#{Config.base_url_domain!()}"
 
-      assert realm_config.port == 4003
-      assert realm_config.protocol == :http
+      assert realm_config.port == expected_port
+      assert realm_config.protocol == expected_protocol
       assert realm_config.dns == expected_dns
     end
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,9 @@ services:
     environment:
       PAIRING_CFSSL_URL: "http://cfssl:8080"
       ASTARTE_EVENTS_PRODUCER_AMQP_HOST: "rabbitmq"
-      ASTARTE_BASE_DOMAIN: ${DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN}
+      ASTARTE_BASE_URL_DOMAIN: "${DOCKER_COMPOSE_ASTARTE_BASE_DOMAIN}"
+      ASTARTE_BASE_URL_PORT: 80
+      ASTARTE_BASE_URL_PROTOCOL: "http"
       PAIRING_FDO_RENDEZVOUS_URL: "http://rendezvous:8041"
     restart: on-failure
     depends_on:


### PR DESCRIPTION
add new variables to configure the ingress port and protocol, to be
used for FDO

default to the endpoint's configuration

depends on #1638