### PR TITLE
chore(dup): Restore test functionality

### DIFF
--- a/apps/astarte_data_updater_plant/mix.exs
+++ b/apps/astarte_data_updater_plant/mix.exs
@@ -34,7 +34,7 @@ defmodule Astarte.DataUpdaterPlant.Mixfile do
         "coveralls.post": :test,
         "coveralls.html": :test
       ],
-      dialyzer: [plt_add_apps: [:astarte_housekeeping, :astarte_realm_management, :ex_unit]],
+      dialyzer: [plt_add_apps: [:astarte_realm_management, :ex_unit]],
       deps: deps() ++ astarte_required_modules(System.get_env("ASTARTE_IN_UMBRELLA"))
     ]
   end
@@ -64,8 +64,6 @@ defmodule Astarte.DataUpdaterPlant.Mixfile do
       {:astarte_generators, github: "astarte-platform/astarte_generators", only: [:dev, :test]},
       {:astarte_realm_management,
        path: "../astarte_realm_management", only: :test, runtime: false},
-      {:astarte_housekeeping,
-       path: "../astarte_housekeeping", only: :test, env: :dev, runtime: false},
       {:astarte_events, path: astarte_lib("astarte_events")}
     ]
   end
@@ -98,8 +96,6 @@ defmodule Astarte.DataUpdaterPlant.Mixfile do
       {:telemetry_metrics_prometheus_core, "~> 1.2"},
       {:observer_cli, "~> 1.5"},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
-      # TODO: needed to run test because we cannot start the housekeeping application as is
-      {:httpoison, "~> 2.2"},
       {:uuid, "~> 2.0", hex: :uuid_erl},
       {:typedstruct, "~> 0.5"},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false}

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/triggers_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/triggers_handler_test.exs
@@ -46,9 +46,9 @@ defmodule Astarte.DataUpdaterPlant.TriggersHandlerTest do
   alias Astarte.DataUpdaterPlant.Config
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.DataUpdaterPlant.TriggersHandler
+  alias Astarte.Events.AMQP.Vhost
   alias Astarte.Events.Config, as: EventsConfig
   alias Astarte.Events.Triggers.DataTriggerContext
-  alias Astarte.Housekeeping.AMQP.Vhost
 
   @introspection "com.My.Interface:1:0;com.Another.Interface:1:2"
   @introspection_map %{

--- a/apps/astarte_data_updater_plant/test/support/cases/data.ex
+++ b/apps/astarte_data_updater_plant/test/support/cases/data.ex
@@ -30,7 +30,7 @@ defmodule Astarte.Cases.Data do
   use Mimic
   import Astarte.Helpers.Database
 
-  alias Astarte.Housekeeping.AMQP.Vhost
+  alias Astarte.Events.AMQP.Vhost
 
   using opts do
     astarte_instance_id = Keyword.get_lazy(opts, :astarte_instance_id, &astarte_instance_id/0)

--- a/apps/astarte_data_updater_plant/test/support/database_test_helper.ex
+++ b/apps/astarte_data_updater_plant/test/support/database_test_helper.ex
@@ -36,7 +36,7 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
   alias Astarte.DataAccess.Realms.SimpleTrigger
   alias Astarte.DataAccess.Repo
   alias Astarte.DataUpdaterPlant.AMQPTestHelper
-  alias Astarte.Housekeeping.AMQP.Vhost
+  alias Astarte.Events.AMQP.Vhost
 
   @test_realm "autotestrealm"
 


### PR DESCRIPTION
#1798 broke DUP tests as DUP had a test dependency on housekeeping.

Now that astarte events exposes vhost functionality, we can clean up the implementation by dropping the dependency on housekeeping entirely.
