### PR TITLE
feat(dup): Validate required interface mapping

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -24,6 +24,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   """
   alias Astarte.Core.Device
   alias Astarte.Core.InterfaceDescriptor
+  alias Astarte.Core.Mapping
   alias Astarte.Core.Mapping.ValueType
   alias Astarte.DataAccess.Data
   alias Astarte.DataUpdaterPlant.DataUpdater.Cache
@@ -63,7 +64,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
          :ok <- can_write_on_interface?(context, interface_descriptor.ownership),
          {:ok, mapping} <- resolve_path(context, interface_descriptor),
          {:ok, {value, value_timestamp, _metadata}} <- decode_bson_payload(context),
-         :ok <- validate_value_type(context, interface_descriptor, mapping, value) do
+         :ok <- validate_value(context, interface_descriptor, mapping, value) do
       maybe_explicit_value_timestamp =
         if mapping.explicit_timestamp,
           do: value_timestamp,
@@ -208,6 +209,44 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
       )
     end
   end
+
+  defp validate_value(context, interface_descriptor, mapping, value) do
+    %{state: state} = context
+
+    mappings = Core.Interface.extract_mappings(interface_descriptor, mapping, state.mappings)
+
+    with :ok <- validate_value_type(context, mappings, value) do
+      validate_required_mappings(context, interface_descriptor, mappings, value)
+    end
+  end
+
+  defp validate_required_mappings(
+         context,
+         %InterfaceDescriptor{aggregation: :object},
+         %{} = mappings_by_key,
+         %{} = value
+       ) do
+    case Enum.find(mappings_by_key, fn {key, mapping} ->
+           mapping.required and not Map.has_key?(value, key)
+         end) do
+      nil ->
+        :ok
+
+      _missing ->
+        %{interface: interface, path: path} = context
+
+        error = %{
+          message: "Missing required mapping key in object sent to #{interface}#{path}.",
+          logger_metadata: [tag: "missing_required_mapping"],
+          error_name: "missing_required_mapping",
+          error: :missing_required_mapping
+        }
+
+        Core.Error.handle_error(context, error)
+    end
+  end
+
+  defp validate_required_mappings(_context, _interface_descriptor, _mappings, _value), do: :ok
 
   defp can_set_to_value(
          context,
@@ -398,18 +437,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
     Core.Error.handle_error(context, error)
   end
 
-  defp validate_value_type(context, interface_descriptor, mapping, value) do
-    %{interface: interface, path: path, payload: payload, state: state} = context
+  defp validate_value_type(context, mappings, value) do
+    %{interface: interface, path: path, payload: payload} = context
 
-    expected_types =
-      Core.Interface.extract_expected_types(
-        path,
-        interface_descriptor,
-        mapping,
-        state.mappings
-      )
-
-    validation = validate_value_type(expected_types, value)
+    validation = validate_value_type(mappings, value)
 
     case validation do
       {:error, :unexpected_value_type} ->
@@ -466,9 +497,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
     {:error, :unexpected_value_type}
   end
 
-  def validate_value_type(%{} = expected_types, %{} = object) do
+  def validate_value_type(%Mapping{value_type: expected_type}, value) do
+    validate_value_type(expected_type, value)
+  end
+
+  def validate_value_type(%{} = mappings_by_key, %{} = object) do
     Enum.reduce_while(object, :ok, fn {key, value}, _acc ->
-      with {:ok, expected_type} <- Map.fetch(expected_types, key),
+      with {:ok, %Mapping{value_type: expected_type}} <- Map.fetch(mappings_by_key, key),
            :ok <- ValueType.validate_value(expected_type, value) do
         {:cont, :ok}
       else

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/interface.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/interface.ex
@@ -311,35 +311,21 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.Interface do
     |> length()
   end
 
-  def extract_expected_types(_path, interface_descriptor, endpoint, mappings) do
-    case interface_descriptor.aggregation do
-      :individual ->
-        endpoint.value_type
-
-      :object ->
-        expected_object_types(interface_descriptor, mappings)
-    end
+  def extract_mappings(%InterfaceDescriptor{aggregation: :individual}, mapping, _mappings) do
+    mapping
   end
 
-  defp expected_object_types(interface_descriptor, mappings) do
-    # TODO: we should probably cache this
+  def extract_mappings(
+        %InterfaceDescriptor{aggregation: :object},
+        _mapping,
+        mappings
+      ) do
     mappings
-    |> Enum.flat_map(fn {_id, mapping} ->
-      mapping_to_expected_type(interface_descriptor.interface_id, mapping)
+    |> Map.new(fn {_id, m} ->
+      key = m.endpoint |> String.split("/") |> List.last()
+      {key, m}
     end)
-    |> Enum.into(%{})
   end
-
-  defp mapping_to_expected_type(interface_id, %Mapping{interface_id: interface_id} = mapping) do
-    expected_key =
-      mapping.endpoint
-      |> String.split("/")
-      |> List.last()
-
-    [{expected_key, mapping.value_type}]
-  end
-
-  defp mapping_to_expected_type(_interface_id, %Mapping{}), do: []
 
   def forget_interfaces(state, []) do
     state

--- a/apps/astarte_data_updater_plant/mix.exs
+++ b/apps/astarte_data_updater_plant/mix.exs
@@ -59,8 +59,7 @@ defmodule Astarte.DataUpdaterPlant.Mixfile do
 
   defp astarte_required_modules(_) do
     [
-      {:astarte_core,
-       github: "astarte-platform/astarte_core", branch: "release-1.3", override: true},
+      {:astarte_core, github: "astarte-platform/astarte_core", branch: "master", override: true},
       {:astarte_generators, github: "astarte-platform/astarte_generators", only: [:dev, :test]},
       {:astarte_realm_management,
        path: "../astarte_realm_management", only: :test, runtime: false},

--- a/apps/astarte_data_updater_plant/mix.lock
+++ b/apps/astarte_data_updater_plant/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "3.3.2", "6cad7469957b29c517a26a27474828f1db28278a13bcc2e7970db9854a3d3080", [:mix], [{:amqp_client, "~> 3.9", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "f977c41d81b65a21234a9158e6491b2296f8bd5bda48d5b611a64b6e0d2c3f31"},
   "amqp_client": {:hex, :amqp_client, "3.12.14", "2b677bc3f2e2234ba7517042b25d72071a79735042e91f9116bd3c176854b622", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.14", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "5f70b6c3b1a739790080da4fddc94a867e99f033c4b1edc20d6ff8b8fb4bd160"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "42b92a5c83aae0e5de23a4f611e87d703a5a24d5", [branch: "release-1.3"]},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "a6efa2e87b7f121cc7656640cdff88c408e180f5", [branch: "master"]},
   "astarte_generators": {:git, "https://github.com/astarte-platform/astarte_generators.git", "772d56ac25ac9c3a05514bf20476e91a8de39c22", []},
   "bunt": {:hex, :bunt, "1.0.0", "081c2c665f086849e6d57900292b3a161727ab40431219529f13c4ddcf3e7a44", [:mix], [], "hexpm", "dc5f86aa08a5f6fa6b8096f0735c4e76d54ae5c9fa2c143e5a1fc7c1cd9bb6b5"},
   "castore": {:hex, :castore, "1.0.17", "4f9770d2d45fbd91dcf6bd404cf64e7e58fed04fadda0923dc32acca0badffa2", [:mix], [], "hexpm", "12d24b9d80b910dd3953e165636d68f147a31db945d2dcb9365e441f8b5351e5"},

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_error_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_error_test.exs
@@ -440,6 +440,54 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerErrorTest do
                  start
                )
     end
+
+    test "missing required mappings", test_context do
+      %{state: state, interfaces: interfaces} = test_context
+
+      object_device_interfaces =
+        interfaces
+        |> Enum.filter(&(&1.aggregation == :object and &1.ownership == :device))
+
+      interface = Enum.at(object_device_interfaces, 0)
+      interface_name = interface.name
+      timestamp = DateTime.utc_now(:millisecond)
+
+      {:ok, descriptor, loaded_state} =
+        Core.Interface.maybe_handle_cache_miss(nil, interface_name, state)
+
+      # Pick the first mapping belonging to this interface and mark it as required
+      {req_endpoint_id, req_mapping} =
+        loaded_state.mappings
+        |> Enum.find(fn {_id, m} -> m.interface_id == interface.interface_id end)
+
+      state_with_required_mapping = %{
+        loaded_state
+        | mappings:
+            Map.put(loaded_state.mappings, req_endpoint_id, %{req_mapping | required: true})
+      }
+
+      path = req_mapping.endpoint |> String.split("/") |> Enum.drop(-1) |> Enum.join("/")
+
+      # Payload value is empty – the required key is absent
+      payload = Cyanide.encode!(%{"v" => %{}, "t" => timestamp})
+
+      # Inject the modified state (with required mapping) from the cache miss
+      expect(Core.Interface, :maybe_handle_cache_miss, fn _cached, ^interface_name, ^state ->
+        {:ok, descriptor, state_with_required_mapping}
+      end)
+
+      expect(Core.Error, :handle_error, &discard_error/2)
+
+      assert {:discard, :missing_required_mapping, ^state_with_required_mapping} =
+               DataHandler.handle_data(
+                 state,
+                 interface_name,
+                 path,
+                 payload,
+                 timestamp,
+                 System.monotonic_time()
+               )
+    end
   end
 
   defp discard_error(context, error), do: {:discard, error.error, context.state}

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/interface_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/interface_test.exs
@@ -177,7 +177,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.InterfaceTest do
       end
     end
 
-    property "extract_expected_types/3 extracts types from endpoint", context do
+    property "extract_mappings/3 extracts mappings from endpoint", context do
       %{
         interfaces: interfaces,
         state: state,
@@ -185,8 +185,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.InterfaceTest do
       } = context
 
       check all interface <- member_of(interfaces),
-                mapping <- member_of(interface.mappings),
-                path <- path_from_endpoint(mapping.endpoint) do
+                mapping <- member_of(interface.mappings) do
         descriptor = state.interfaces[interface.name]
 
         keyspace = Realm.keyspace_name(realm_name)
@@ -200,8 +199,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.InterfaceTest do
         endpoint = Repo.one(query, prefix: keyspace)
 
         expected_type =
-          Core.Interface.extract_expected_types(
-            path,
+          Core.Interface.extract_mappings(
             descriptor,
             endpoint,
             state.mappings
@@ -301,13 +299,16 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.InterfaceTest do
     end
   end
 
-  defp valid_type?(mapping, expected_type, :individual), do: mapping.value_type == expected_type
+  defp valid_type?(mapping, %Endpoint{value_type: value_type}, :individual),
+    do: mapping.value_type == value_type
 
-  defp valid_type?(mapping, expected_type, :object) do
+  defp valid_type?(mapping, %{} = mappings_by_key, :object) do
     key = mapping.endpoint |> String.split("/") |> List.last()
-    value = mapping.value_type
 
-    %{key => value} == expected_type
+    case Map.fetch(mappings_by_key, key) do
+      {:ok, %Mapping{value_type: value_type}} -> mapping.value_type == value_type
+      :error -> false
+    end
   end
 
   defp matches?(endpoint, path, aggregation) do


### PR DESCRIPTION
This PR introduces support for the `required` flag on object interface mapping endpoints. 
When a mapping has `required: true`, incoming data must include that endpoint's key — otherwise the message is rejected.


