### PR TITLE
fix(pairing): Return empty owner service info message

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session.ex
@@ -222,7 +222,9 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
         svk: svk,
         sek: sek,
         max_owner_service_info_size: max_owner_service_info_size,
-        device_service_info: device_service_info
+        device_service_info: device_service_info,
+        owner_service_info: owner_service_info,
+        last_chunk_sent: last_chunk_sent
       } = database_session
 
       session = %Session{
@@ -239,7 +241,9 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
         svk: SessionKey.from_db(svk),
         sek: SessionKey.from_db(sek),
         max_owner_service_info_size: max_owner_service_info_size,
-        device_service_info: device_service_info
+        device_service_info: device_service_info,
+        owner_service_info: owner_service_info,
+        last_chunk_sent: last_chunk_sent
       }
 
       {:ok, session}

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/service_info_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/service_info_test.exs
@@ -155,5 +155,35 @@ defmodule Astarte.Pairing.FDO.ServiceInfoTest do
 
       assert is_binary(encoded_owner_service_info)
     end
+
+    test "returns empty owner service info when all chunks are sent", %{
+      realm: realm_name,
+      session: session
+    } do
+      service_info = %{{"devmode", "active"} => true}
+
+      device_info = %DeviceServiceInfo{
+        is_more_service_info: false,
+        service_info: service_info
+      }
+
+      ServiceInfo.build_owner_service_info(realm_name, session, device_info)
+
+      {:ok, session_after} = Session.fetch(realm_name, session.key)
+
+      empty_device_info = %DeviceServiceInfo{
+        is_more_service_info: false,
+        service_info: %{}
+      }
+
+      empty_owner_message = OwnerServiceInfo.empty()
+
+      assert {:ok, empty_owner_message} ==
+               ServiceInfo.build_owner_service_info(
+                 realm_name,
+                 session_after,
+                 empty_device_info
+               )
+    end
   end
 end


### PR DESCRIPTION
When FDO API receives empty device service info message , and all chunks of owner service info are sent, return empty Owner service info message.