### PR TITLE
fix(rm): Return sane errors for nonexistent realm

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/realm_config/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/realm_config/queries.ex
@@ -143,4 +143,29 @@ defmodule Astarte.RealmManagement.RealmConfig.Queries do
         {:error, reason}
     end
   end
+
+  def realm_existing?(realm_name) do
+    keyspace_name = Realm.astarte_keyspace_name()
+
+    query =
+      from r in Realm,
+        prefix: ^keyspace_name,
+        where: r.realm_name == ^realm_name,
+        select: count()
+
+    consistency = Consistency.domain_model(:read)
+
+    case Repo.safe_fetch_one(query, consistency: consistency) do
+      {:ok, count} ->
+        {:ok, count > 0}
+
+      {:error, reason} ->
+        Logger.warning("Cannot check if realm exists: #{inspect(reason)}.",
+          tag: "realm_existing_error",
+          realm: realm_name
+        )
+
+        {:error, reason}
+    end
+  end
 end

--- a/apps/astarte_realm_management/lib/astarte_realm_management_web/plug/verify_realm_exists.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management_web/plug/verify_realm_exists.ex
@@ -1,0 +1,68 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagementWeb.Plug.VerifyRealmExists do
+  @moduledoc false
+  @behaviour Plug
+
+  import Phoenix.Controller
+  import Plug.Conn
+
+  alias Astarte.RealmManagement.RealmConfig.Queries
+
+  require Logger
+
+  def init(opts) do
+    opts
+  end
+
+  def call(conn, _opts) do
+    realm_name = conn.path_params["realm_name"]
+
+    case Queries.realm_existing?(realm_name) do
+      {:ok, true} ->
+        Logger.metadata(realm: realm_name)
+
+        conn
+
+      {:ok, false} ->
+        Logger.warning("Realm #{realm_name} does not exist.",
+          tag: "realm_not_found",
+          realm: realm_name
+        )
+
+        conn
+        |> put_status(:forbidden)
+        |> put_view(Astarte.RealmManagementWeb.ErrorView)
+        |> render(:"403")
+        |> halt()
+
+      {:error, reason} ->
+        Logger.error("Error checking if realm exists: #{inspect(reason)}.",
+          tag: "realm_check_error",
+          realm: realm_name
+        )
+
+        conn
+        |> put_status(:service_unavailable)
+        |> put_view(Astarte.RealmManagementWeb.ErrorView)
+        |> render(:"503")
+        |> halt()
+    end
+  end
+end

--- a/apps/astarte_realm_management/lib/astarte_realm_management_web/router.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management_web/router.ex
@@ -22,6 +22,7 @@ defmodule Astarte.RealmManagementWeb.Router do
   pipeline :api do
     plug :accepts, ["json"]
     plug Astarte.RealmManagementWeb.Plug.LogRealm
+    plug Astarte.RealmManagementWeb.Plug.VerifyRealmExists
     plug Astarte.RealmManagementWeb.Plug.AuthorizePath
   end
 

--- a/apps/astarte_realm_management/test/astarte_realm_management_web/plugs/verify_realm_exists_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management_web/plugs/verify_realm_exists_test.exs
@@ -1,0 +1,68 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.RealmManagementWeb.Plug.VerifyRealmExistsTest do
+  use Astarte.Cases.Data, async: true
+  use Astarte.RealmManagementWeb.ConnCase
+  use Mimic
+
+  alias Astarte.RealmManagement.RealmConfig.Queries
+  alias Astarte.RealmManagementWeb.Plug.VerifyRealmExists
+
+  describe "init/1" do
+    test "returns opts unchanged" do
+      opts = [some: :option]
+      assert VerifyRealmExists.init(opts) == opts
+    end
+  end
+
+  describe "call/2" do
+    setup %{conn: conn, realm_name: realm_name} do
+      conn =
+        conn
+        |> Plug.Conn.put_private(:phoenix_format, "json")
+        |> Map.put(:path_params, %{"realm_name" => realm_name})
+
+      {:ok, conn: conn}
+    end
+
+    test "passes through unchanged when realm exists", %{conn: conn} do
+      result = VerifyRealmExists.call(conn, VerifyRealmExists.init([]))
+
+      refute result.halted
+    end
+
+    test "returns 403 Forbidden and halts when realm does not exist", %{conn: conn} do
+      conn = Map.put(conn, :path_params, %{"realm_name" => "nonexistentrealm"})
+
+      result = VerifyRealmExists.call(conn, VerifyRealmExists.init([]))
+
+      assert result.halted
+      assert json_response(result, 403)["errors"]["detail"] == "Forbidden"
+    end
+
+    test "returns 503 Service Unavailable and halts on query error", %{conn: conn} do
+      expect(Queries, :realm_existing?, fn _realm -> {:error, :database_error} end)
+
+      result = VerifyRealmExists.call(conn, VerifyRealmExists.init([]))
+
+      assert result.halted
+      assert result.status == 503
+    end
+  end
+end


### PR DESCRIPTION
Add plug so Realm Management API returns Forbidden for requests with nonexistent realm.