### PR TITLE
refactor(fdo): move eatoken encode logic to eatoken module

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/eatoken.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/eatoken.ex
@@ -17,18 +17,76 @@
 #
 
 defmodule Astarte.Pairing.FDO.OwnerOnboarding.EAToken do
+  @moduledoc """
+  Functions for encoding and decoding Entity Attestation Tokens (EAT) used in FDO.
+
+  EAT tokens are the COSE_Sign1 objects that contain attestation claims about a device.
+  """
   alias COSE.Messages.Sign1
 
+  # UEID prefix byte as per FDO specification
+  @eat_random <<1>>
+
+  # IANA & FDO EAT Claim mappings (Appendix E & Spec 3.3.6)
   @known_payload_claims %{
+    # EAT-NONCE: Nonce claim for freshness
     10 => :nonce,
+    # UEID: Universal Entity ID claim
     256 => :ueid,
+    # EAT-FDO: FDO Claim wrapping the FDO payload
     -257 => :fdo
   }
 
   @known_unprotected_header_claims %{
-    -258 => :maroeprefix,
-    -259 => :euphnonce
+    -258 => :maroeprefix
   }
+
+  @doc """
+  Builds a UEID (Universal Entity ID) by prepending the FDO-specified prefix byte
+  to the given GUID.
+
+  """
+  def build_ueid(guid), do: @eat_random <> guid
+
+  def parse_ueid(ueid) do
+    case ueid do
+      <<@eat_random, guid::binary-size(16)>> -> {:ok, guid}
+      _ -> {:error, :invalid_ueid}
+    end
+  end
+
+  @doc """
+  Encodes and signs an EAToken with the given payload claims, unprotected header claims,
+  and private key.
+
+  """
+  def encode_sign(
+        payload_claims,
+        uhdr_claims,
+        priv_key,
+        extra_payload_claims \\ %{},
+        extra_unprotected_header_claims \\ %{}
+      ) do
+    eat_payload =
+      translate_claims_encode(
+        payload_claims,
+        @known_payload_claims,
+        extra_payload_claims
+      )
+
+    eat_uhdr =
+      translate_claims_encode(
+        uhdr_claims,
+        @known_unprotected_header_claims,
+        extra_unprotected_header_claims
+      )
+
+    eat_cbor_payload = CBOR.encode(eat_payload)
+    phdr = %{alg: :es256}
+
+    Sign1.build(eat_cbor_payload, phdr, eat_uhdr)
+    |> Sign1.sign_encode_cbor(priv_key)
+  end
 
   def verify_decode_cbor(
         eatoken_cbor,
@@ -84,6 +142,16 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.EAToken do
     |> Map.new(fn {claim_id, value} ->
       claim = Map.get(known_claims, claim_id, claim_id)
       {claim, value}
+    end)
+  end
+
+  defp translate_claims_encode(claims, known_claims, extra_claims) do
+    all_claims = Map.merge(known_claims, extra_claims)
+    atom_to_int = for {int, atom} <- all_claims, into: %{}, do: {atom, int}
+
+    Map.new(claims, fn {key, value} ->
+      int_key = Map.get(atom_to_int, key, key)
+      {int_key, value}
     end)
   end
 end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/prove_device.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/prove_device.ex
@@ -33,22 +33,14 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveDevice do
   # xB keys generation
   alias Astarte.Pairing.FDO.OwnerOnboarding.SessionKey
   alias COSE.Keys.ECC
-  alias COSE.Messages.Sign1
 
-  # Alias per la libreria COSE (da adattare in base alla libreria effettiva in uso su Astarte)
+  # EAToken encoding and decoding
   alias Astarte.Pairing.FDO.OwnerOnboarding.EAToken
 
-  # --- IANA & FDO Constants (Appendix E & Spec 3.3.6) ---
-
-  # EAT-FDO: FDO-specific claim wrapping the FDO payload (Label -257) [cite: 3456]
-  @eat_fdo_label -257
-  @eat_nonce_label 10
-  @eat_ueid_label 256
-  @euph_nonce -259
-
-  @eat_random <<1>>
-
   @nonce_binary_size 16
+
+  # EUPHNonce: Nonce in unprotected headers (Label -259)
+  @euph_nonce -259
 
   typedstruct enforce: true do
     @typedoc "Decoded content of the TO2.ProveDevice message."
@@ -79,17 +71,22 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveDevice do
     field :raw_eat_token, binary()
   end
 
+  def euph_nonce_claim_key, do: @euph_nonce
+
   @doc """
   Decodes the TO2.ProveDevice message, verifies the COSE signature using the
   Device Public Key, and extracts the required FDO fields.
   """
   @spec decode(binary(), any()) :: {:ok, t()} | {:error, atom()}
   def decode(binary_msg, device_pub_key) do
-    with {:ok, cose_object} <- EAToken.verify_decode_cbor(binary_msg, device_pub_key),
+    extra_uhdr_claims = %{euph_nonce_claim_key() => :euph_nonce}
+
+    with {:ok, cose_object} <-
+           EAToken.verify_decode_cbor(binary_msg, device_pub_key, %{}, extra_uhdr_claims),
          {:ok, xb_key} <- extract_fdo_payload(cose_object.payload),
          {:ok, nonce_prove} <- fetch_binary(cose_object.payload, :nonce),
          :ok <- check_expected_binary_size(nonce_prove, @nonce_binary_size),
-         {:ok, nonce_setup} <- fetch_binary(cose_object.uhdr, :euphnonce),
+         {:ok, nonce_setup} <- fetch_binary(cose_object.uhdr, :euph_nonce),
          :ok <- check_expected_binary_size(nonce_setup, @nonce_binary_size),
          {:ok, ueid} <- fetch_binary(cose_object.payload, :ueid),
          {:ok, guid} <- guid_from_ueid(ueid) do
@@ -118,16 +115,20 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveDevice do
   end
 
   def encode_sign(%ProveDevice{} = prove_device_payload, priv_key) do
-    # TODO add a EAToken.encode() function to create the EAT payload
-    eat_cbor_payload =
-      prove_device_payload
-      |> prove_device_payload_to_cbor()
+    payload_claims = %{
+      fdo: [prove_device_payload.xb_key_exchange |> COSE.tag_as_byte()],
+      nonce: prove_device_payload.nonce_to2_prove_dv |> COSE.tag_as_byte(),
+      ueid: EAToken.build_ueid(prove_device_payload.guid) |> COSE.tag_as_byte()
+    }
 
-    phdr = %{alg: :es256}
+    uhdr_claims = %{
+      euph_nonce: prove_device_payload.nonce_to2_setup_dv |> COSE.tag_as_byte()
+    }
 
-    uhdr = %{@euph_nonce => prove_device_payload.nonce_to2_setup_dv |> COSE.tag_as_byte()}
+    # euph_nonce is FDO-specific, not part of standard EAT, so pass as extra claim
+    extra_uhdr_claims = %{@euph_nonce => :euph_nonce}
 
-    Sign1.build(eat_cbor_payload, phdr, uhdr) |> Sign1.sign_encode_cbor(priv_key)
+    EAToken.encode_sign(payload_claims, uhdr_claims, priv_key, %{}, extra_uhdr_claims)
   end
 
   # Extracts xBKeyExchange from the EAT-FDO claim array
@@ -159,18 +160,9 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.ProveDevice do
   end
 
   defp guid_from_ueid(ueid) do
-    case ueid do
-      <<@eat_random::binary, guid::binary-size(16)>> -> {:ok, guid}
-      _ -> {:error, :message_body_error}
+    case EAToken.parse_ueid(ueid) do
+      {:ok, guid} -> {:ok, guid}
+      {:error, :invalid_ueid} -> {:error, :message_body_error}
     end
-  end
-
-  defp prove_device_payload_to_cbor(prove_device_payload) do
-    %{
-      @eat_fdo_label => [prove_device_payload.xb_key_exchange |> COSE.tag_as_byte()],
-      @eat_nonce_label => prove_device_payload.nonce_to2_prove_dv |> COSE.tag_as_byte(),
-      @eat_ueid_label => (@eat_random <> prove_device_payload.guid) |> COSE.tag_as_byte()
-    }
-    |> CBOR.encode()
   end
 end


### PR DESCRIPTION
This PR  moves the custom EAToken encode logic in ProveDevice in a dedicated module.