### PR TITLE
chore(fdo): device should be deleted if fdo process didn’t complete successfully

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -249,13 +249,14 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
     end
   end
 
-  def done(to2_session, body) do
+  def done(realm_name, to2_session, body) do
     # retrieve nonce NonceTO2ProveDv from session and check against incoming nonce from device
     # if match -> retrieve NonceTO2SetupDv from session and send back to device
     with {:ok, %DonePayload{nonce_to2_prove_dv: prove_dv_nonce_challenge}} <-
            DonePayload.decode(body),
          :ok <-
-           check_prove_dv_nonces_equality(prove_dv_nonce_challenge, to2_session.prove_dv_nonce) do
+           check_prove_dv_nonces_equality(prove_dv_nonce_challenge, to2_session.prove_dv_nonce),
+         {:ok, _device} <- Queries.remove_device_ttl(realm_name, to2_session.device_id) do
       done2_message = build_done2_message(to2_session.setup_dv_nonce)
       {:ok, done2_message}
     end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session.ex
@@ -139,6 +139,12 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
     end
   end
 
+  def add_device_id(session, realm_name, device_id) do
+    with :ok <- Queries.session_update_device_id(realm_name, session.key, device_id) do
+      {:ok, %{session | device_id: device_id}}
+    end
+  end
+
   def add_device_service_info(session, realm_name, new_service_info) do
     service_info = encode_values_to_cbor(new_service_info)
     session = update_in(session.device_service_info, &Map.merge(&1 || %{}, service_info))

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
@@ -69,9 +69,10 @@ defmodule Astarte.PairingWeb.FDOOnboardingController do
   end
 
   def done(conn, _params) do
+    realm_name = Map.fetch!(conn.params, "realm_name")
     to2_session = conn.assigns.to2_session
 
-    with {:ok, response_msg} <- OwnerOnboarding.done(to2_session, conn.assigns.body) do
+    with {:ok, response_msg} <- OwnerOnboarding.done(realm_name, to2_session, conn.assigns.body) do
       conn
       |> render("secure.cbor", %{cbor_response: response_msg})
     end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/owner_service_info_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/owner_service_info_test.exs
@@ -30,7 +30,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerServiceInfoTest do
     test "correctly encodes a fragmentation message (IsMore=true)" do
       chunk_data = %{"big_config" => "part_1"}
 
-      expected_service_info =
+      _expected_service_info =
         [
           ["big_config", CBOR.encode("part_1") |> COSE.tag_as_byte()]
         ]
@@ -45,7 +45,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerServiceInfoTest do
       encoded_binary = OwnerServiceInfo.encode(msg)
 
       assert {:ok, decoded_list, ""} = CBOR.decode(encoded_binary)
-      assert [true, false, chunk_data] = decoded_list
+      assert [true, false, _chunk_data] = decoded_list
     end
 
     test "correctly encodes the Done message (IsDone=true)" do

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
@@ -243,7 +243,7 @@ defmodule Astarte.PairingWeb.FDOOnboardingControllerTest do
       setup_authenticated(context, :done, 70)
     end
 
-    test "calls OwnerOnboarding.done/2", %{
+    test "calls OwnerOnboarding.done/3", %{
       conn: conn,
       create_path: path,
       message_id: id,
@@ -252,7 +252,7 @@ defmodule Astarte.PairingWeb.FDOOnboardingControllerTest do
       expected_response = %{"result" => "finished"}
       expected_cbor_response = CBOR.encode(expected_response)
 
-      expect(OwnerOnboarding, :done, fn _, _ -> {:ok, expected_cbor_response} end)
+      expect(OwnerOnboarding, :done, fn _, _, _ -> {:ok, expected_cbor_response} end)
 
       request_body = Session.encrypt_and_sign(session, CBOR.encode(%{done: 1}))
 


### PR DESCRIPTION
**Problem** 

In the current implementation, the device is permanently inserted into the database when the server processes Message 68 (DeviceServiceInfo).

However, the onboarding process is not actually finished until the device receives Message 70 (Done). If a failure occurs in the small window between Message 68 and Message 70, we end up in an inconsistent state, where:

- The Device believes it failed and will eventually retry.
- The Database believes the Device is successfully registered.

**Solution**

Register the device with a ttl and remove the ttl only if we succesfully finish the to2 protocol.
