### PR TITLE
fix(pairing): get OV entries from decoded voucher

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -105,7 +105,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
   def ov_next_entry(cbor_body, realm_name, device_id) do
     # entry num represent the current enties we need to check for in the ov
     with {:ok, [entry_num], _} <- CBOR.decode(cbor_body),
-         {:ok, ownership_voucher} <- Queries.get_ownership_voucher(realm_name, device_id) do
+         {:ok, ownership_voucher} <- OwnershipVoucher.fetch(realm_name, device_id) do
       OwnershipVoucherCore.get_ov_entry(ownership_voucher, entry_num)
     end
   end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/core.ex
@@ -17,6 +17,7 @@
 #
 
 defmodule Astarte.Pairing.FDO.OwnershipVoucher.Core do
+  alias Astarte.Pairing.FDO.OwnershipVoucher
   alias Astarte.Pairing.FDO.OwnershipVoucher.Core
 
   @type decoded_voucher :: list()
@@ -95,15 +96,17 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher.Core do
     end
   end
 
-  def get_ov_entry(ownership_voucher, entry_num) do
-    ov_entries = Enum.at(ownership_voucher, 3)
+  def get_ov_entry(_ov, entry_num) when entry_num < 0 do
+    {:error, "invalid_entry_number"}
+  end
 
-    if entry_num < length(ov_entries) && entry_num >= 0 do
-      entry = Enum.at(ov_entries, entry_num)
-      response = [entry_num, entry]
-      {:ok, CBOR.encode(response)}
-    else
-      {:error, "invalid_entry_number"}
+  def get_ov_entry(%OwnershipVoucher{entries: entries}, entry_num) do
+    case Enum.fetch(entries, entry_num) do
+      {:ok, entry} ->
+        {:ok, CBOR.encode([entry_num, entry])}
+
+      :error ->
+        {:error, "invalid_entry_number"}
     end
   end
 


### PR DESCRIPTION
This PR updates the ownership-voucher retrieval and entry-extraction logic to ensure the voucher is decoded before accessing its entries, and refactors the `get_ov_entry/2` function to use the structured `OwnershipVoucher` representation.