### PR TITLE
ci: Fix snapshot build

### DIFF
--- a/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
@@ -57,7 +57,7 @@ jobs:
 
   push_snapshot_to_registry:
     name: Push Docker images to Docker Hub
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.platform }}
     permissions:
       packages: write
       contents: read
@@ -74,6 +74,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        platform:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
         app:
           - astarte_appengine_api
           - astarte_data_updater_plant
@@ -128,5 +131,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
           annotations: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The snapshot is being built for arm, but it looks like cross-compiling
elixir doesn't work by default, and is also slower than building
on the same architecture.

Let's add the platform to the matrix instead!
