### PR TITLE
build(docker): properly cache dependencies

### DIFF
--- a/apps/astarte_appengine_api/Dockerfile
+++ b/apps/astarte_appengine_api/Dockerfile
@@ -7,9 +7,6 @@ RUN apt-get update --allow-releaseinfo-change -y && apt-get install -y build-ess
 
 WORKDIR /app
 
-COPY ../../libs ./libraries
-COPY apps/astarte_appengine_api .  
-
 # Install hex
 RUN mix local.hex --force && \
     mix local.rebar --force && \
@@ -25,6 +22,7 @@ ENV ASTARTE_LIBRARIES_PATH=libraries
 # Cache elixir deps
 ADD apps/astarte_appengine_api/mix.exs ./
 ADD apps/astarte_appengine_api/mix.lock ./
+COPY ../../libs ./libraries
 
 RUN mix do deps.get, deps.compile
 

--- a/apps/astarte_data_updater_plant/Dockerfile
+++ b/apps/astarte_data_updater_plant/Dockerfile
@@ -7,9 +7,6 @@ RUN apt-get update --allow-releaseinfo-change -y && apt-get install -y build-ess
 
 WORKDIR /app
 
-COPY apps/astarte_data_updater_plant/ ./
-COPY libs/ ./libraries
-
 # Install hex
 RUN mix local.hex --force && \
     mix local.rebar --force && \
@@ -24,6 +21,8 @@ ENV ASTARTE_LIBRARIES_PATH=libraries
 # Cache elixir deps
 ADD apps/astarte_data_updater_plant/mix.exs ./
 ADD apps/astarte_data_updater_plant/mix.lock ./
+COPY libs/ ./libraries
+
 RUN mix do deps.get, deps.compile
 
 ADD apps/astarte_data_updater_plant/ .

--- a/apps/astarte_housekeeping/Dockerfile
+++ b/apps/astarte_housekeeping/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update --allow-releaseinfo-change -y && apt-get install -y build-ess
 
 WORKDIR /app
 
-COPY ../../libs ./libraries
-COPY apps/astarte_housekeeping .  
 # Install hex
 RUN mix local.hex --force && \
 mix local.rebar --force && \
@@ -25,6 +23,7 @@ ENV ASTARTE_LIBRARIES_PATH=libraries
 # Cache elixir deps
 ADD apps/astarte_housekeeping/mix.exs ./
 ADD apps/astarte_housekeeping/mix.lock ./
+COPY ../../libs ./libraries
 
 RUN mix do deps.get, deps.compile
 

--- a/apps/astarte_pairing/Dockerfile
+++ b/apps/astarte_pairing/Dockerfile
@@ -7,9 +7,6 @@ RUN apt-get update --allow-releaseinfo-change -y && apt-get install -y build-ess
 
 WORKDIR /app
 
-COPY apps/astarte_pairing/ ./
-COPY ../../libs ./libraries
-
 # Install hex
 RUN mix local.hex --force && \
 mix local.rebar --force && \
@@ -24,6 +21,7 @@ ENV ASTARTE_LIBRARIES_PATH=libraries
 # Cache elixir deps
 ADD apps/astarte_pairing/mix.exs ./
 ADD apps/astarte_pairing/mix.lock ./
+COPY ../../libs ./libraries
 
 RUN mix do deps.get, deps.compile
 

--- a/apps/astarte_realm_management/Dockerfile
+++ b/apps/astarte_realm_management/Dockerfile
@@ -18,15 +18,12 @@ ARG BUILD_ENV=prod
 ENV MIX_ENV=$BUILD_ENV
 ENV ASTARTE_LIBRARIES_PATH=libraries
 
-#copy data_access from library
-COPY ../../libs ./libraries
-COPY apps/astarte_realm_management . 
-
 ENV ASTARTE_LIBRARIES_PATH=libraries
 
 # Cache elixir deps
 ADD apps/astarte_realm_management/mix.exs ./
 ADD apps/astarte_realm_management/mix.lock ./
+COPY ../../libs ./libraries
 
 RUN mix do deps.get, deps.compile
 

--- a/apps/astarte_trigger_engine/Dockerfile
+++ b/apps/astarte_trigger_engine/Dockerfile
@@ -7,9 +7,6 @@ RUN apt-get update --allow-releaseinfo-change -y && apt-get install -y build-ess
 
 WORKDIR /app
 
-COPY ../../libs ./libraries
-COPY apps/astarte_trigger_engine .  
-
 # Install hex
 RUN mix local.hex --force && \
 mix local.rebar --force && \
@@ -26,6 +23,7 @@ ENV ASTARTE_LIBRARIES_PATH=libraries
 # Cache elixir deps
 ADD apps/astarte_trigger_engine/mix.exs ./
 ADD apps/astarte_trigger_engine/mix.lock ./
+COPY ../../libs ./libraries
 
 RUN mix do deps.get, deps.compile
 


### PR DESCRIPTION
only copy the contents of the service **after** the deps have been
compiled, so that changes to the code do not invalidate the cache