### PR TITLE
fix(pairing): align query return format

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/queries.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/queries.ex
@@ -240,7 +240,7 @@ defmodule Astarte.Pairing.Queries do
 
     consistency = Consistency.domain_model(:read)
 
-    Repo.one(query, consistency: consistency)
+    Repo.fetch_one(query, consistency: consistency)
   end
 
   def get_owner_private_key(realm_name, device_id) do
@@ -256,7 +256,7 @@ defmodule Astarte.Pairing.Queries do
 
     consistency = Consistency.domain_model(:read)
 
-    Repo.one(query, consistency: consistency)
+    Repo.fetch_one(query, consistency: consistency)
   end
 
   def create_ownership_voucher(

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/ownership_voucher_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/ownership_voucher_controller_test.exs
@@ -45,7 +45,17 @@ defmodule Astarte.PairingWeb.Controllers.OwnershipVoucherControllerTest do
       |> post(path, @sample_params)
       |> response(200)
 
-      assert Queries.get_owner_private_key(realm_name, sample_device_guid())
+      assert {:ok, _} = Queries.get_ownership_voucher(realm_name, sample_device_guid())
+    end
+
+    test "stores the owner private key", context do
+      %{auth_conn: conn, create_path: path, realm_name: realm_name} = context
+
+      conn
+      |> post(path, @sample_params)
+      |> response(200)
+
+      assert {:ok, _} = Queries.get_owner_private_key(realm_name, sample_device_guid())
     end
 
     test "starts the to0 protocol", context do


### PR DESCRIPTION
The `get_ownership_voucher/2 ` and `get_owner_private_key` functions never returns a tuple (e.g., {:ok, value}).
Instead, it returns:
- a `binary` when a voucher exists
- `nil` when no voucher is found

Because of this, the previous pattern matching on {:ok, voucher} was incorrect and never matched.
This PR updates the functions to correctly handle the actual return tuple.


