### PR TITLE
fix(pairing): send all required headers during fdo

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_fallback_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_fallback_controller.ex
@@ -67,6 +67,7 @@ defmodule Astarte.PairingWeb.FDOFallbackController do
     conn
     |> assign(:correlation_id, correlation_id)
     |> put_status(500)
+    |> put_resp_header("message-type", "255")
     |> render("error.cbor", %{error_code: error_code})
   end
 

--- a/apps/astarte_pairing/lib/astarte_pairing_web/plug/fdo_session.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/plug/fdo_session.ex
@@ -32,9 +32,10 @@ defmodule Astarte.PairingWeb.Plug.FDOSession do
     realm_name = Map.fetch!(conn.path_params, "realm_name")
 
     with [session_key] <- get_req_header(conn, "authorization"),
-         {:ok, session_key} <- Ecto.UUID.dump(session_key),
          {:ok, session} <- Session.fetch(realm_name, session_key) do
-      assign(conn, :to2_session, session)
+      conn
+      |> put_resp_header("authorization", session_key)
+      |> assign(:to2_session, session)
     else
       _ -> FDOFallbackController.invalid_token(conn)
     end


### PR DESCRIPTION
fdo requires two headers to always be sent
- the authorization header for the session
- the message type header for the format of our response