### PR TITLE
fix(dup): ensure device deletion rpc always checks updated status

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/impl.ex
@@ -140,6 +140,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Impl do
   end
 
   def start_device_deletion(state, timestamp) do
+    # Force deletion status check
+    state = %{state | last_deletion_in_progress_refresh: 0}
+
     # Device deletion is among time-based actions
     new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
 


### PR DESCRIPTION
previously, even if the data updater received the correct rpc, if the device deletion status was cached, the rpc was just a no-op this forces the status to be refreshed so that the process actually starts if it needs to

<!--

**Please, carefully describe what the PR does and why you are opening it.**

Short check list:

* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
* [ ] Make sure to open your PR against the right branch: master / release-VERSION
* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
* [ ] Make sure to sign-off all your commits
* [ ] GPG signing is appreciated
* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)

-->
