### PR TITLE
ci: Fix snapshot platform build

### DIFF
--- a/.github/workflows/publish-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-release-to-dockerhub-workflow.yaml
@@ -45,9 +45,9 @@ jobs:
   e2e_tests:
     uses: ./.github/workflows/astarte-end-to-end-test-workflow.yaml
 
-  push_release_to_registry:
+  build_release:
     name: Push Docker images to Docker Hub
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform.os }}
     permissions:
       packages: write
       contents: read
@@ -57,8 +57,12 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
+          - os: ubuntu-22.04
+            platform: linux/amd64
+            platform-pair: linux-amd64
+          - os: ubuntu-22.04-arm
+            platform: linux/arm64
+            platform-pair: linux-arm64
         app:
           - astarte_appengine_api
           - astarte_data_updater_plant
@@ -87,6 +91,62 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Build Docker image
+        uses: docker/build-push-action@v6.18.0
+        id: build
+        with:
+          context: .
+          file: apps/${{ matrix.app }}/Dockerfile
+          push: true
+          platforms: ${{ matrix.platform.platform }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.app }}
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ matrix.app }}/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform.platform-pair }}
+          path: ${{ runner.temp }}/digests/${{ matrix.app }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge_images:
+    name: Publish release
+    runs-on: ubuntu-22.04
+    needs:
+      - build_release
+    strategy:
+      fail-fast: true
+      matrix:
+        app:
+          - astarte_appengine_api
+          - astarte_data_updater_plant
+          - astarte_housekeeping
+          - astarte_pairing
+          - astarte_realm_management
+          - astarte_trigger_engine
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/${{ matrix.app }}
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
@@ -96,12 +156,8 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
 
-      - name: Build and push tagged Docker image
-        id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        with:
-          context: .
-          file: apps/${{ matrix.app }}/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests/${{ matrix.app }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ matrix.app }}@sha256:%s ' *)

--- a/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
@@ -55,7 +55,7 @@ jobs:
   e2e_tests:
     uses: ./.github/workflows/astarte-end-to-end-test-workflow.yaml
 
-  push_snapshot_to_registry:
+  build_snapshot:
     name: Push Docker images to Docker Hub
     runs-on: ${{ matrix.platform }}
     permissions:
@@ -75,8 +75,12 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
+          - os: ubuntu-22.04
+            platform: linux/amd64
+            platform-pair: linux-amd64
+          - os: ubuntu-22.04-arm
+            platform: linux/arm64
+            platform-pair: linux-arm64
         app:
           - astarte_appengine_api
           - astarte_data_updater_plant
@@ -88,13 +92,76 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3.4.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build branch slug env variable (job-scoped)
+        run: |
+          # Slugify branch/tag name for Docker tag safety and consistency
+          echo "BRANCH_SLUG=$(echo "${GITHUB_REF_NAME}" | sha1sum | cut -f 1 -d ' ')" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        id: build
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: .
+          file: apps/${{ matrix.app }}/Dockerfile
+          push: true
+          platforms: ${{ matrix.platform.platform }}
+          cache-from: type=gha,scope=${{ matrix.app.name }}-${{ env.BRANCH_SLUG }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app.name }}-${{ env.BRANCH_SLUG }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.app }}
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ matrix.app }}/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform.platform-pair }}
+          path: ${{ runner.temp }}/digests/${{ matrix.app }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge_snapshots:
+    name: Publish snapshot
+    runs-on: ubuntu-22.04
+    needs:
+      - build_snapshot
+    strategy:
+      fail-fast: true
+      matrix:
+        app:
+          - astarte_appengine_api
+          - astarte_data_updater_plant
+          - astarte_housekeeping
+          - astarte_pairing
+          - astarte_realm_management
+          - astarte_trigger_engine
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/${{ matrix.app }}
+          pattern: digests-*
+          merge-multiple: true
+
       - name: Get current datetime
         id: datetime
         run: |
           echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3.4.0
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -122,13 +189,8 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
 
-      - name: Build and push tagged Docker image
-        id: push
-        uses: docker/build-push-action@v6.18.0
-        with:
-          context: .
-          file: apps/${{ matrix.app }}/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          annotations: ${{ steps.meta.outputs.labels }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests/${{ matrix.app }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ matrix.app }}@sha256:%s ' *)

--- a/.github/workflows/publish-tool-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-tool-release-to-dockerhub-workflow.yaml
@@ -10,9 +10,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  push_tool_release_to_registry:
+  build_release:
     name: Push Docker images of Astarte tools to Docker Hub
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform.os }}
     permissions:
       packages: write
       contents: read
