### PR TITLE
chore(fdo): the owner public key is encoded only when sent to the device

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/core.ex
@@ -19,6 +19,7 @@
 defmodule Astarte.Pairing.FDO.OwnershipVoucher.Core do
   alias Astarte.Pairing.FDO.OwnershipVoucher
   alias Astarte.Pairing.FDO.OwnershipVoucher.Core
+  alias Astarte.Pairing.FDO.Types.PublicKey
 
   @type decoded_voucher :: list()
 
@@ -58,10 +59,11 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher.Core do
 
   def entry_private_key(entry) do
     with {:ok, entry} <- COSE.Messages.Sign1.decode(entry),
-         %CBOR.Tag{tag: :bytes, value: entry} <- entry.payload,
-         {:ok, entry, _} <- CBOR.decode(entry),
-         [_hash_prev, _hash_hdr, _extra, pub_key] <- entry do
-      {:ok, pub_key}
+         %CBOR.Tag{tag: :bytes, value: payload} <- entry.payload,
+         {:ok, decoded_entry, _} <- CBOR.decode(payload),
+         [_hash_prev, _hash_hdr, _extra, pub_key] <- decoded_entry,
+         {:ok, decoded_pubkey} <- PublicKey.decode(pub_key) do
+      {:ok, decoded_pubkey}
     else
       _ -> :error
     end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/ownership_voucher.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/ownership_voucher.ex
@@ -54,7 +54,7 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher do
   end
 
   def owner_public_key(ownership_voucher) do
-    # TODO: handle ownership vouchers without entries
+    # N.B.: Checking if there are entries is not necessary, as by spec the ownership voucher will always have at least one entry
     List.last(ownership_voucher.entries)
     |> Core.entry_private_key()
   end


### PR DESCRIPTION
With this PR the owner public key is handled internally with its decoded struct and encoded only when is sent to the device.
