### PR TITLE
feat(generators)!: allow parameterization of the `group` generator + tests

### DIFF
--- a/libs/astarte_generators/test/astarte/core/generators/group_test.exs
+++ b/libs/astarte_generators/test/astarte/core/generators/group_test.exs
@@ -1,0 +1,49 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Core.Generators.GroupTest do
+  @moduledoc """
+  Tests for Astarte Group generator.
+  """
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Astarte.Core.Generators.Group, as: GroupGenerator
+
+  @moduletag :group
+
+  @doc false
+  describe "group generator fields" do
+    @tag :success
+    property "success valid group name" do
+      check all group_name <- GroupGenerator.name(), max_runs: 500 do
+        assert String.first(group_name) not in ["@", "~", "\s"]
+      end
+    end
+  end
+
+  @doc false
+  describe "group generator struct" do
+    @tag :success
+    property "success base group creation" do
+      check all group <- GroupGenerator.group() do
+        refute is_nil(group)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [x] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:
As a preparatory step for migrating the various tests using `astarte_generators` within the mono-repo, it was necessary to complete the `group` generator.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->

#### Special notes for your reviewer:
Breaking changes if you have used Group generators.

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [x] No

**BREAKING CHANGE**: The group generator doesn't accept whole device structs as parameters anymore