### PR TITLE
ci: Use staple actions for docs generation

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -29,16 +29,11 @@ jobs:
         with:
           repository: astarte-platform/docs
           path: docs
-      - uses: erlef/setup-beam@v1.15
-        with:
-          elixir-version: "1.15.7"
-          otp-version: "26.1"
-      - name: Install Dependencies
-        working-directory: ./astarte/doc
-        run: mix deps.get
       - name: Build Docs
-        working-directory: ./astarte/doc
-        run: mix docs
+        uses: team-alembic/staple-actions/actions/mix-docs@a74b3b61209d35d45526df174766632f8aee03ed
+        with:
+          working-directory: ./astarte/doc
+          mix-env: dev
       - name: Copy Docs, preserving Device SDK docs
         run: |
           export DOCS_DIRNAME="astarte/$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-//g')"


### PR DESCRIPTION
Using staple actions reduces complexity, gives us caching for free and takes the elixir version from .tool-versions automatically
