### PR TITLE
ci: fail fast for formatting errors

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -19,8 +19,8 @@ env:
   otp_version: "26.1"
 
 jobs:
-  test-dialyzer:
-    name: Check Dialyzer
+  lint:
+    name: Lint
     runs-on: ubuntu-22.04
     env:
       MIX_ENV: ci
@@ -52,6 +52,9 @@ jobs:
       - name: Install Dependencies
         working-directory: ./apps/${{ inputs.app }}
         run: mix deps.get
+      - name: Check formatting
+        working-directory: ./apps/${{ inputs.app }}
+        run: mix format --check-formatted
       - name: Create PLTs dir
         working-directory: ./apps/${{ inputs.app }}
         run: mkdir -p dialyzer_cache && mix dialyzer --plt
@@ -114,9 +117,6 @@ jobs:
       - name: Install Dependencies
         working-directory: ./apps/${{ inputs.app }}
         run: mix deps.get
-      - name: Check formatting
-        working-directory: ./apps/${{ inputs.app }}
-        run: mix format --check-formatted
       - name: Compile
         working-directory: ./apps/${{ inputs.app }}
         run: mix compile --warnings-as-errors --force


### PR DESCRIPTION
the previous implementation checked for formatting in the build job, making it compile and fail twice in case of formatting error.

with this rework, the previous dialyzer workflow is extended to be a generic lint workflow, which can host formatting checks and will also host credo once we finally add it to all services

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
