### PR TITLE
feat(pairing): FDO feature gate

### DIFF
--- a/.github/workflows/astarte-end-to-end-test-workflow.yaml
+++ b/.github/workflows/astarte-end-to-end-test-workflow.yaml
@@ -142,6 +142,8 @@ jobs:
           astartectl utils gen-keypair test
       - name: Load astarte images
         run: ls ${{ runner.temp }}/*.tar | xargs --max-args 1 docker load --input
+      - name: Enable FDO
+        run: echo "PAIRING_ENABLE_FDO=true" >> .tmp/repos/astarte/.env
       - name: Start all Astarte services
         working-directory: .tmp/repos/astarte
         run: docker compose up -d

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [1.3.0] - Unreleased
-- [astarte_pairing] FDO authentication. New environment variables are needed in order to use FDO:
-  - `PAIRING_FDO_RENDEZVOUS_URL` - url of the rendezvous server (default: "http://rendezvous:8041")
-  - `ASTARTE_BASE_URL_DOMAIN` - domain part of the base url of astarte, used by devices to connect during to2 (required)
-  - `ASTARTE_BASE_URL_PORT` - port of the base url of astarte (required)
-  - `ASTARTE_BASE_URL_PROTOCOL` - protocol of the base url of astarte (required)
+- [astarte_pairing] FDO authentication (EXPERIMENTAL feature, disabled by default). New environment variables are needed in order to use FDO:
+  - `PAIRING_ENABLE_FDO` - whether the FDO feature is enabled or not (default: false)
+  - `PAIRING_FDO_RENDEZVOUS_URL` - URL of the rendezvous server (default: "http://rendezvous:8041")
+  - `ASTARTE_BASE_URL_DOMAIN` - domain part of the base URL of astarte, used by devices to connect in TO2 phase (required if FDO enabled)
+  - `ASTARTE_BASE_URL_PORT` - port of the base URL of astarte (required if FDO enabled)
+  - `ASTARTE_BASE_URL_PROTOCOL` - protocol of the base URL of astarte (required if FDO enabled)
 
 ## [1.3.0-rc.0] - 2025-11-21
 ### Added

--- a/apps/astarte_pairing/config/test.exs
+++ b/apps/astarte_pairing/config/test.exs
@@ -96,6 +96,8 @@ config :astarte_pairing,
        System.get_env("CFSSL_API_URL") || "http://localhost:8080"
 
 config :astarte_pairing, :astarte_instance_id, "test"
+
+config :astarte_pairing, :enable_fdo, true
 config :astarte_pairing, :base_url_domain, "api.astarte.localhost"
 config :astarte_pairing, :base_url_port, 4003
 config :astarte_pairing, :base_url_protocol, :http

--- a/apps/astarte_pairing/lib/astarte_pairing_web/plug/fdo_gate.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/plug/fdo_gate.ex
@@ -1,0 +1,39 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.PairingWeb.Plug.FDOGate do
+  use Plug.Builder
+
+  alias Astarte.Pairing.Config
+
+  def init(_opts) do
+    nil
+  end
+
+  def call(conn, _opts) do
+    case Config.enable_fdo!() do
+      true ->
+        conn
+
+      _ ->
+        conn
+        |> send_resp(404, "")
+        |> halt()
+    end
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
@@ -33,6 +33,10 @@ defmodule Astarte.PairingWeb.Router do
     plug Astarte.PairingWeb.Plug.LogHwId
   end
 
+  pipeline :fdo_feature_gate do
+    plug Astarte.PairingWeb.Plug.FDOGate
+  end
+
   pipeline :fdo do
     plug :accepts, ["cbor"]
     plug :put_view, Astarte.PairingWeb.FDOView
@@ -50,6 +54,8 @@ defmodule Astarte.PairingWeb.Router do
   end
 
   scope "/v1/:realm_name/fdo/101", Astarte.PairingWeb do
+    pipe_through :fdo_feature_gate
+
     pipe_through :fdo
 
     post "/msg/60", FDOOnboardingController, :hello_device
@@ -74,6 +80,7 @@ defmodule Astarte.PairingWeb.Router do
     get "/health", HealthController, :show
 
     scope "/ownership" do
+      pipe_through :fdo_feature_gate
       pipe_through :agent_api
       post "/", OwnershipVoucherController, :create
     end

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
@@ -27,6 +27,7 @@ defmodule Astarte.PairingWeb.FDOOnboardingControllerTest do
   alias Astarte.Pairing.FDO.OwnerOnboarding.DeviceServiceInfo
   alias Astarte.Pairing.FDO.OwnerOnboarding.Session
   alias Astarte.Pairing.FDO.ServiceInfo
+  alias Astarte.Pairing.Config
 
   setup :verify_on_exit!
 
@@ -274,6 +275,23 @@ defmodule Astarte.PairingWeb.FDOOnboardingControllerTest do
 
       conn = post(conn, path, request_body)
       assert {100, id} == assert_cbor_error(conn)
+    end
+  end
+
+  describe "FDO feature disabled" do
+    setup context do
+      setup_authenticated(context, :hello_device, 60)
+    end
+
+    test "makes the /v1/:realm_name/fdo/101 endpoints return a 404 error", %{
+      conn: conn,
+      create_path: path
+    } do
+      stub(Config, :enable_fdo!, fn -> false end)
+
+      conn
+      |> post(path, CBOR.encode(%{hello: "device"}))
+      |> response(404)
     end
   end
 end

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/ownership_voucher_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/ownership_voucher_controller_test.exs
@@ -23,6 +23,7 @@ defmodule Astarte.PairingWeb.Controllers.OwnershipVoucherControllerTest do
 
   alias Astarte.Pairing.Queries
   alias Astarte.Pairing.FDO.Rendezvous
+  alias Astarte.Pairing.Config
 
   import Astarte.Helpers.FDO
 
@@ -69,6 +70,16 @@ defmodule Astarte.PairingWeb.Controllers.OwnershipVoucherControllerTest do
       conn
       |> post(path, @sample_params)
       |> response(200)
+    end
+
+    test "returns a 404 error if FDO feature is disabled", context do
+      %{auth_conn: conn, create_path: path} = context
+
+      stub(Config, :enable_fdo!, fn -> false end)
+
+      conn
+      |> post(path, @sample_params)
+      |> response(404)
     end
   end
 


### PR DESCRIPTION
Implement the FDO feature gate, adding a new env var "PAIRING_ENABLE_FDO" to select whether FDO feature is enabled or not in an Astarte installation (default: false).
When FDO is disabled, all the FDO API endpoints return HTTP error 404 to any client request.

Added relevant unit tests and updated the CHANGELOG.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [X] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [x] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [x] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
