### PR TITLE
ci: always publish releases to dockerhub

### DIFF
--- a/.github/workflows/publish-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-release-to-dockerhub-workflow.yaml
@@ -11,45 +11,6 @@ on:
         type: string
 
 jobs:
-  astarte_appengine_api:
-    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
-    with:
-      app: "astarte_appengine_api"
-    secrets: inherit
-
-  astarte_data_updater_plant:
-    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
-    with:
-      app: "astarte_data_updater_plant"
-    secrets: inherit
-
-  astarte_housekeeping:
-    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
-    with:
-      app: "astarte_housekeeping"
-    secrets: inherit
-
-  astarte_pairing:
-    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
-    with:
-      app: "astarte_pairing"
-    secrets: inherit
-
-  astarte_realm_management:
-    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
-    with:
-      app: "astarte_realm_management"
-    secrets: inherit
-
-  astarte_trigger_engine:
-    uses: ./.github/workflows/astarte-apps-build-workflow.yaml
-    with:
-      app: "astarte_trigger_engine"
-    secrets: inherit
-
-  e2e_tests:
-    uses: ./.github/workflows/astarte-end-to-end-test-workflow.yaml
-
   build_release:
     name: Push Docker images to Docker Hub
     runs-on: ${{ matrix.platform.os }}
@@ -75,14 +36,6 @@ jobs:
           - astarte_pairing
           - astarte_realm_management
           - astarte_trigger_engine
-    needs:
-      - astarte_appengine_api
-      - astarte_data_updater_plant
-      - astarte_housekeeping
-      - astarte_pairing
-      - astarte_realm_management
-      - astarte_trigger_engine
-      - e2e_tests
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
tagging a release is a deliberate choice, we don't want missing images
caused by red ci