### PR TITLE
refactor(pairing): remove redundant fields from OwnershipVoucher

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding.ex
@@ -41,6 +41,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
   alias Astarte.Pairing.FDO.OwnerOnboarding.SetupDevicePayload
   alias Astarte.Pairing.FDO.OwnerOnboarding.DeviceServiceInfoReady
   alias Astarte.Pairing.FDO.OwnerOnboarding.OwnerServiceInfoReady
+  alias Astarte.Pairing.FDO.OwnershipVoucher.Header
 
   require Logger
 
@@ -60,10 +61,13 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding do
       hello_device_hash = Hash.new(:sha256, cbor_hello_device)
       eb_sig_info = DeviceAttestation.eb_sig_info(session.device_signature)
 
+      cbor_ov_header = Header.cbor_encode(ownership_voucher.header)
+      cbor_hmac_list = Hash.encode(ownership_voucher.hmac)
+
       prove_ovh =
         %ProveOVHdr{
-          cbor_ov_header: ownership_voucher.cbor_header,
-          cbor_hmac: ownership_voucher.cbor_hmac,
+          cbor_ov_header: cbor_ov_header,
+          cbor_hmac: cbor_hmac_list,
           num_ov_entries: num_ov_entries,
           nonce_to2_prove_ov: hello_device.nonce,
           eb_sig_info: eb_sig_info,

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/header.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/header.ex
@@ -68,4 +68,23 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher.Header do
       hash -> Hash.decode(hash)
     end
   end
+
+  def encode(%Header{} = header) do
+    [
+      header.protocol_version,
+      COSE.tag_as_byte(header.guid),
+      RendezvousInfo.encode(header.rendezvous_info),
+      header.device_info,
+      PublicKey.encode(header.public_key),
+      encode_cert_chain_hash(header.cert_chain_hash)
+    ]
+  end
+
+  def cbor_encode(%Header{} = header) do
+    encode(header)
+    |> CBOR.encode()
+  end
+
+  defp encode_cert_chain_hash(nil), do: nil
+  defp encode_cert_chain_hash(hash), do: Hash.encode(hash)
 end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/ownership_voucher_encoding_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/ownership_voucher_encoding_test.exs
@@ -1,0 +1,34 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnershipVoucherEncodingTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.Pairing.FDO.OwnershipVoucher
+  alias Astarte.Helpers.FDO
+
+  test "encode_voucher_to_cbor/1 dynamically reconstructs valid CBOR from static sample" do
+    original_cbor = FDO.sample_cbor_voucher()
+
+    {:ok, voucher_struct} = OwnershipVoucher.decode_cbor(original_cbor)
+
+    re_encoded_cbor = OwnershipVoucher.cbor_encode(voucher_struct)
+
+    assert original_cbor == re_encoded_cbor
+  end
+end


### PR DESCRIPTION
- Removes the cbor_header and cbor_hmac fields from the OwnershipVoucher struct.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
