### PR TITLE
feat(rm): Enable optional interface endpoints

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/interfaces/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/interfaces/queries.ex
@@ -238,12 +238,12 @@ defmodule Astarte.RealmManagement.Interfaces.Queries do
     (
       interface_id, endpoint_id, interface_name, interface_major_version, interface_minor_version,
       interface_type, endpoint, value_type, reliability, retention, database_retention_policy,
-      database_retention_ttl, expiry, allow_unset, explicit_timestamp, description, doc
+      database_retention_ttl, expiry, allow_unset, explicit_timestamp, description, doc, required
     )
     VALUES (
       ?, ?, ?, ?, ?,
       ?, ?, ?, ?, ?, ?,
-      ?, ?, ?, ?, ?, ?
+      ?, ?, ?, ?, ?, ?, ?
     )
     """
 
@@ -264,7 +264,8 @@ defmodule Astarte.RealmManagement.Interfaces.Queries do
       mapping.allow_unset,
       mapping.explicit_timestamp,
       mapping.description,
-      mapping.doc
+      mapping.doc,
+      mapping.required
     ]
 
     {insert_mapping_statement, params}

--- a/apps/astarte_realm_management/mix.exs
+++ b/apps/astarte_realm_management/mix.exs
@@ -64,8 +64,7 @@ defmodule Astarte.RealmManagement.Mixfile do
 
   defp astarte_required_modules(_) do
     [
-      {:astarte_core,
-       github: "astarte-platform/astarte_core", branch: "release-1.3", override: true}
+      {:astarte_core, github: "astarte-platform/astarte_core", branch: "master", override: true}
     ]
   end
 

--- a/apps/astarte_realm_management/mix.lock
+++ b/apps/astarte_realm_management/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "3.3.2", "6cad7469957b29c517a26a27474828f1db28278a13bcc2e7970db9854a3d3080", [:mix], [{:amqp_client, "~> 3.9", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "f977c41d81b65a21234a9158e6491b2296f8bd5bda48d5b611a64b6e0d2c3f31"},
   "amqp_client": {:hex, :amqp_client, "3.12.14", "2b677bc3f2e2234ba7517042b25d72071a79735042e91f9116bd3c176854b622", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.14", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "5f70b6c3b1a739790080da4fddc94a867e99f033c4b1edc20d6ff8b8fb4bd160"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "42b92a5c83aae0e5de23a4f611e87d703a5a24d5", [branch: "release-1.3"]},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "a6efa2e87b7f121cc7656640cdff88c408e180f5", [branch: "master"]},
   "astarte_generators": {:git, "https://github.com/astarte-platform/astarte_generators.git", "8f3a5a518695185c2bb628d0920ba9b6e555e7b4", []},
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "castore": {:hex, :castore, "1.0.15", "8aa930c890fe18b6fe0a0cff27b27d0d4d231867897bd23ea772dee561f032a3", [:mix], [], "hexpm", "96ce4c69d7d5d7a0761420ef743e2f4096253931a3ba69e5ff8ef1844fe446d3"},

--- a/apps/astarte_realm_management/test/astarte_realm_management_web/controllers/interface_controller_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management_web/controllers/interface_controller_test.exs
@@ -60,6 +60,22 @@ defmodule Astarte.RealmManagementWeb.InterfaceControllerTest do
     ]
   }
 
+  @iface_with_required_mappings %{
+    "interface_name" => @interface_name,
+    "version_major" => @interface_major,
+    "version_minor" => 2,
+    "type" => "datastream",
+    "ownership" => "device",
+    "aggregation" => "object",
+    "mappings" => [
+      %{
+        "endpoint" => "/test",
+        "type" => "integer",
+        "required" => true
+      }
+    ]
+  }
+
   setup %{realm: realm, astarte_instance_id: astarte_instance_id} do
     on_exit(fn ->
       Database.setup_database_access(astarte_instance_id)
@@ -179,6 +195,24 @@ defmodule Astarte.RealmManagementWeb.InterfaceControllerTest do
 
       post2_conn = post(conn, interface_path(conn, :create, realm), data: @valid_attrs)
       assert json_response(post2_conn, 409)["errors"] != %{}
+    end
+
+    test "renders interface on required mapping", %{
+      auth_conn: conn,
+      realm: realm
+    } do
+      conn =
+        post(conn, interface_path(conn, :create, realm),
+          data: @iface_with_required_mappings,
+          async_operation: "false"
+        )
+
+      assert response(conn, 201) == ""
+
+      get_conn =
+        get(conn, interface_path(conn, :show, realm, @interface_name, @interface_major_str))
+
+      assert json_response(get_conn, 200)["data"] == @iface_with_required_mappings
     end
 
     test "renders error on mapping with higher database_retention_ttl than the maximum", %{


### PR DESCRIPTION
Add new `required` field to enable optional interface endpoints.