### PR TITLE
feat(pairing): Add rendezvous server SSL configuration options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - `ASTARTE_BASE_URL_DOMAIN` - domain part of the base URL of astarte, used by devices to connect in TO2 phase (required if FDO enabled)
   - `ASTARTE_BASE_URL_PORT` - port of the base URL of astarte (required if FDO enabled)
   - `ASTARTE_BASE_URL_PROTOCOL` - protocol of the base URL of astarte (required if FDO enabled)
+  - `PAIRING_FDO_RENDEZVOUS_SSL_ENABLED` - whether SSL is enabled for the connection to the rendezvous server (default: false)
+  - `PAIRING_FDO_RENDEZVOUS_SSL_CA_FILE` - path to the CA certificate file for the rendezvous server TLS connection; when not specified, the bundled cURL certificate bundle will be used
+  - `PAIRING_FDO_RENDEZVOUS_SSL_DISABLE_SNI` - disable Server Name Indication for the rendezvous server TLS connection (default: false)
+  - `PAIRING_FDO_RENDEZVOUS_SSL_CUSTOM_SNI` - custom SNI hostname for the rendezvous server TLS connection; when not specified, the Rendezvous hostname will be used
 
 - [astarte_housekeeping] AMQP management configuration moved to `astarte_events` library. Environment variables changed:
   - `HOUSEKEEPING_AMQP_SSL_ENABLED` is now `ASTARTE_EVENTS_AMQP_MANAGEMENT_SSL_ENABLED`

--- a/apps/astarte_pairing/lib/astarte_pairing/config.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/config.ex
@@ -80,6 +80,71 @@ defmodule Astarte.Pairing.Config do
     type: :binary,
     default: "http://rendezvous:8041"
 
+  @envdoc "Enable SSL for the FDO Rendezvous Server connection. If not specified, SSL is disabled."
+  app_env :fdo_rendezvous_ssl_enabled, :astarte_pairing, :fdo_rendezvous_ssl_enabled,
+    os_env: "PAIRING_FDO_RENDEZVOUS_SSL_ENABLED",
+    type: :boolean,
+    default: false
+
+  @envdoc "Path to the CA certificate file for the FDO Rendezvous Server TLS connection. When not specified, the bundled cURL certificate bundle will be used."
+  app_env :fdo_rendezvous_ssl_ca_file, :astarte_pairing, :fdo_rendezvous_ssl_ca_file,
+    os_env: "PAIRING_FDO_RENDEZVOUS_SSL_CA_FILE",
+    type: :binary,
+    default: CAStore.file_path()
+
+  @envdoc "Disable FDO Rendezvous Server Name Indication. Defaults to false."
+  app_env :fdo_rendezvous_ssl_disable_sni,
+          :astarte_pairing,
+          :fdo_rendezvous_ssl_disable_sni,
+          os_env: "PAIRING_FDO_RENDEZVOUS_SSL_DISABLE_SNI",
+          type: :boolean,
+          default: false
+
+  @envdoc "Specify the hostname to be used in TLS Server Name Indication extension. If not specified, the FDO Rendezvous Server host will be used. This value is used only if Server Name Indication is enabled."
+  app_env :fdo_rendezvous_ssl_custom_sni, :astarte_pairing, :fdo_rendezvous_ssl_custom_sni,
+    os_env: "PAIRING_FDO_RENDEZVOUS_SSL_CUSTOM_SNI",
+    type: :binary
+
+  @doc """
+  Returns the SSL options for the FDO Rendezvous Server HTTP client.
+  Returns an empty list if SSL is disabled.
+  """
+  def fdo_rendezvous_ssl_options! do
+    if fdo_rendezvous_ssl_enabled!() do
+      build_rendezvous_ssl_options()
+    else
+      []
+    end
+  end
+
+  defp build_rendezvous_ssl_options do
+    [
+      cacertfile: fdo_rendezvous_ssl_ca_file!(),
+      verify: :verify_peer,
+      depth: 10
+    ]
+    |> populate_rendezvous_sni()
+  end
+
+  defp populate_rendezvous_sni(ssl_options) do
+    if fdo_rendezvous_ssl_disable_sni!() do
+      Keyword.put(ssl_options, :server_name_indication, :disable)
+    else
+      server_name =
+        case fdo_rendezvous_ssl_custom_sni!() do
+          nil ->
+            fdo_rendezvous_url!()
+            |> URI.parse()
+            |> Map.fetch!(:host)
+
+          custom_sni ->
+            custom_sni
+        end
+
+      Keyword.put(ssl_options, :server_name_indication, to_charlist(server_name))
+    end
+  end
+
   def init! do
     if {:ok, nil} == ca_cert() do
       case CFSSLCredentials.ca_cert() do

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/client.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/rendezvous/client.ex
@@ -36,7 +36,7 @@ defmodule Astarte.Pairing.FDO.Rendezvous.Client do
   @impl true
   def process_request_options(options) do
     auth_opts = [
-      # ssl: Config.ssl_options!() no ssl?
+      ssl: Config.fdo_rendezvous_ssl_options!()
     ]
 
     Keyword.merge(auth_opts, options)


### PR DESCRIPTION
SSL for FDO Rendezvous Server is disabled by default and can be enabled via environment variables.

New environment variables introduced:
- PAIRING_FDO_RENDEZVOUS_SSL_ENABLED: enables SSL (default: false)
- PAIRING_FDO_RENDEZVOUS_SSL_CA_FILE: path to a custom CA certificate
  file; when not set, the bundled cURL certificate bundle is used
- PAIRING_FDO_RENDEZVOUS_SSL_DISABLE_SNI: disables Server Name
  Indication (default: false)
- PAIRING_FDO_RENDEZVOUS_SSL_CUSTOM_SNI: custom SNI hostname; when not
  set, the value of PAIRING_FDO_RENDEZVOUS_HOST is used
