### PR TITLE
ci: Publish docker images

### DIFF
--- a/.github/workflows/publish-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-release-to-dockerhub-workflow.yaml
@@ -1,0 +1,107 @@
+name: Publish Docker images
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  astarte_appengine_api:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_appengine_api"
+    secrets: inherit
+
+  astarte_data_updater_plant:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_data_updater_plant"
+    secrets: inherit
+
+  astarte_housekeeping:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_housekeeping"
+    secrets: inherit
+
+  astarte_pairing:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_pairing"
+    secrets: inherit
+
+  astarte_realm_management:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_realm_management"
+    secrets: inherit
+
+  astarte_trigger_engine:
+    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
+    with:
+      app: "astarte_trigger_engine"
+    secrets: inherit
+
+  e2e_tests:
+    uses: ./.github/workflows/astarte-end-to-end-test-workflow.yaml
+
+  push_release_to_registry:
+    name: Push Docker images to Docker Hub
+    runs-on: ${{ matrix.platform }}
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+        app:
+          - astarte_appengine_api
+          - astarte_data_updater_plant
+          - astarte_housekeeping
+          - astarte_pairing
+          - astarte_realm_management
+          - astarte_trigger_engine
+    needs:
+      - astarte_appengine_api
+      - astarte_data_updater_plant
+      - astarte_housekeeping
+      - astarte_pairing
+      - astarte_realm_management
+      - astarte_trigger_engine
+      - e2e_tests
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            astarte/${{ matrix.app }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Build and push tagged Docker image
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: .
+          file: apps/${{ matrix.app }}/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-tool-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-tool-release-to-dockerhub-workflow.yaml
@@ -1,0 +1,70 @@
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish Docker images of Astarte tools
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  push_tool_release_to_registry:
+    name: Push Docker images of Astarte tools to Docker Hub
+    runs-on: ${{ matrix.platform }}
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+        app:
+          - tool: astarte_device_fleet_simulator
+            context: tools/astarte_device_fleet_simulator
+            file: tools/astarte_device_fleet_simulator/Dockerfile
+          - tool: astarte_e2e
+            context: .
+            file: tools/astarte_e2e/Dockerfile
+          - tool: astarte_export
+            context: .
+            file: tools/astarte_export/Dockerfile
+          - tool: astarte_import
+            context: .
+            file: tools/astarte_import/Dockerfile
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) of Astarte tools for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            astarte/${{ matrix.app.tool }}
+          tags: |
+            type=semver,pattern={{version}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push tagged Docker image of Astarte tools
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ${{ matrix.app.context }}
+          file: ${{ matrix.app.file }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-tool-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-tool-snapshot-to-dockerhub-workflow.yaml
@@ -1,0 +1,82 @@
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Publish snapshot Docker images of Astarte tools
+
+on:
+  push:
+    paths:
+      - "tools/**"
+      - ".github/workflows/publish-tool-snapshot-to-dockerhub-workflow.yaml"
+    branches:
+      - "master"
+      - "release-*"
+  workflow_dispatch:
+
+jobs:
+  push_tool_snapshot_to_registry:
+    name: Push Docker images of Astarte tools to Docker Hub
+    runs-on: ${{ matrix.platform }}
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+        app:
+          - tool: astarte_device_fleet_simulator
+            context: tools/astarte_device_fleet_simulator
+            file: tools/astarte_device_fleet_simulator/Dockerfile
+          - tool: astarte_e2e
+            context: .
+            file: tools/astarte_e2e/Dockerfile
+          - tool: astarte_export
+            context: .
+            file: tools/astarte_export/Dockerfile
+          - tool: astarte_import
+            context: .
+            file: tools/astarte_import/Dockerfile
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Compute tag name for snapshot images of Astarte tools
+        id: compute-tag
+        run: |
+          export TAG="$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-\(.*\)/\1-snapshot/g' )"
+          echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract metadata (tags, labels) of Astarte tools for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: |
+            astarte/${{ matrix.app.tool }}
+          tags: |
+            # TODO we probably want something smarter, but the 'pattern' type runs only on tags at the moment
+            type=raw,value=${{ steps.compute-tag.outputs.TAG }}
+
+      - name: Build and push tagged Docker image of Astarte tools
+        id: push
+        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
+        with:
+          context: ${{ matrix.app.context }}
+          file: ${{ matrix.app.file }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Have the github CI publish docker images instead of relying on dockerhub to build images.

`workflow_dispatch` is added to all workflows in order to allow running them manually from GitHub

backport of #1013 #1008 #960

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, take a look at our developer guide (TODO link dev guide)!
2. Make sure to check these marks:
-->
* [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
* [ ] I have added to [CHANGELOG.md](../CHANGELOG.md) relevant changes and any other user facing change
* [ ] I have added or ran the appropriate tests
<!--
3. If the PR is unfinished, mark it as `[WIP]` in the title
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If there is no related issue, do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

##### Does this PR introduce a user-facing change?
* [ ] Yes
* [ ] No

#### Additional documentation e.g. usage docs, diagrams, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->
```docs

```
