### PR TITLE
fix(rm): deletion for long disconnected devices

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/rpc/data_updater_plant/client.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/rpc/data_updater_plant/client.ex
@@ -17,9 +17,13 @@
 #
 
 defmodule Astarte.RealmManagement.RPC.DataUpdaterPlant.Client do
+  alias Astarte.Core.Device
+
   def start_device_deletion_rpc(realm_name, decoded_id) do
+    encoded_device_id = Device.encode_device_id(decoded_id)
+
     server_via_tuple()
-    |> GenServer.call({:start_device_deletion, {realm_name, decoded_id}})
+    |> GenServer.call({:start_device_deletion, {realm_name, encoded_device_id}})
   end
 
   defp server_via_tuple(), do: {:via, Horde.Registry, {Registry.DataUpdaterRPC, :server}}


### PR DESCRIPTION
dup's rpc server expects an encoded device id for the device deletion
rpc, but rm was sending the decoded device id