### PR TITLE
fix(fdo): clean up old sessions

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -583,7 +583,8 @@ defmodule Astarte.Housekeeping.Realms.Queries do
       svk blob,
       sek blob,
       PRIMARY KEY (session_key)
-    );
+    )
+    WITH default_time_to_live = 7200;
     """
 
     with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do

--- a/apps/astarte_housekeeping/priv/migrations/realm/0010_create_device_session_table.sql
+++ b/apps/astarte_housekeeping/priv/migrations/realm/0010_create_device_session_table.sql
@@ -15,4 +15,5 @@ CREATE TABLE :keyspace.to2_sessions (
   svk blob,
   sek blob,
   PRIMARY KEY (session_key)
-);
+)
+WITH default_time_to_live = 7200;

--- a/apps/astarte_pairing/lib/astarte_pairing/queries.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/queries.ex
@@ -33,8 +33,6 @@ defmodule Astarte.Pairing.Queries do
 
   require Logger
 
-  @two_hours 7200
-
   def realm_existing?(realm_name) do
     keyspace_name = Realm.astarte_keyspace_name()
 
@@ -282,8 +280,7 @@ defmodule Astarte.Pairing.Queries do
     with {:ok, session_key} <- Astarte.DataAccess.UUID.dump(session_key) do
       keyspace = Realm.keyspace_name(realm_name)
       consistency = Consistency.device_info(:write)
-      ttl = @two_hours
-      opts = [prefix: keyspace, consistency: consistency, ttl: ttl]
+      opts = [prefix: keyspace, consistency: consistency]
 
       session = %{session | session_key: :erlang.term_to_binary(session_key)}
 
@@ -317,8 +314,7 @@ defmodule Astarte.Pairing.Queries do
     with {:ok, session_key} <- Astarte.DataAccess.UUID.dump(session_key) do
       keyspace = Realm.keyspace_name(realm_name)
       consistency = Consistency.device_info(:write)
-      ttl = @two_hours
-      opts = [prefix: keyspace, consistency: consistency, ttl: ttl]
+      opts = [prefix: keyspace, consistency: consistency]
 
       session_key = :erlang.term_to_binary(session_key)
 

--- a/apps/astarte_pairing/test/support/helpers/database.ex
+++ b/apps/astarte_pairing/test/support/helpers/database.ex
@@ -102,7 +102,8 @@ defmodule Astarte.Helpers.Database do
     svk blob,
     sek blob,
     PRIMARY KEY (session_key)
-  );
+  )
+  WITH default_time_to_live = 7200;
   """
 
   @create_devices_table """


### PR DESCRIPTION
This PR sets a default table-wide ttl for to2_sessions and remove custom ttl logic that was previously set in the session related queries.