### PR TITLE
fix(rpc): don't crash on rm+pairing clustering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- New environment variables for trigger notifications between realm management repliacs and realm management -> pairing. These variables are currently being used only by realm management
+- New environment variables for trigger notifications between realm management replicas and realm management -> pairing. These variables are currently being used only by realm management
   - `REALM_MANAGEMENT_CLUSTERING_KUBERNETES_SELECTOR`. The Endpoint label to query to get other realm management instances. Defaults to `app=astarte-realm-management`.
-  - `PAIRING_CLUSTERING_KUBERNETES_SELECTOR`. The Endpoint label to query to get other realm management instances. Defaults to `app=astarte-pairing`.
+  - `PAIRING_CLUSTERING_KUBERNETES_SELECTOR`. The Endpoint label to query to get pairing instances. Defaults to `app=astarte-pairing`.
+- [astarte_pairing] Cluster with realm management using `CLUSTERING_STRATEGY` and `CLUSTERING_KUBERNETES_NAMESPACE`
 
 ## [1.3.0-rc.0] - 2025-11-21
 

--- a/apps/astarte_realm_management/config/config.exs
+++ b/apps/astarte_realm_management/config/config.exs
@@ -27,8 +27,6 @@ config :phoenix, :json_library, Jason
 # Disable phoenix logger since we're using PlugLoggerWithMeta
 config :phoenix, :logger, false
 
-# TODO: add astarte_realm_management when available: it's needed to notify all realm_management
-# replicas of trigger installation/deletions
 config :astarte_rpc, :astarte_services, [
   :astarte_data_updater_plant,
   :astarte_pairing,

--- a/libs/astarte_rpc/lib/astarte_rpc/config.ex
+++ b/libs/astarte_rpc/lib/astarte_rpc/config.ex
@@ -111,7 +111,7 @@ defmodule Astarte.RPC.Config do
            ]
          ]},
       astarte_pairing:
-        {:realm_management_k8s,
+        {:pairing_k8s,
          [
            strategy: Elixir.Cluster.Strategy.Kubernetes,
            config: [


### PR DESCRIPTION
due to a copy/paste error, realm_management and pairing were sharing the same child id, resulting in a startup crash

depends on #1745 