### PR TITLE
chore(pairing): added correct error logs for ov_next_entry

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -103,10 +103,15 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
   end
 
   def ov_next_entry(cbor_body, realm_name, device_id) do
-    # entry num represent the current enties we need to check for in the ov
-    with {:ok, [entry_num], _} <- CBOR.decode(cbor_body),
-         {:ok, ownership_voucher} <- OwnershipVoucher.fetch(realm_name, device_id) do
-      OwnershipVoucherCore.get_ov_entry(ownership_voucher, entry_num)
+    # entry num represent the current entries we need to check for in the ov
+    case CBOR.decode(cbor_body) do
+      {:ok, [entry_num], _} when is_integer(entry_num) ->
+        with {:ok, ownership_voucher} <- OwnershipVoucher.fetch(realm_name, device_id) do
+          OwnershipVoucherCore.get_ov_entry(ownership_voucher, entry_num)
+        end
+
+      _ ->
+        {:error, :message_body_error}
     end
   end
 

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/core.ex
@@ -97,7 +97,7 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher.Core do
   end
 
   def get_ov_entry(_ov, entry_num) when entry_num < 0 do
-    {:error, "invalid_entry_number"}
+    {:error, :invalid_message}
   end
 
   def get_ov_entry(%OwnershipVoucher{entries: entries}, entry_num) do
@@ -106,7 +106,7 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher.Core do
         {:ok, CBOR.encode([entry_num, entry])}
 
       :error ->
-        {:error, "invalid_entry_number"}
+        {:error, :invalid_message}
     end
   end
 

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/ov_next_entry_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/ov_next_entry_test.exs
@@ -63,7 +63,7 @@ defmodule Astarte.Pairing.FDO.Onboarding.OvNextEntryTest do
     end
 
     test "returns error for negative entry_num", %{voucher: voucher} do
-      assert {:error, "invalid_entry_number"} =
+      assert {:error, :invalid_message} =
                Core.get_ov_entry(voucher, -1)
     end
 
@@ -71,7 +71,7 @@ defmodule Astarte.Pairing.FDO.Onboarding.OvNextEntryTest do
       voucher: voucher,
       count: invalid_index
     } do
-      assert {:error, "invalid_entry_number"} =
+      assert {:error, :invalid_message} =
                Core.get_ov_entry(voucher, invalid_index)
     end
   end

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
@@ -127,8 +127,7 @@ defmodule Astarte.PairingWeb.FDOOnboardingControllerTest do
            message_id: id
          } do
       conn = post(conn, path, CBOR.encode(%{next: "entry"}))
-      # FIXME this should return error 100?
-      assert {500, id} == assert_cbor_error(conn)
+      assert {100, id} == assert_cbor_error(conn)
     end
   end
 


### PR DESCRIPTION
THis PR adds added correct error logs for ov_next_entry to match fdo fallback controller logic according to FDO spec.