### PR TITLE
ci: Run libraries ci for astarte_generators

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -19,6 +19,7 @@ coverage:
           - astarte_trigger_engine
           - astarte_data_access
           - astarte_events
+          - astarte_generators
           - astarte_rpc
 
 ignore:
@@ -74,6 +75,10 @@ flags:
     carryforward: true
     paths:
       - libs/astarte_events
+  astarte_generators:
+    carryforward: true
+    paths:
+      - libs/astarte_generators
   astarte_rpc:
     carryforward: true
     paths:

--- a/.github/workflows/astarte-generators-workflow.yaml
+++ b/.github/workflows/astarte-generators-workflow.yaml
@@ -1,0 +1,39 @@
+name: Build and Test Astarte Generators
+
+on:
+  # Run when pushing to stable branches
+  push:
+    paths:
+      - "libs/astarte_generators/**"
+      - ".github/workflows/astarte-libs-build-workflow.yaml"
+      - ".github/workflows/astarte-generators-workflow.yaml"
+      - ".github/codecov.yml"
+    branches:
+      - "master"
+      - "release-*"
+
+  # Run on branch/tag creation
+  create:
+
+  # Run on pull requests for astarte_generators lib
+  pull_request:
+    paths:
+      - "libs/astarte_generators/**"
+      - ".github/workflows/astarte-libs-build-workflow.yaml"
+      - ".github/workflows/astarte-generators-workflow.yaml"
+      - ".github/codecov.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  astarte_generators:
+    uses: ./.github/workflows/astarte-libs-build-workflow.yaml
+    with:
+      lib: "astarte_generators"
+    secrets: inherit

--- a/libs/astarte_generators/mix.exs
+++ b/libs/astarte_generators/mix.exs
@@ -27,7 +27,7 @@ defmodule Astarte.Core.Generators.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps() ++ astarte_required_modules(),
       package: package(),
-      dialyzer: dialyzer(),
+      dialyzer: [plt_add_apps: [:ex_unit]],
       test_coverage: [tool: ExCoveralls]
     ]
   end
@@ -45,18 +45,7 @@ defmodule Astarte.Core.Generators.MixProject do
     ]
   end
 
-  defp dialyzer,
-    do: [
-      plt_core_path: dialyzer_cache_directory(Mix.env()),
-      plt_add_apps: [:ex_unit],
-      ignore_warnings: "dialyzer.ignore-warnings",
-      files: ["lib"]
-    ]
-
-  defp dialyzer_cache_directory(:ci), do: "dialyzer_cache"
-  defp dialyzer_cache_directory(_), do: nil
-
-  defp elixirc_paths(env) when env in [:test, :ci], do: ["test/support", "lib"]
+  defp elixirc_paths(:test), do: ["test/support", "lib"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help deps" to learn about dependencies.
@@ -64,9 +53,9 @@ defmodule Astarte.Core.Generators.MixProject do
     [
       {:stream_data, "~> 1.1"},
       # Test section
-      {:dialyxir, "~> 1.4", only: [:dev, :ci], runtime: false},
-      {:credo, "~> 1.7", only: [:dev, :test, :ci], runtime: false},
-      {:excoveralls, "~> 0.15", only: [:test, :ci]},
+      {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},
+      {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
+      {:excoveralls, "~> 0.15", only: :test},
       {:mox, "~> 0.5", only: :test}
     ]
   end


### PR DESCRIPTION
after the merge of generators in the monorepo, the ci was not updated
to run its tests.

fix this by using the same workflow as other libraries
