### PR TITLE
test(pairing): fix flakiness

### DIFF
--- a/apps/astarte_pairing/test/support/helpers/database.ex
+++ b/apps/astarte_pairing/test/support/helpers/database.ex
@@ -36,7 +36,7 @@ defmodule Astarte.Helpers.Database do
   """
 
   @drop_keyspace """
-  DROP KEYSPACE :keyspace
+  DROP KEYSPACE IF EXISTS :keyspace
   """
 
   @create_realms_table """
@@ -300,13 +300,13 @@ defmodule Astarte.Helpers.Database do
 
   def teardown_astarte_keyspace do
     astarte_keyspace = Realm.astarte_keyspace_name()
-    execute!(astarte_keyspace, @drop_keyspace)
+    execute!(astarte_keyspace, @drop_keyspace, [], timeout: 60_000)
     :ok
   end
 
   def teardown_realm_keyspace!(realm_name) do
     realm_keyspace = Realm.keyspace_name(realm_name)
-    execute!(realm_keyspace, @drop_keyspace)
+    execute!(realm_keyspace, @drop_keyspace, [], timeout: 60_000)
     :ok
   end
 

--- a/apps/astarte_pairing/test/support/helpers/device.ex
+++ b/apps/astarte_pairing/test/support/helpers/device.ex
@@ -47,7 +47,15 @@ defmodule Astarte.Helpers.Device do
 
     Repo.delete(interface_db, prefix: keyspace)
 
-    capture_log(fn -> RMInterfaces.install_interface(realm_name, interface_params) end)
+    capture_log(fn ->
+      case RMInterfaces.install_interface(realm_name, interface_params) do
+        {:error, reason} ->
+          raise "Failed to install interface #{interface.name} v#{interface.major_version}: #{inspect(reason)}"
+
+        _ ->
+          :ok
+      end
+    end)
   end
 
   def insert_device_cleanly(realm_name, device, interfaces, secret) do


### PR DESCRIPTION
This PR add fixes to errors detected during a 100 mix tests run to check flakyness in the pairing service