### PR TITLE
ci: Add conventional commit check

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -19,3 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: crate-ci/typos@v1.40.0
+  commit:
+    name: Commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: crate-ci/committed@v1.1.10

--- a/committed.toml
+++ b/committed.toml
@@ -1,0 +1,51 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+style = "conventional"
+allowed_types = ["fix", "feat", "perf", "chore", "build", "docs", "style", "refactor", "test", "ci"]
+allowed_scopes = [
+  # services
+  "dup",
+  "rm",
+  "pairing",
+  "housekeeping",
+  "appengine",
+  "te",
+  # libraries
+  "data_access",
+  "events",
+  "rpc",
+  "generators",
+  # tools
+  "e2e",
+  "import",
+  "export",
+  "fleet",
+  # build/dev tools
+  "docker",
+  "credo",
+  "nix",
+]
+merge_commit = false
+imperative_subject = true
+subject_not_punctuated = true
+subject_capitalized = false
+subject_length = 72
+line_length = 100


### PR DESCRIPTION
Add a check for conventional commits using [committed]

As we want to generate the changelog from commit messages, add relevant checks such that entries can be placed in the changelog without manual intervention

A selected list of allowed scopes has been populated, but more can be added if anything's been forgotten

The subject and line length have been set to the maximum recommended by GitHub

See also [how we use it in edgehog] and the [configuration reference]

[committed]: https://github.com/crate-ci/committed
[how we use it in edgehog]: https://github.com/edgehog-device-manager/edgehog/blob/main/committed.toml
[configuration reference]: https://github.com/crate-ci/committed/blob/master/docs/reference.md