### PR TITLE
chore: revamp pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,51 @@
+#### What this PR does / why we need it:
+
+#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:
+
 <!--
-
-**Please, carefully describe what the PR does and why you are opening it.**
-
-Short check list:
-
-* [ ] Please, make sure to read CONTRIBUTING.md and CODE_OF_CONDUCT.md
-* [ ] Make sure to open your PR against the right branch: master / release-VERSION
-* [ ] Add to CHANGELOG.md relevant changes and any other user facing change.
-* [ ] Make sure to sign-off all your commits
-* [ ] GPG signing is appreciated
-* [ ] Make sure the code follows coding style (use automated formatting, such as `mix format`)
-
+This section can be blank if this pull request does not require additional resources.
 -->
+
+---
+
+<details>
+<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>
+
+1. You can take a look at our [developer guide] for an introduction on Astarte development!
+2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
+3. If the PR is unfinished or you're actively working on it, mark it as draft
+
+When fixing existing issues, use [github's syntax to link your pull request] to it
+
+> `fixes #<issue number>`
+
+We also have a syntax to signal dependencies to other open pull requests
+
+> `depends on #<pr number>`
+> `depends on https://github.com/...`
+
+In case of stacked PRs, you may add the PR number in the last commit's title instead:
+
+> ```mermaid
+> gitGraph
+>     commit id: "Current master"
+>     branch feat1
+>     checkout feat1
+>     commit id: "feat: add something"
+>     commit id: "feat: add something else (#100)"
+>     branch feat2
+>     checkout feat2
+>     commit id: "refactor: do something"
+>     commit id: "fix: solve issue"
+>     commit id: "feat: add a feature (#101)"
+>     branch feat3
+>     checkout feat3
+>     commit id: "feat: feat without pr number"
+> ```
+
+</details>
+
+[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
+[developer guide]: https://docs.astarte-platform.org/astarte/snapshot/001-dev_guide.html
+[CONTRIBUTING.md]: ../CONTRIBUTING.md
+[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md


### PR DESCRIPTION
the pull request template was lost in 9f6554

restore it and simplify it: we now have ci and conventional commits taking care of many of the checkboxes

here's a preview:
#### What this PR does / why we need it:

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Astarte development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it
> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests
> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:
> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```
</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.astarte-platform.org/astarte/snapshot/001-dev_guide.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md