### PR TITLE
chore(pairing): added correct error logs for prove_device

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -165,8 +165,11 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
          {:ok, session} <- Session.build_session_secret(session, realm_name, owner_key, xb),
          {:ok, session} <- Session.derive_key(session, realm_name) do
       resp_msg = build_setup_device_message(connection_credentials, received_setup_dv_nonce)
-
       {:ok, %{setup_dv_nonce: received_setup_dv_nonce, resp: resp_msg, session: session}}
+    else
+      error ->
+        Logger.error("prove_device failed: #{inspect(error)}")
+        error
     end
   end
 
@@ -230,7 +233,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
 
       false ->
         # non-matching proveDv nonces
-        {:error, :prove_dv_nonce_mismatch}
+        {:error, :invalid_message}
     end
   end
 
@@ -241,7 +244,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
 
       false ->
         # non-matching device GUIDs
-        {:error, :device_guid_mismatch}
+        {:error, :invalid_message}
     end
   end
 

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/prove_device.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/prove_device.ex
@@ -101,6 +101,8 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveDevice do
          guid: guid,
          raw_eat_token: binary_msg
        }}
+    else
+      _ -> {:error, :message_body_error}
     end
   end
 
@@ -135,9 +137,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveDevice do
   defp extract_fdo_payload(payload_map) do
     case Map.fetch(payload_map, :fdo) do
       {:ok, [%CBOR.Tag{tag: :bytes, value: xb_key}]} when is_binary(xb_key) -> {:ok, xb_key}
-      # FIXME return valid errors for FDO fallback controller
-      {:ok, _invalid_structure} -> {:error, :invalid_fdo_claim_structure}
-      :error -> {:error, :missing_eat_fdo_claim}
+      _ -> {:error, :message_body_error}
     end
   end
 

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/done_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/done_test.exs
@@ -46,7 +46,7 @@ defmodule Astarte.Pairing.FDO.Onboarding.DoneTest do
     test "returns {:error, TBD} when the ProveDv nonces don't match" do
       mismatch_msg = [%CBOR.Tag{tag: :bytes, value: @wrong_prove_dv_nonce}]
 
-      {:error, :prove_dv_nonce_mismatch} =
+      {:error, :invalid_message} =
         OwnerOnboarding.done(@minimal_to2_session, mismatch_msg)
     end
   end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/prove_device_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/prove_device_test.exs
@@ -171,7 +171,7 @@ defmodule Astarte.Pairing.OwnerOnboarding.Onboarding.ProveDevice do
         context.prove_device_data |> ProveDevice.encode_sign(context.device_key)
 
       # the first check that fails is the one about the EAT FDO claim decode
-      {:error, :invalid_fdo_claim_structure} =
+      {:error, :message_body_error} =
         ProveDevice.decode(prove_device_msg_notag, context.device_key)
     end
   end
@@ -221,7 +221,7 @@ defmodule Astarte.Pairing.OwnerOnboarding.Onboarding.ProveDevice do
 
     creds = dummy_creds()
 
-    assert {:error, :prove_dv_nonce_mismatch} =
+    assert {:error, :invalid_message} =
              OwnerOnboarding.verify_and_build_response(
                realm_name,
                session,
@@ -270,7 +270,7 @@ defmodule Astarte.Pairing.OwnerOnboarding.Onboarding.ProveDevice do
 
     creds = dummy_creds()
 
-    assert :error =
+    assert {:error, :message_body_error} =
              OwnerOnboarding.verify_and_build_response(
                realm_name,
                session,


### PR DESCRIPTION
THis PR adds added correct error logs for prove_device to match fdo fallback controller logic according to FDO spec.