### PR TITLE
fix(pairing): handle CBOR tags in message 64

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/eatoken.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/eatoken.ex
@@ -55,8 +55,10 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.EAToken do
   defp verify_payload(payload, extra_claims) do
     known_claims = Map.merge(@known_payload_claims, extra_claims)
 
-    case CBOR.decode(payload) do
-      {:ok, raw_claims = %{}, _} -> {:ok, translate_claims(raw_claims, known_claims)}
+    with %CBOR.Tag{tag: :bytes, value: cbor_payload} <- payload,
+         {:ok, raw_claims = %{}, _} <- CBOR.decode(cbor_payload) do
+      {:ok, translate_claims(raw_claims, known_claims)}
+    else
       _ -> :error
     end
   end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/prove_device.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/prove_device.ex
@@ -94,7 +94,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveDevice do
   # Spec: TO2ProveDevicePayload = [ xBKeyExchange ]
   defp extract_fdo_payload(payload_map) do
     case Map.fetch(payload_map, @eat_fdo_label) do
-      {:ok, [xb_key]} when is_binary(xb_key) -> {:ok, xb_key}
+      {:ok, [%CBOR.Tag{tag: :bytes, value: xb_key}]} when is_binary(xb_key) -> {:ok, xb_key}
       {:ok, _invalid_structure} -> {:error, :invalid_fdo_claim_structure}
       :error -> {:error, :missing_eat_fdo_claim}
     end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/prove_device_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/prove_device_test.exs
@@ -40,10 +40,10 @@ defmodule Astarte.Pairing.OwnerOnboarding.Onboarding.ProveDevice do
     eat_claims = %{
       10 => prove_dv_nonce_val,
       256 => guid_val,
-      -257 => [<<>>]
+      -257 => [COSE.tag_as_byte(<<>>)]
     }
 
-    payload_bin = CBOR.encode(eat_claims)
+    payload_bin = CBOR.encode(eat_claims) |> COSE.tag_as_byte()
 
     COSE.Messages.Sign1.sign_encode_cbor(
       %COSE.Messages.Sign1{


### PR DESCRIPTION
Some data are in CBOR tags and needs to be properly extracted
