### PR TITLE
chore(pairing): added correct error logs for device_service_info

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/service_info.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/service_info.ex
@@ -160,7 +160,7 @@ defmodule Astarte.Pairing.FDO.ServiceInfo do
 
   # end
   def handle_message_68(_realm_name, _session_key, _) do
-    {:error, :invalid_payload}
+    {:error, :message_body_error}
   end
 
   defp generate_device_id(%{"devmod:sn" => sn}), do: UUID.uuid5(:oid, sn, :raw)


### PR DESCRIPTION
THis PR adds added correct error logs for device_service_info to match fdo fallback controller logic according to FDO spec.