### PR TITLE
refactor(pairing): use the guid as primary key for vouchers

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -555,7 +555,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
       private_key blob,
       voucher_data blob,
       guid blob,
-      PRIMARY KEY (guid, voucher_data)
+      PRIMARY KEY (guid)
     );
     """
 

--- a/apps/astarte_housekeeping/priv/migrations/realm/0009_create_ownership_vouchers_table.sql
+++ b/apps/astarte_housekeeping/priv/migrations/realm/0009_create_ownership_vouchers_table.sql
@@ -2,5 +2,5 @@ CREATE TABLE :keyspace.ownership_vouchers (
   private_key blob,
   voucher_data blob,
   guid blob,
-  PRIMARY KEY (guid, voucher_data)
+  PRIMARY KEY (guid)
 );

--- a/apps/astarte_housekeeping/test/support/helpers/database.ex
+++ b/apps/astarte_housekeeping/test/support/helpers/database.ex
@@ -72,8 +72,8 @@ defmodule Astarte.Housekeeping.Helpers.Database do
   CREATE TABLE :keyspace.ownership_vouchers (
       private_key blob,
       voucher_data blob,
-      device_id uuid,
-      PRIMARY KEY (device_id, voucher_data)
+      guid blob,
+      PRIMARY KEY (guid)
    );
   """
 

--- a/apps/astarte_pairing/lib/astarte_pairing/queries.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/queries.ex
@@ -241,33 +241,27 @@ defmodule Astarte.Pairing.Queries do
   def get_ownership_voucher(realm_name, guid) do
     keyspace_name = Realm.keyspace_name(realm_name)
 
-    # FIXME: functions that depends on this one shall handle one or more ownership voucher, keeping just the first for now
     query =
       from o in OwnershipVoucher,
         prefix: ^keyspace_name,
-        where: o.guid == ^guid,
-        limit: 1,
         select: o.voucher_data
 
     consistency = Consistency.domain_model(:read)
 
-    Repo.fetch_one(query, consistency: consistency)
+    Repo.fetch(query, guid, consistency: consistency)
   end
 
   def get_owner_private_key(realm_name, guid) do
     keyspace_name = Realm.keyspace_name(realm_name)
 
-    # FIXME: functions that depends on this one shall handle one or more private key, keeping just the first for now
     query =
       from o in OwnershipVoucher,
         prefix: ^keyspace_name,
-        where: o.guid == ^guid,
-        limit: 1,
         select: o.private_key
 
     consistency = Consistency.domain_model(:read)
 
-    Repo.fetch_one(query, consistency: consistency)
+    Repo.fetch(query, guid, consistency: consistency)
   end
 
   def create_ownership_voucher(

--- a/apps/astarte_pairing/test/support/helpers/database.ex
+++ b/apps/astarte_pairing/test/support/helpers/database.ex
@@ -80,7 +80,7 @@ defmodule Astarte.Helpers.Database do
       private_key blob,
       voucher_data blob,
       guid blob,
-      PRIMARY KEY (guid, voucher_data)
+      PRIMARY KEY (guid)
    );
   """
 

--- a/libs/astarte_data_access/lib/astarte_data_access/fdo/ownership_voucher.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/fdo/ownership_voucher.ex
@@ -24,7 +24,7 @@ defmodule Astarte.DataAccess.FDO.OwnershipVoucher do
   @primary_key false
   typed_schema "ownership_vouchers" do
     field :private_key, :binary
-    field :voucher_data, :binary, primary_key: true
+    field :voucher_data, :binary
     field :guid, Astarte.DataAccess.UUID, primary_key: true
   end
 


### PR DESCRIPTION
originally, we had decided to allow multiple ownership vouchers for a single device guid, with the motivation being that the rendezvous server was supposed to be in charge of deciding the validity of ownership vouchers and lift us from that job.

in practice, we implemented our application logic as if there was always a single voucher for a guid, by simply adding `limit: 1` to all our queries. this also added complexity and was investigated as a possible source of bugs multiple times.

for our implementation, supporting multiple vouchers for each guid doesn't really make sense anymore, as our vouchers are short-lived anyway, so let's just allow a single voucher for a guid!
