### PR TITLE
chore(pairing): added correct error logs for hello_device

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/ownership_voucher.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/ownership_voucher.ex
@@ -71,8 +71,11 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher do
 
   def fetch(realm_name, device_id) do
     case Queries.get_ownership_voucher(realm_name, device_id) do
-      {:ok, ownership_voucher_cbor} -> decode_cbor(ownership_voucher_cbor)
-      _ -> :error
+      {:ok, ownership_voucher_cbor} ->
+        decode_cbor(ownership_voucher_cbor)
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/hello_device_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/hello_device_test.exs
@@ -64,13 +64,13 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDeviceTest do
 
       cbor_payload = CBOR.encode(invalid_payload)
 
-      assert HelloDevice.decode(cbor_payload) == :error
+      assert HelloDevice.decode(cbor_payload) == {:error, :message_body_error}
     end
 
     test "returns error when CBOR decode fails" do
       invalid_binary = "invalid_cbor"
 
-      assert :error == HelloDevice.decode(invalid_binary)
+      assert {:error, :message_body_error} == HelloDevice.decode(invalid_binary)
     end
   end
 

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
@@ -94,8 +94,7 @@ defmodule Astarte.PairingWeb.FDOOnboardingControllerTest do
       message_id: id
     } do
       conn = post(conn, path, CBOR.encode(%{hello: "device"}))
-      # FIXME this should return error 100?
-      assert {500, id} == assert_cbor_error(conn)
+      assert {100, id} == assert_cbor_error(conn)
     end
   end
 


### PR DESCRIPTION
THis PR adds added correct error logs for hello_device to match fdo fallback controller logic according to FDO spec.
