### PR TITLE
refactor(fdo): use a phoenix.token as the session key 

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -554,8 +554,8 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     CREATE TABLE #{keyspace_name}.ownership_vouchers (
       private_key blob,
       voucher_data blob,
-      device_id uuid,
-      PRIMARY KEY (device_id, voucher_data)
+      guid blob,
+      PRIMARY KEY (guid, voucher_data)
     );
     """
 
@@ -567,10 +567,11 @@ defmodule Astarte.Housekeeping.Realms.Queries do
   defp create_to2_sessions_table(keyspace_name) do
     query = """
     CREATE TABLE #{keyspace_name}.to2_sessions (
-      session_key blob,
+      guid blob,
+      device_id uuid,
+      nonce blob,
       sig_type int,
       epid_group blob,
-      device_id uuid,
       device_public_key blob,
       prove_dv_nonce blob,
       setup_dv_nonce blob,
@@ -585,7 +586,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
       device_service_info map<tuple<text, text>, blob>,
       owner_service_info list<blob>,
       last_chunk_sent int,
-      PRIMARY KEY (session_key)
+      PRIMARY KEY (guid)
     )
     WITH default_time_to_live = 7200;
     """

--- a/apps/astarte_housekeeping/priv/migrations/realm/0009_create_ownership_vouchers_table.sql
+++ b/apps/astarte_housekeeping/priv/migrations/realm/0009_create_ownership_vouchers_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE :keyspace.ownership_vouchers (
   private_key blob,
   voucher_data blob,
-  device_id uuid,
-  PRIMARY KEY (device_id, voucher_data)
+  guid blob,
+  PRIMARY KEY (guid, voucher_data)
 );

--- a/apps/astarte_housekeeping/priv/migrations/realm/0010_create_device_session_table.sql
+++ b/apps/astarte_housekeeping/priv/migrations/realm/0010_create_device_session_table.sql
@@ -1,8 +1,9 @@
 CREATE TABLE :keyspace.to2_sessions (
-  session_key blob,
+  guid blob,
+  device_id uuid,
+  nonce blob,
   sig_type int,
   epid_group blob,
-  device_id uuid,
   device_public_key blob,
   prove_dv_nonce blob,
   setup_dv_nonce blob,
@@ -17,6 +18,6 @@ CREATE TABLE :keyspace.to2_sessions (
   device_service_info map<tuple<text, text>, blob>,
   owner_service_info list<blob>,
   last_chunk_sent int,
-  PRIMARY KEY (session_key)
+  PRIMARY KEY (guid)
 )
 WITH default_time_to_live = 7200;

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/hello_device.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/hello_device.ex
@@ -80,7 +80,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice do
     @typedoc "A hello device message structure."
 
     field :max_size, non_neg_integer()
-    field :device_id, binary()
+    field :guid, binary()
     field :nonce, binary()
     field :kex_name, kex_name()
     field :cipher_name, cipher()
@@ -114,7 +114,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice do
 
   defp parse_hello_device([
          max_size,
-         %CBOR.Tag{tag: :bytes, value: device_id},
+         %CBOR.Tag{tag: :bytes, value: guid},
          %CBOR.Tag{tag: :bytes, value: nonce_hello_device},
          kex_name,
          cipher_name,
@@ -126,7 +126,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice do
       {:ok,
        %HelloDevice{
          max_size: max_size,
-         device_id: device_id,
+         guid: guid,
          nonce: nonce_hello_device,
          kex_name: kex_name_str,
          cipher_name: cipher,
@@ -156,7 +156,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice do
   def generate(opts \\ []) do
     defaults = %HelloDevice{
       max_size: 1_000,
-      device_id: Astarte.Core.Device.random_device_id(),
+      guid: Astarte.Core.Device.random_device_id(),
       nonce: :crypto.strong_rand_bytes(16),
       kex_name: "ECDH256",
       cipher_name: :aes_256_gcm,
@@ -169,7 +169,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDevice do
   def encode(hello_device) do
     [
       hello_device.max_size,
-      COSE.tag_as_byte(hello_device.device_id),
+      COSE.tag_as_byte(hello_device.guid),
       COSE.tag_as_byte(hello_device.nonce),
       hello_device.kex_name,
       COSE.algorithm(hello_device.cipher_name),

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session.ex
@@ -25,12 +25,14 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
   alias Astarte.Pairing.FDO.OwnerOnboarding.SignatureInfo
   alias Astarte.Pairing.FDO.OwnerOnboarding.Session
   alias Astarte.Pairing.FDO.OwnerOnboarding.SessionKey
+  alias Astarte.Pairing.FDO.OwnerOnboarding.SessionToken
   alias Astarte.Pairing.Queries
   alias COSE.Messages.Encrypt0
 
   typedstruct do
-    field :key, String.t()
-    field :device_id, Astarte.DataAccess.UUID
+    field :guid, binary()
+    field :device_id, Astarte.DataAccess.UUID, default: nil
+    field :nonce, binary()
     field :device_signature, SignatureInfo.device_signature()
     field :prove_dv_nonce, binary()
     field :setup_dv_nonce, binary()
@@ -49,16 +51,15 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
   end
 
   def new(realm_name, hello_device, ownership_voucher, owner_key) do
-    key = UUID.uuid4(:raw)
     prove_dv_nonce = :crypto.strong_rand_bytes(16)
+    nonce = :crypto.strong_rand_bytes(16)
 
     %HelloDevice{
-      device_id: device_id,
+      guid: guid,
       easig_info: easig_info,
       cipher_name: cipher_suite_name,
       kex_name: kex_name
-    } =
-      hello_device
+    } = hello_device
 
     with {:ok, owner_random, xa} <- SessionKey.new(kex_name, owner_key),
          {:ok, device_signature} <-
@@ -67,7 +68,9 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
            SignatureInfo.device_signature_to_database_params(device_signature),
          session_params =
            %TO2Session{
-             device_id: device_id,
+             guid: guid,
+             device_id: nil,
+             nonce: nonce,
              prove_dv_nonce: prove_dv_nonce,
              kex_suite_name: kex_name,
              cipher_suite_name: cipher_suite_name,
@@ -77,13 +80,16 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
          :ok <-
            Queries.store_session(
              realm_name,
-             key,
+             guid,
              session_params
            ) do
+      token = SessionToken.generate(guid, nonce)
+
       session =
         %Session{
-          key: UUID.binary_to_string!(key),
-          device_id: device_id,
+          guid: guid,
+          device_id: nil,
+          nonce: nonce,
           prove_dv_nonce: prove_dv_nonce,
           kex_suite_name: kex_name,
           cipher_suite: cipher_suite_name,
@@ -92,25 +98,30 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
           device_signature: device_signature
         }
 
-      {:ok, session}
+      {:ok, token, session}
     end
   end
 
   def add_setup_dv_nonce(session, realm_name, setup_dv_nonce) do
-    with :ok <- Queries.session_add_setup_dv_nonce(realm_name, session.key, setup_dv_nonce) do
+    with :ok <- Queries.session_add_setup_dv_nonce(realm_name, session.guid, setup_dv_nonce) do
       {:ok, %{session | setup_dv_nonce: setup_dv_nonce}}
     end
   end
 
   def add_max_owner_service_info_size(session, realm_name, size) do
-    with :ok <- Queries.add_session_max_owner_service_info_size(realm_name, session.key, size) do
+    with :ok <-
+           Queries.add_session_max_owner_service_info_size(realm_name, session.guid, size) do
       {:ok, %{session | max_owner_service_info_size: size}}
     end
   end
 
   def add_owner_service_info(session, realm_name, owner_service_info) do
     with :ok <-
-           Queries.session_add_owner_service_info(realm_name, session.key, owner_service_info) do
+           Queries.session_add_owner_service_info(
+             realm_name,
+             session.guid,
+             owner_service_info
+           ) do
       {:ok, %{session | owner_service_info: owner_service_info}}
     end
   end
@@ -121,7 +132,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
         with :ok <-
                Queries.session_update_last_chunk_sent(
                  realm_name,
-                 session.key,
+                 session.guid,
                  index
                ) do
           {:ok, %{session | last_chunk_sent: index}, service_info_chunk}
@@ -145,7 +156,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
   end
 
   def add_device_id(session, realm_name, device_id) do
-    with :ok <- Queries.session_update_device_id(realm_name, session.key, device_id) do
+    with :ok <- Queries.session_update_device_id(realm_name, session.guid, device_id) do
       {:ok, %{session | device_id: device_id}}
     end
   end
@@ -157,7 +168,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
     with :ok <-
            Queries.session_add_device_service_info(
              realm_name,
-             session.key,
+             session.guid,
              session.device_service_info
            ) do
       {:ok, session}
@@ -172,11 +183,11 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
   end
 
   def build_session_secret(session, realm_name, owner_key, xb) do
-    %Session{kex_suite_name: kex, owner_random: owner_random, key: session_key} = session
+    %Session{kex_suite_name: kex, owner_random: owner_random, guid: guid} = session
 
     with {:ok, secret} <-
            SessionKey.compute_shared_secret(kex, owner_key, owner_random, xb),
-         :ok <- Queries.add_session_secret(realm_name, session_key, secret) do
+         :ok <- Queries.add_session_secret(realm_name, guid, secret) do
       {:ok, %{session | secret: secret}}
     end
   end
@@ -187,13 +198,13 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
       cipher_suite: cipher_suite,
       secret: secret,
       owner_random: owner_random,
-      key: session_key
+      guid: guid
     } = session
 
     with {:ok, sevk, svk, sek} <-
            SessionKey.derive_key(kex_suite_name, cipher_suite, secret, owner_random),
          [db_sevk, db_svk, db_sek] = Enum.map([sevk, svk, sek], &SessionKey.to_db/1),
-         :ok <- Queries.add_session_keys(realm_name, session_key, db_sevk, db_svk, db_sek) do
+         :ok <- Queries.add_session_keys(realm_name, guid, db_sevk, db_svk, db_sek) do
       {:ok, %{session | sevk: sevk, svk: svk, sek: sek}}
     end
   end
@@ -219,12 +230,14 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
     |> Encrypt0.encrypt_encode(cipher, sevk, iv)
   end
 
-  def fetch(realm_name, session_key) do
-    with {:ok, database_session} <- Queries.fetch_session(realm_name, session_key),
+  def fetch(realm_name, guid) do
+    with {:ok, database_session} <- Queries.fetch_session(realm_name, guid),
          {:ok, device_signature} <-
            SignatureInfo.database_params_to_device_signature(database_session) do
       %TO2Session{
+        guid: guid,
         device_id: device_id,
+        nonce: db_nonce,
         prove_dv_nonce: prove_dv_nonce,
         setup_dv_nonce: setup_dv_nonce,
         kex_suite_name: kex_suite_name,
@@ -241,8 +254,9 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.Session do
       } = database_session
 
       session = %Session{
-        key: session_key,
+        guid: guid,
         device_id: device_id,
+        nonce: db_nonce,
         prove_dv_nonce: prove_dv_nonce,
         setup_dv_nonce: setup_dv_nonce,
         kex_suite_name: kex_suite_name,

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session_token.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/owner_onboarding/session_token.ex
@@ -1,0 +1,57 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.Pairing.FDO.OwnerOnboarding.SessionToken do
+  @moduledoc """
+  Handles session tokens for FDO.TO2.
+
+  Uses Phoenix.Token to create and verify signed tokens containing:
+  - guid: The unique device identifier
+  - nonce: A random nonce for replay attack prevention
+  """
+
+  alias Phoenix.Token
+
+  @token_salt "fdo_session_token"
+  # Token valid for 24 hours
+  @max_age 86400
+
+  @doc """
+  Generates a signed token containing guid and nonce.
+
+  """
+  def generate(guid, nonce) do
+    claims = %{guid: guid, nonce: nonce}
+    Token.sign(Astarte.PairingWeb.Endpoint, @token_salt, claims)
+  end
+
+  @doc """
+  Verifies and decodes a token, returning guid and nonce.
+
+  """
+  def verify(token) do
+    case Token.verify(Astarte.PairingWeb.Endpoint, @token_salt, token, max_age: @max_age) do
+      {:ok, %{guid: guid, nonce: nonce}} ->
+        {:ok, guid, nonce}
+
+      {:error, reason} ->
+        # reason can be :invalid, :missing or :expired
+        {:error, reason}
+    end
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/ownership_voucher.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/ownership_voucher/ownership_voucher.ex
@@ -66,8 +66,8 @@ defmodule Astarte.Pairing.FDO.OwnershipVoucher do
     end
   end
 
-  def fetch(realm_name, device_id) do
-    case Queries.get_ownership_voucher(realm_name, device_id) do
+  def fetch(realm_name, guid) do
+    case Queries.get_ownership_voucher(realm_name, guid) do
       {:ok, ownership_voucher_cbor} ->
         decode_cbor(ownership_voucher_cbor)
 

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
@@ -31,10 +31,10 @@ defmodule Astarte.PairingWeb.FDOOnboardingController do
     realm_name = Map.fetch!(conn.params, "realm_name")
     cbor_hello_device = conn.assigns.cbor_body
 
-    with {:ok, session_key, response_msg} <-
+    with {:ok, token, response_msg} <-
            OwnerOnboarding.hello_device(realm_name, cbor_hello_device) do
       conn
-      |> put_resp_header("authorization", session_key)
+      |> put_resp_header("authorization", token)
       |> render("default.cbor", %{cbor_response: response_msg})
     end
   end
@@ -43,10 +43,10 @@ defmodule Astarte.PairingWeb.FDOOnboardingController do
     realm_name = Map.fetch!(conn.params, "realm_name")
     cbor_body = conn.assigns.cbor_body
 
-    device_id = conn.assigns.to2_session.device_id
+    guid = conn.assigns.to2_session.guid
 
     with {:ok, response} <-
-           OwnerOnboarding.ov_next_entry(cbor_body, realm_name, device_id) do
+           OwnerOnboarding.ov_next_entry(cbor_body, realm_name, guid) do
       conn
       |> render("default.cbor", %{cbor_response: response})
     end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/prove_device_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/onboarding/prove_device_test.exs
@@ -115,7 +115,7 @@ defmodule Astarte.Pairing.OwnerOnboarding.Onboarding.ProveDevice do
         xb_key_exchange: xb,
         nonce_to2_prove_dv: session.prove_dv_nonce,
         nonce_to2_setup_dv: @test_setup_dv_nonce,
-        guid: session.device_id,
+        guid: session.guid,
         raw_eat_token: <<>>
       }
       |> ProveDevice.encode_sign(device_key)
@@ -157,7 +157,7 @@ defmodule Astarte.Pairing.OwnerOnboarding.Onboarding.ProveDevice do
         xb_key_exchange: xb,
         nonce_to2_prove_dv: wrong_nonce,
         nonce_to2_setup_dv: @test_setup_dv_nonce,
-        guid: session.device_id,
+        guid: session.guid,
         raw_eat_token: <<>>
       }
       |> ProveDevice.encode_sign(device_key)
@@ -220,7 +220,7 @@ defmodule Astarte.Pairing.OwnerOnboarding.Onboarding.ProveDevice do
         xb_key_exchange: xb,
         nonce_to2_prove_dv: session.prove_dv_nonce,
         nonce_to2_setup_dv: @test_setup_dv_nonce,
-        guid: session.device_id,
+        guid: session.guid,
         raw_eat_token: <<>>
       }
       |> ProveDevice.encode_sign(device_key2)
@@ -252,7 +252,7 @@ defmodule Astarte.Pairing.OwnerOnboarding.Onboarding.ProveDevice do
           xb_key_exchange: xb,
           nonce_to2_prove_dv: session.prove_dv_nonce,
           nonce_to2_setup_dv: @test_setup_dv_nonce,
-          guid: session.device_id,
+          guid: session.guid,
           raw_eat_token: <<>>
         }
         |> ProveDevice.encode_sign(device_key)

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/hello_device_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/hello_device_test.exs
@@ -26,7 +26,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDeviceTest do
     setup do
       valid_data = %{
         max_size: 65_535,
-        device_id: %CBOR.Tag{tag: :bytes, value: <<1, 2, 3, 4>>},
+        guid: %CBOR.Tag{tag: :bytes, value: <<1, 2, 3, 4>>},
         nonce: %CBOR.Tag{tag: :bytes, value: <<5, 6, 7, 8>>},
         kex_name: "DHKEXid14",
         cipher_name: :aes_256_gcm,
@@ -48,11 +48,11 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDeviceTest do
     } do
       assert {:ok, %HelloDevice{} = hello_device} = HelloDevice.decode(cbor)
 
-      %CBOR.Tag{tag: :bytes, value: device_id} = data.device_id
+      %CBOR.Tag{tag: :bytes, value: guid} = data.guid
       %CBOR.Tag{tag: :bytes, value: nonce} = data.nonce
 
       assert hello_device.max_size == data.max_size
-      assert hello_device.device_id == device_id
+      assert hello_device.guid == guid
       assert hello_device.nonce == nonce
       assert hello_device.kex_name == data.kex_name
       assert hello_device.cipher_name == data.cipher_name
@@ -91,6 +91,6 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.HelloDeviceTest do
 
   defp hello_device_list(data) do
     cipher = COSE.algorithm(data.cipher_name)
-    [data.max_size, data.device_id, data.nonce, data.kex_name, cipher, data.easig_info]
+    [data.max_size, data.guid, data.nonce, data.kex_name, cipher, data.easig_info]
   end
 end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/owner_onboarding_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/owner_onboarding_test.exs
@@ -33,7 +33,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerOnboardingTest do
     insert_voucher(realm_name, key_p256_x509, cbor_p256_x509, id_p256_x509)
 
     hello_msg_p256_x509 =
-      HelloDevice.generate(device_id: id_p256_x509, kex_name: "ECDH256", easig_info: :es256)
+      HelloDevice.generate(guid: id_p256_x509, kex_name: "ECDH256", easig_info: :es256)
 
     cbor_hello_p256_x509 = HelloDevice.cbor_encode(hello_msg_p256_x509)
 
@@ -43,7 +43,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerOnboardingTest do
     insert_voucher(realm_name, key_p384_x509, cbor_p384_x509, id_p384_x509)
 
     hello_msg_p384_x509 =
-      HelloDevice.generate(device_id: id_p384_x509, kex_name: "ECDH384", easig_info: :es384)
+      HelloDevice.generate(guid: id_p384_x509, kex_name: "ECDH384", easig_info: :es384)
 
     cbor_hello_p384_x509 = HelloDevice.cbor_encode(hello_msg_p384_x509)
 
@@ -53,7 +53,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerOnboardingTest do
     insert_voucher(realm_name, key_p256_chain, cbor_p256_chain, id_p256_chain)
 
     hello_msg_p256_x5chain =
-      HelloDevice.generate(device_id: id_p256_chain, kex_name: "ECDH256", easig_info: :es256)
+      HelloDevice.generate(guid: id_p256_chain, kex_name: "ECDH256", easig_info: :es256)
 
     cbor_hello_p256_chain = HelloDevice.cbor_encode(hello_msg_p256_x5chain)
 
@@ -63,7 +63,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerOnboardingTest do
     insert_voucher(realm_name, key_p384_chain, cbor_p384_chain, id_p384_chain)
 
     hello_msg_p384_x5chain =
-      HelloDevice.generate(device_id: id_p384_chain, kex_name: "ECDH384", easig_info: :es384)
+      HelloDevice.generate(guid: id_p384_chain, kex_name: "ECDH384", easig_info: :es384)
 
     cbor_hello_p384_x5chain = HelloDevice.cbor_encode(hello_msg_p384_x5chain)
 
@@ -77,19 +77,19 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerOnboardingTest do
 
   describe "hello_device/2" do
     test "P-256 Flow: negotiates ECDH256 and ES256", %{realm_name: realm_name, p256_x509: ctx} do
-      assert {:ok, session_key, resp_binary} =
+      assert {:ok, token, resp_binary} =
                OwnerOnboarding.hello_device(realm_name, ctx.cbor_hello)
 
-      assert is_binary(session_key)
+      assert is_binary(token)
       assert {:ok, sign1_msg} = Sign1.decode_cbor(resp_binary)
       assert sign1_msg.phdr.alg == :es256
     end
 
     test "P-384 Flow: negotiates ECDH384 and ES384", %{realm_name: realm_name, p384_x509: ctx} do
-      assert {:ok, session_key, resp_binary} =
+      assert {:ok, token, resp_binary} =
                OwnerOnboarding.hello_device(realm_name, ctx.cbor_hello)
 
-      assert is_binary(session_key)
+      assert is_binary(token)
       assert {:ok, sign1_msg} = Sign1.decode_cbor(resp_binary)
       assert sign1_msg.phdr.alg == :es384
     end
@@ -99,10 +99,10 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerOnboardingTest do
     realm_name: realm_name,
     p256_chain: ctx
   } do
-    assert {:ok, session_key, resp_binary} =
+    assert {:ok, token, resp_binary} =
              OwnerOnboarding.hello_device(realm_name, ctx.cbor_hello)
 
-    assert is_binary(session_key)
+    assert is_binary(token)
     assert {:ok, sign1_msg} = Sign1.decode_cbor(resp_binary)
     assert sign1_msg.phdr.alg == :es256
   end
@@ -111,10 +111,10 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.OwnerOnboardingTest do
     realm: realm_name,
     p384_chain: ctx
   } do
-    assert {:ok, session_key, resp_binary} =
+    assert {:ok, token, resp_binary} =
              OwnerOnboarding.hello_device(realm_name, ctx.cbor_hello)
 
-    assert is_binary(session_key)
+    assert is_binary(token)
     assert {:ok, sign1_msg} = Sign1.decode_cbor(resp_binary)
     assert sign1_msg.phdr.alg == :es384
   end

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/session_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/owner_onboarding/session_test.exs
@@ -35,10 +35,10 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.SessionTest do
         ownership_voucher: ownership_voucher
       } = context
 
-      assert {:ok, session} =
+      assert {:ok, _token, session} =
                Session.new(realm_name, hello_device, ownership_voucher, owner_key)
 
-      assert is_binary(session.key)
+      assert is_binary(session.guid)
       assert session.prove_dv_nonce
       assert session.owner_random
       assert session.xa
@@ -205,7 +205,7 @@ defmodule Astarte.Pairing.FDO.OwnerOnboarding.SessionTest do
       p384_device_key = COSE.Keys.ECC.generate(:es384)
       {:ok, _dev_rand, xb} = SessionKey.new("ECDH384", p384_device_key)
 
-      {:ok, session} =
+      {:ok, _token, session} =
         Session.new(realm_name, hello_device, p384_voucher, p384_owner_key)
 
       {:ok, session_with_secret} =

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/service_info_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/service_info_test.exs
@@ -59,18 +59,18 @@ defmodule Astarte.Pairing.FDO.ServiceInfoTest do
       xb: xb
     } = context
 
-    {:ok, session} =
+    {:ok, token, session} =
       Session.new(realm_name, hello_device, ownership_voucher, owner_key)
 
     on_exit(fn ->
       setup_database_access(astarte_instance_id)
-      delete_session(realm_name, session.key)
+      delete_session(realm_name, session.guid)
     end)
 
     {:ok, session} = Session.build_session_secret(session, realm_name, owner_key, xb)
     {:ok, session} = Session.derive_key(session, realm_name)
 
-    %{session: session}
+    %{session: session, token: token}
   end
 
   describe "build_owner_service_info/3 when device has more data" do
@@ -95,7 +95,7 @@ defmodule Astarte.Pairing.FDO.ServiceInfoTest do
                  device_info
                )
 
-      {:ok, session_after} = Session.fetch(realm_name, session.key)
+      {:ok, session_after} = Session.fetch(realm_name, session.guid)
 
       assert expected_service_info == session_after.device_service_info
     end
@@ -124,11 +124,11 @@ defmodule Astarte.Pairing.FDO.ServiceInfoTest do
         service_info: second_service_info
       }
 
-      {:ok, session} = Session.fetch(realm_name, session.key)
+      {:ok, session} = Session.fetch(realm_name, session.guid)
 
       ServiceInfo.build_owner_service_info(realm_name, session, device_info)
 
-      {:ok, session_after} = Session.fetch(realm_name, session.key)
+      {:ok, session_after} = Session.fetch(realm_name, session.guid)
 
       assert expected_service_info == session_after.device_service_info
     end
@@ -169,7 +169,7 @@ defmodule Astarte.Pairing.FDO.ServiceInfoTest do
 
       ServiceInfo.build_owner_service_info(realm_name, session, device_info)
 
-      {:ok, session_after} = Session.fetch(realm_name, session.key)
+      {:ok, session_after} = Session.fetch(realm_name, session.guid)
 
       empty_device_info = %DeviceServiceInfo{
         is_more_service_info: false,

--- a/apps/astarte_pairing/test/support/cases/fdo_session.ex
+++ b/apps/astarte_pairing/test/support/cases/fdo_session.ex
@@ -114,10 +114,10 @@ defmodule Astarte.Cases.FDOSession do
       HelloDevice.generate(
         kex_name: kex_name,
         easig_info: context.device_key.alg,
-        device_id: context.device_id
+        guid: context.device_id
       )
 
-    {:ok, session} =
+    {:ok, token, session} =
       Session.new(
         context.realm_name,
         hello_device,
@@ -127,7 +127,7 @@ defmodule Astarte.Cases.FDOSession do
 
     on_exit(fn ->
       setup_database_access(context.astarte_instance_id)
-      delete_session(context.realm_name, session.key)
+      delete_session(context.realm_name, session.guid)
     end)
 
     {:ok, session} =
@@ -135,7 +135,13 @@ defmodule Astarte.Cases.FDOSession do
 
     {:ok, session} = Session.derive_key(session, context.realm_name)
 
-    %{hello_device: hello_device, session: session, device_random: device_random, xb: xb}
+    %{
+      hello_device: hello_device,
+      session: session,
+      token: token,
+      device_random: device_random,
+      xb: xb
+    }
   end
 
   defp generate_keys_and_voucher(key_type) do

--- a/apps/astarte_pairing/test/support/helpers/fdo.ex
+++ b/apps/astarte_pairing/test/support/helpers/fdo.ex
@@ -165,11 +165,11 @@ defmodule Astarte.Helpers.FDO do
     CBOR.encode([%CBOR.Tag{tag: :bytes, value: nonce}])
   end
 
-  def insert_voucher(realm_name, private_key, cbor_voucher, device_id) do
+  def insert_voucher(realm_name, private_key, cbor_voucher, guid) do
     %DBOwnershipVoucher{
       voucher_data: cbor_voucher,
       private_key: private_key,
-      device_id: device_id
+      guid: guid
     }
     |> Repo.insert(prefix: Realm.keyspace_name(realm_name))
   end

--- a/libs/astarte_data_access/lib/astarte_data_access/fdo/ownership_voucher.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/fdo/ownership_voucher.ex
@@ -25,13 +25,13 @@ defmodule Astarte.DataAccess.FDO.OwnershipVoucher do
   typed_schema "ownership_vouchers" do
     field :private_key, :binary
     field :voucher_data, :binary, primary_key: true
-    field :device_id, Astarte.DataAccess.UUID, primary_key: true
+    field :guid, Astarte.DataAccess.UUID, primary_key: true
   end
 
   @doc false
   def changeset(%OwnershipVoucher{} = ownership_voucher, attrs) do
     ownership_voucher
-    |> cast(attrs, [:private_key, :voucher_data, :device_id])
-    |> validate_required([:private_key, :voucher_data, :device_id])
+    |> cast(attrs, [:private_key, :voucher_data, :guid])
+    |> validate_required([:private_key, :voucher_data, :guid])
   end
 end

--- a/libs/astarte_data_access/lib/astarte_data_access/fdo/to2_session.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/fdo/to2_session.ex
@@ -39,8 +39,9 @@ defmodule Astarte.DataAccess.FDO.TO2Session do
 
   @primary_key false
   typed_schema "to2_sessions" do
-    field :session_key, :binary, primary_key: true
+    field :guid, :binary, primary_key: true
     field :device_id, Astarte.DataAccess.UUID
+    field :nonce, :binary
     field :sig_type, Ecto.Enum, values: [es256: -7, es384: -35, eipd10: 90, eipd11: 91]
     field :epid_group, :binary
     field :device_public_key, :binary


### PR DESCRIPTION
This PR add a 1:1 relationship between GUID and session for the FDO.TO2 protocol, by using a Phoenix Token where:

- The guid is stored in the claims, that way we can deduce the guid from a given jwt
- A nonce is used to prevent replay attacks
- The token is a string so that it can be valid for the header

This change prevents the situation in which a device start an infinite number of sessions and move forward with all of them, a behaviour that can potentially doss astarte.