### PR TITLE
test(dup): fix flakyness

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/device.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/device.ex
@@ -427,9 +427,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Device do
         {:error, :interface_loading_failed} ->
           Logger.warning("Failed #{interface} interface loading.")
           {:halt, {:error, :sending_properties_to_interface_failed}}
-
-        {:error, reason} ->
-          {:halt, {:error, reason}}
       end
     end)
   end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/interface_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/interface_test.exs
@@ -123,16 +123,25 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.InterfaceTest do
       %{
         state: state,
         interfaces: interfaces,
+        interface_descriptors: interface_descriptors,
         realm_name: realm_name,
         device: device
       } = context
+
+      descriptors_map =
+        interface_descriptors
+        |> Map.new(fn desc ->
+          {desc.interface_id, desc}
+        end)
 
       valid_interfaces =
         interfaces |> Enum.filter(&(&1.type == :properties and &1.ownership == :device))
 
       check all interface <- member_of(valid_interfaces),
                 mapping_update <- valid_mapping_update_for(interface) do
-        Helpers.Database.insert_values(realm_name, device, interface, [mapping_update])
+        descriptor = Map.fetch!(descriptors_map, interface.interface_id)
+
+        Helpers.Database.insert_values(realm_name, device, interface, descriptor, [mapping_update])
 
         keyspace = Realm.keyspace_name(realm_name)
 

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/time_based_actions_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/time_based_actions_test.exs
@@ -355,6 +355,7 @@ defmodule Astarte.DataUpdaterPlant.TimeBasedActionsTest do
   end
 
   describe "reload_datastream_maximum_storage_retention_on_expiry/2" do
+    @describetag timeout: 120_000
     setup do
       %{realm_names: [realm_name]} = setup_instance()
 


### PR DESCRIPTION
This PR add fixes to errors detected during a 100 mix tests run to check flakyness in the dup service