### PR TITLE
ci: avoid conflicting caches for libs/

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -42,9 +42,9 @@ jobs:
         id: plt_cache
         with:
           path: apps/${{ inputs.app }}/dialyzer_cache
-          key: ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-${{ github.sha }}
+          key: ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', inputs.app, '/mix.lock')) }}-${{ hashFiles(format('{0}{1}', github.workspace, '/libs/')) }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-
+            ${{ runner.os }}-dialyzer_cache-${{ env.otp_version }}-${{ env.elixir_version }}-${{ inputs.app }}-${{ hashFiles(format('{0}{1}{2}{3}', github.workspace, '/apps/', inputs.app, '/mix.lock')) }}-${{ hashFiles(format('{0}{1}', github.workspace, '/libs/')) }}-
       - uses: erlef/setup-beam@v1.15
         with:
           otp-version: ${{ env.otp_version }}


### PR DESCRIPTION
the dialyzer check uses cached PLT, but the key of this cache does not include any hash of libs/, so changes in libs/ may trigger a false politive for the cache hit and result in the dialyzer check failing

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
