### PR TITLE
chore(pairing): device -> owner secure tunnel

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/queries.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/queries.ex
@@ -299,7 +299,12 @@ defmodule Astarte.Pairing.Queries do
   end
 
   def add_session_keys(realm_name, session_key, sevk, svk, sek) do
-    updates = [sevk: sevk, svk: svk, sek: sek]
+    updates = [
+      sevk: :erlang.term_to_binary(sevk),
+      svk: :erlang.term_to_binary(svk),
+      sek: :erlang.term_to_binary(sek)
+    ]
+
     update_session(realm_name, session_key, updates)
   end
 

--- a/apps/astarte_pairing/lib/astarte_pairing_web/plug/decrypt_and_verify.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/plug/decrypt_and_verify.ex
@@ -1,0 +1,40 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2025 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.PairingWeb.Plug.DecryptAndVerify do
+  use Plug.Builder
+
+  import Plug.Conn
+
+  alias Astarte.Pairing.FDO.OwnerOnboarding.Session
+
+  def init(_opts) do
+    nil
+  end
+
+  def call(conn, _opts) do
+    session = conn.assigns.to2_session
+    body = conn.assigns.cbor_body
+
+    # TODO: send error message 101
+    case Session.decrypt_and_verify(session, body) do
+      {:ok, body} -> assign(conn, :cbor_body, body)
+      :error -> conn |> send_resp(500, "") |> halt()
+    end
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
@@ -43,6 +43,10 @@ defmodule Astarte.PairingWeb.Router do
     plug Astarte.PairingWeb.Plug.FDOSession
   end
 
+  pipeline :fdo_tunnel do
+    plug Astarte.PairingWeb.Plug.DecryptAndVerify
+  end
+
   scope "/v1/:realm_name", Astarte.PairingWeb do
     pipe_through :realm_api
 
@@ -61,6 +65,8 @@ defmodule Astarte.PairingWeb.Router do
       pipe_through :fdo_session
 
       post "/msg/62", FDOOnboardingController, :ov_next_entry
+
+      pipe_through :fdo_tunnel
     end
 
     scope "/agent" do

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/session_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/session_test.exs
@@ -115,7 +115,9 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.SessionTest do
       } = context
 
       assert {:ok, session} = Session.derive_key(session, realm_name)
-      assert is_binary(session.sevk)
+      assert %COSE.Keys.Symmetric{k: binary_key, alg: alg} = session.sevk
+      assert is_binary(binary_key)
+      assert alg == :aes_256_gcm
     end
   end
 end


### PR DESCRIPTION
add a pipeline to automagically extract the encoded payload, effectively
performing the device -> owner secure tunnel

depends on #1642