### PR TITLE
feat(housekeeping): Create realm vhosts for old realms

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/migrator.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/migrator.ex
@@ -25,6 +25,7 @@ defmodule Astarte.Housekeeping.Migrator do
   alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.DataAccess.Repo
+  alias Astarte.Events.AMQP.Vhost
   alias Astarte.Housekeeping.Realms.Queries
   alias Astarte.Housekeeping.Realms.Realm, as: HKRealm
 
@@ -81,7 +82,8 @@ defmodule Astarte.Housekeeping.Migrator do
     )
 
     with {:ok, realm_astarte_schema_version} <- get_realm_astarte_schema_version(realm_name),
-         :ok <- migrate_realm_from_version(realm_name, realm_astarte_schema_version) do
+         :ok <- migrate_realm_from_version(realm_name, realm_astarte_schema_version),
+         :ok <- Vhost.create_vhost(realm_name) do
       migrate_realms(tail)
     end
   end

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
@@ -22,6 +22,7 @@ defmodule Astarte.Housekeeping.MigratorTest do
 
   alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Realms.Realm, as: DatabaseRealm
+  alias Astarte.Events.AMQP.Vhost
   alias Astarte.Housekeeping.Helpers.Database
   alias Astarte.Housekeeping.Migrator
   alias Astarte.Housekeeping.Realms.Core
@@ -74,7 +75,8 @@ defmodule Astarte.Housekeeping.MigratorTest do
       Queries.initialize_database()
       Core.create_realm(realm, [])
       Database.edit_with_outdated_column_for_astarte_realms_table!()
-      :ok
+
+      %{realm_name: realm_name}
     end
 
     test "returns ok with complete db" do
@@ -112,6 +114,11 @@ defmodule Astarte.Housekeeping.MigratorTest do
     test "returns error due do xandra connection problem" do
       Mimic.stub(Xandra, :execute, fn _, _, _, _ -> {:error, %Xandra.ConnectionError{}} end)
       assert {:error, :database_connection_error} = Migrator.run_realms_migrations()
+    end
+
+    test "creates the realm vhost", %{realm_name: realm_name} do
+      Mimic.expect(Vhost, :create_vhost, fn ^realm_name -> :ok end)
+      assert :ok = Migrator.run_realms_migrations()
     end
   end
 

--- a/apps/astarte_housekeeping/test/test_helper.exs
+++ b/apps/astarte_housekeeping/test/test_helper.exs
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 - 2025 SECO Mind Srl
+# Copyright 2017 - 2026 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 # limitations under the License.
 #
 
-Mimic.copy(Astarte.DataAccess.Health.Health)
 Mimic.copy(Astarte.DataAccess.Config)
+Mimic.copy(Astarte.DataAccess.Health.Health)
 Mimic.copy(Astarte.DataAccess.Repo)
-Mimic.copy(Astarte.Housekeeping.Realms)
-Mimic.copy(Astarte.Housekeeping.Config)
-Mimic.copy(Astarte.Housekeeping.Realms.Queries)
-Mimic.copy(Xandra)
 Mimic.copy(Astarte.Events.AMQP)
+Mimic.copy(Astarte.Events.AMQP.Vhost)
 Mimic.copy(Astarte.Events.Config)
+Mimic.copy(Astarte.Housekeeping.Config)
+Mimic.copy(Astarte.Housekeeping.Realms)
+Mimic.copy(Astarte.Housekeeping.Realms.Queries)
 Mimic.copy(HTTPoison)
 Mimic.copy(HTTPoison.Base)
+Mimic.copy(Xandra)
 
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
this is done by adding an additional step after running migrations.
it works because the vhost creation step is idempotent.