### PR TITLE
test(astarte_rpc): Add tests to the Astarte RPC

### DIFF
--- a/libs/astarte_rpc/coveralls.json
+++ b/libs/astarte_rpc/coveralls.json
@@ -1,0 +1,3 @@
+{
+  "skip_files": ["test", "deps", "_build"]
+}

--- a/libs/astarte_rpc/test/astarte_rpc/config/astarte_services_test.exs
+++ b/libs/astarte_rpc/test/astarte_rpc/config/astarte_services_test.exs
@@ -1,0 +1,62 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RPC.Config.AstarteServicesTest do
+  use ExUnit.Case, async: true
+
+  describe "cast/1" do
+    test "returns ok with valid single service" do
+      assert {:ok, [:astarte_data_updater_plant]} ==
+               Astarte.RPC.Config.AstarteServices.cast([:astarte_data_updater_plant])
+    end
+
+    test "returns ok with multiple valid services" do
+      services = [:astarte_pairing, :astarte_realm_management]
+      assert {:ok, result} = Astarte.RPC.Config.AstarteServices.cast(services)
+      assert MapSet.equal?(MapSet.new(result), MapSet.new(services))
+    end
+
+    test "returns ok with all valid services" do
+      services = [
+        :astarte_data_updater_plant,
+        :astarte_pairing,
+        :astarte_realm_management,
+        :astarte_vmq_plugin
+      ]
+
+      assert {:ok, result} = Astarte.RPC.Config.AstarteServices.cast(services)
+      assert MapSet.equal?(MapSet.new(result), MapSet.new(services))
+    end
+
+    test "returns error with invalid service" do
+      assert :error == Astarte.RPC.Config.AstarteServices.cast([:invalid_service])
+    end
+
+    test "returns error with mix of valid and invalid services" do
+      assert :error ==
+               Astarte.RPC.Config.AstarteServices.cast([
+                 :astarte_pairing,
+                 :invalid_service
+               ])
+    end
+
+    test "returns ok with empty list" do
+      assert {:ok, []} == Astarte.RPC.Config.AstarteServices.cast([])
+    end
+  end
+end

--- a/libs/astarte_rpc/test/astarte_rpc/config/clustering_strategy_test.exs
+++ b/libs/astarte_rpc/test/astarte_rpc/config/clustering_strategy_test.exs
@@ -1,0 +1,54 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RPC.Config.ClusteringStrategyTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.RPC.Config.ClusteringStrategy
+
+  describe "cast/1" do
+    test "casts valid string values" do
+      assert ClusteringStrategy.cast("none") == {:ok, :none}
+      assert ClusteringStrategy.cast("kubernetes") == {:ok, :kubernetes}
+      assert ClusteringStrategy.cast("docker-compose") == {:ok, :docker_compose}
+    end
+
+    test "casts valid atom values" do
+      assert ClusteringStrategy.cast(:none) == {:ok, :none}
+      assert ClusteringStrategy.cast(:kubernetes) == {:ok, :kubernetes}
+      assert ClusteringStrategy.cast(:docker_compose) == {:ok, :docker_compose}
+    end
+
+    test "returns error for invalid string values" do
+      assert ClusteringStrategy.cast("invalid") == :error
+      assert ClusteringStrategy.cast("unknown") == :error
+    end
+
+    test "returns error for invalid atom values" do
+      assert ClusteringStrategy.cast(:invalid) == :error
+      assert ClusteringStrategy.cast(:unknown) == :error
+    end
+
+    test "returns error for non-string, non-atom values" do
+      assert ClusteringStrategy.cast(123) == :error
+      assert ClusteringStrategy.cast([]) == :error
+      assert ClusteringStrategy.cast(%{}) == :error
+      assert ClusteringStrategy.cast(nil) == :error
+    end
+  end
+end

--- a/libs/astarte_rpc/test/astarte_rpc/triggers/triggers_test.exs
+++ b/libs/astarte_rpc/test/astarte_rpc/triggers/triggers_test.exs
@@ -61,6 +61,26 @@ defmodule Astarte.RPC.TriggersTest do
     end
   end
 
+  describe "subscribe_types/1" do
+    test "subscribe_types subscribes to trigger type topics" do
+      types = [:device_trigger]
+
+      Triggers.subscribe_types(types)
+
+      PubSub.broadcast(Server, "trigger-by-type:device_trigger", :msg)
+
+      assert_receive :msg
+    end
+
+    test "subscribe_types with empty list does not subscribe to any topic" do
+      Triggers.subscribe_types([])
+
+      PubSub.broadcast(Server, "trigger-by-type:device_trigger", :msg)
+
+      refute_receive :msg
+    end
+  end
+
   describe "notify_installation/5" do
     test "sends an install trigger message to all the replicas for device triggers", context do
       %{


### PR DESCRIPTION
Test triggers, services and clustering modules in Astarte RPC library.
