### PR TITLE
docs(pairing): corrected shell commands in readme to run mix test

### DIFF
--- a/apps/astarte_pairing/README.md
+++ b/apps/astarte_pairing/README.md
@@ -31,7 +31,8 @@ database, (we suggest scylla)
 
 ```shell
 docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
-docker run --rn -d --net=host -p 8080/tcp ispirata/docker-alpine-cfssl-autotest:astarte
+docker run --rm  -d -p 5672:5672 -p 15672:15672 --name rabbit rabbitmq:3.12.0-management
+docker run --rm -d --net=host -p 8080/tcp ispirata/docker-alpine-cfssl-autotest:astarte
 ```
 
 by default `CASSANDRA_NODES` and `CFSSL_API_URL` environment variables map to localhost, so that


### PR DESCRIPTION
This PR fix shell commands in README needed to run Mix Test.