@@ -22,8 +22,12 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
+          - os: ubuntu-22.04
+            platform: linux/amd64
+            platform-pair: linux-amd64
+          - os: ubuntu-22.04-arm
+            platform: linux/arm64
+            platform-pair: linux-arm64
         app:
           - tool: astarte_device_fleet_simulator
             context: tools/astarte_device_fleet_simulator
@@ -47,24 +51,71 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Build Docker image
+        uses: docker/build-push-action@v6.18.0
+        id: build
+        with:
+          context: ${{ matrix.app.context }}
+          file: ${{ matrix.app.file }}
+          push: true
+          platforms: ${{ matrix.platform.platform }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.app.tool }}
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ matrix.app.tool }}/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform.platform-pair }}
+          path: ${{ runner.temp }}/digests/${{ matrix.app.tool }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge_images:
+    name: Publish release
+    runs-on: ubuntu-22.04
+    needs:
+      - build_release
+    strategy:
+      fail-fast: true
+      matrix:
+        app:
+          - astarte_device_fleet_simulator
+          - astarte_e2e
+          - astarte_export
+          - astarte_import
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/${{ matrix.app }}
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) of Astarte tools for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: |
-            astarte/${{ matrix.app.tool }}
+            astarte/${{ matrix.app }}
           tags: |
             type=semver,pattern={{version}}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push tagged Docker image of Astarte tools
-        id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        with:
-          context: ${{ matrix.app.context }}
-          file: ${{ matrix.app.file }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests/${{ matrix.app }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ matrix.app }}@sha256:%s ' *)

--- a/.github/workflows/publish-tool-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-tool-snapshot-to-dockerhub-workflow.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   push_tool_snapshot_to_registry:
     name: Push Docker images of Astarte tools to Docker Hub
-    runs-on: ${{ matrix.platform }}
+    runs-on: ${{ matrix.platform.os }}
     permissions:
       packages: write
       contents: read
@@ -27,8 +27,12 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm
+          - os: ubuntu-22.04
+            platform: linux/amd64
+            platform-pair: linux-amd64
+          - os: ubuntu-22.04-arm
+            platform: linux/arm64
+            platform-pair: linux-arm64
         app:
           - tool: astarte_device_fleet_simulator
             context: tools/astarte_device_fleet_simulator
@@ -52,6 +56,76 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Build branch slug env variable (job-scoped)
+        run: |
+          # Slugify branch/tag name for Docker tag safety and consistency
+          echo "BRANCH_SLUG=$(echo "${GITHUB_REF_NAME}" | sha1sum | cut -f 1 -d ' ')" >> $GITHUB_ENV
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        id: build
+        uses: docker/build-push-action@v6.18.0
+        with:
+          context: ${{ matrix.app.context }}
+          file: ${{ matrix.app.file }}
+          push: true
+          platforms: ${{ matrix.platform.platform }}
+          cache-from: type=gha,scope=${{ matrix.app.tool }}-${{ env.BRANCH_SLUG }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app.tool }}-${{ env.BRANCH_SLUG }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests/${{ matrix.app.tool }}
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${{ matrix.app.tool }}/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform.platform-pair }}
+          path: ${{ runner.temp }}/digests/${{ matrix.app.tool }}/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge_snapshots:
+    name: Publish snapshot
+    runs-on: ubuntu-22.04
+    needs:
+      - build_snapshot
+    strategy:
+      fail-fast: true
+      matrix:
+        platform:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+        app:
+          - astarte_device_fleet_simulator
+          - astarte_e2e
+          - astarte_export
+          - astarte_import
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests/${{ matrix.app }}
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Get current datetime
+        id: datetime
+        run: |
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Compute tag name for snapshot images of Astarte tools
         id: compute-tag
         run: |
@@ -66,17 +140,13 @@ jobs:
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
           images: |
-            astarte/${{ matrix.app.tool }}
+            astarte/${{ matrix.app }}
           tags: |
             # TODO we probably want something smarter, but the 'pattern' type runs only on tags at the moment
             type=raw,value=${{ steps.compute-tag.outputs.TAG }}
 
-      - name: Build and push tagged Docker image of Astarte tools
-        id: push
-        uses: docker/build-push-action@3b5e8027fcad23fda98b2e3ac259d8d67585f671
-        with:
-          context: ${{ matrix.app.context }}
-          file: ${{ matrix.app.file }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests/${{ matrix.app }}
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ matrix.app }}@sha256:%s ' *)


### PR DESCRIPTION
snapshots are currently built and uploaded for both amd64 and arm64, but the images are built and push separately and the last build overrides the first. to solve this, we use the method described in the [docker documentation]

to make the snapshot build faster, caching is also introduced, using the same logic we use when building images for the e2e test

[docker documentation]: https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
