### PR TITLE
fix: crashes on new scylladb versions

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         database:
           - "cassandra:3.11.15"
-          - "scylladb/scylla:5.2.2"
+          - "scylladb/scylla:2025.2.2"
         rabbitmq:
           - "rabbitmq:3.12.0-management"
     services:
@@ -135,7 +135,7 @@ jobs:
       - name: Upload Coverage Results to CodeCov
         # Don't upload more than once per component
         if: |
-          matrix.database == 'scylladb/scylla:5.2.2' &&
+          matrix.database == 'scylladb/scylla:2025.2.2' &&
           ${{ github.repository }} == astarte-platform/astarte
         uses: codecov/codecov-action@v5
         with:

--- a/README.md
+++ b/README.md
@@ -101,3 +101,11 @@ needs.
 Astarte source code is released under the Apache 2 License.
 
 Check the LICENSE file for more information.
+
+## Notice
+
+The docker-compose file uses a version of ScyllaDB licensed under the Business Source License (BSL).
+
+- Development, testing, and demo use is free under the BSL
+- Production use over the defined BSL threshold **requires a commercial license** from [ScyllaDB](https://www.scylladb.com/)
+- For details, see the [ScyllaDB License Agreement](https://github.com/scylladb/scylladb/blob/master/LICENSE-ScyllaDB-Source-Available.md)

--- a/apps/astarte_housekeeping/test/support/helpers/database.ex
+++ b/apps/astarte_housekeeping/test/support/helpers/database.ex
@@ -431,4 +431,14 @@ defmodule Astarte.Housekeeping.Helpers.Database do
   defp execute(keyspace, query, params \\ [], opts \\ []) do
     Repo.query(String.replace(query, ":keyspace", keyspace), params, opts)
   end
+
+  def lightweight_transaction_check(keyspace_name) do
+    lwt_query = """
+    INSERT INTO #{keyspace_name}.kv_store (group, key, value)
+    VALUES ('test', 'test', intAsBlob(0))
+    IF NOT EXISTS
+    """
+
+    Repo.query(lwt_query)
+  end
 end

--- a/doc/pages/architecture/090-database.md
+++ b/doc/pages/architecture/090-database.md
@@ -38,6 +38,18 @@ CREATE KEYSPACE astarte
     durable_writes = true;
 ```
 
+> #### Tablets {: .info}
+>
+> In recent versions of scylladb, we explicitly disable the tablets feature as they break
+> lightweight transactions, which are used within astarte
+>
+> ```sql
+> CREATE KEYSPACE astarte
+>   WITH replication = {'class': 'SimpleStrategy', 'replication_factor': <replication factor>}  AND
+>     durable_writes = true AND
+>     tablets = { 'enabled': false };
+> ```
+
 ```sql
 CREATE TABLE astarte.realms (
   realm_name varchar,
@@ -75,6 +87,18 @@ CREATE KEYSPACE <realm name>
   WITH replication = {'class': 'SimpleStrategy', 'replication_factor': :replication_factor} AND
     durable_writes = true;
 ```
+
+> #### Tablets {: .info}
+>
+> In recent versions of scylladb, we explicitly disable the tablets feature as they break
+> lightweight transactions, which are used within astarte
+>
+> ```sql
+> CREATE KEYSPACE <realm name>
+>   WITH replication = {'class': 'SimpleStrategy', 'replication_factor': :replication_factor} AND
+>     durable_writes = true AND
+>     tablets = { 'enabled': false };
+> ```
 
 ```sql
 CREATE TYPE <realm name>.capabilities (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -225,7 +225,7 @@ services:
 
   # Scylla
   scylla:
-    image: scylladb/scylla:5.2.2
+    image: scylladb/scylla:2025.2.2
     hostname: scylla
     restart: on-failure
     volumes:

--- a/libs/astarte_data_access/.github/workflows/build-workflow.yaml
+++ b/libs/astarte_data_access/.github/workflows/build-workflow.yaml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         database:
           - "cassandra:3.11.15"
-          - "scylladb/scylla:5.2.2"
+          - "scylladb/scylla:2025.2.2"
     services:
       database:
         image: ${{ matrix.database }}


### PR DESCRIPTION
somewhere along the lines scylladb changed the default for 
NetworkReplicationStrategy to use tablets. these are incompatible with
some astarte queries as we need lightweight transactions for some
operations (such as device deletion)

for now, always disable tablets so that the old logic still works.
this is accomplished by always trying to create keyspaces and explicitly
disabling tablets, and in case we're on cassandra or an old version of
scylladb, we catch the failure and try again without specifying an
option (as tablets don't exist at all in those databases)

update scylladb to the new, source available version to align it to the
production environment
