### PR TITLE
fix(pairing): proveovhdr payload encoding

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/device_attestation.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/device_attestation.ex
@@ -17,7 +17,9 @@
 #
 
 defmodule Astarte.Pairing.FDO.OwnerOnboarding.DeviceAttestation do
-  @empty_binary COSE.tag_as_byte(<<>>)
+  alias Astarte.Pairing.FDO.OwnerOnboarding.SignatureInfo
 
-  def eb_sig_info({ecc, _}) when ecc in [:es256, :es384], do: @empty_binary
+  def eb_sig_info({ecc, _} = device_signature) when ecc in [:es256, :es384] do
+    SignatureInfo.from_device_signature(device_signature)
+  end
 end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/signature_info.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/signature_info.ex
@@ -43,6 +43,23 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.SignatureInfo do
     end
   end
 
+  def encode(sig_info) do
+    case sig_info do
+      :es256 -> [@es256, %CBOR.Tag{tag: :bytes, value: <<>>}]
+      :es384 -> [@es384, %CBOR.Tag{tag: :bytes, value: <<>>}]
+      {:eipd10, gid} -> [@eipd10, %CBOR.Tag{tag: :bytes, value: gid}]
+      {:eipd11, gid} -> [@eipd11, %CBOR.Tag{tag: :bytes, value: gid}]
+    end
+  end
+
+  def from_device_signature(device_signature) do
+    case device_signature do
+      {:es256, _} -> :es256
+      {:es384, _} -> :es384
+      epid -> epid
+    end
+  end
+
   @spec validate(t(), OwnershipVoucher.t()) :: {:ok, device_signature()} | :error
   def validate(sig_info, ownership_voucher) do
     with {:ok, device_public_key} <- OwnershipVoucher.device_public_key(ownership_voucher) do

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/types/hash.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/types/hash.ex
@@ -42,7 +42,7 @@ defmodule Astarte.Pairing.FDO.Types.Hash do
     %Hash{type: hash_type, hash: hash} = hash
 
     type_id = encode_type(hash_type)
-    [type_id, hash]
+    [type_id, COSE.tag_as_byte(hash)]
   end
 
   def encode_cbor(hash) do


### PR DESCRIPTION
multiple fields were missing a `tag_as_bytes`, and the signature info
had the wrong typing

with this change, the device successfully validates proveovhdr

depends on #1662