### PR TITLE
refactor: make list keys return the list of keys

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/open_bao/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/open_bao/core.ex
@@ -245,8 +245,7 @@ defmodule Astarte.Pairing.FDO.OpenBao.Core do
     end
   end
 
-  @spec list_keys(String.t()) ::
-          :error | {:error, Jason.DecodeError.t()} | {:ok, any()}
+  @spec list_keys(String.t()) :: {:ok, [String.t()]} | :error
   def list_keys(namespace) do
     headers = [{"Content-Type", "application/json"}]
 
@@ -254,7 +253,14 @@ defmodule Astarte.Pairing.FDO.OpenBao.Core do
 
     case Client.list("/transit/keys", headers, options) do
       {:ok, %HTTPoison.Response{status_code: 200, body: resp_body}} ->
-        parse_json_data(resp_body)
+        case parse_data_key(resp_body, "keys") do
+          {:ok, keys} ->
+            {:ok, keys}
+
+          {:error, reason} ->
+            Logger.error("Encountered HTTP error while getting keys list: #{inspect(reason)}")
+            :error
+        end
 
       {:ok, %HTTPoison.Response{status_code: 404}} ->
         {:ok, []}

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/open_bao/core.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/open_bao/core.ex
@@ -258,7 +258,7 @@ defmodule Astarte.Pairing.FDO.OpenBao.Core do
             {:ok, keys}
 
           {:error, reason} ->
-            Logger.error("Encountered HTTP error while getting keys list: #{inspect(reason)}")
+            Logger.error("Encountered error while getting keys list: #{inspect(reason)}")
             :error
         end
 

--- a/apps/astarte_pairing/lib/astarte_pairing/fdo/open_bao/open_bao.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing/fdo/open_bao/open_bao.ex
@@ -34,7 +34,7 @@ defmodule Astarte.Pairing.FDO.OpenBao do
     Core.get_key(key_name, namespace)
   end
 
-  @spec list_keys_names() :: {:ok, map()} | :error
+  @spec list_keys_names() :: {:ok, [String.t()]} | :error
   def list_keys_names(opts \\ []) do
     namespace = Keyword.fetch!(opts, :namespace)
     Core.list_keys(namespace)

--- a/apps/astarte_pairing/test/astarte_pairing/fdo/open_bao/open_bao_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/fdo/open_bao/open_bao_test.exs
@@ -398,7 +398,7 @@ defmodule Astarte.Pairing.FDO.OpenBaoTest do
                "allow_plaintext_backup" => ^allow_key_export_and_backup
              } = key_data2
 
-      assert {:ok, %{"keys" => [key_name, key_name1, key_name2]}} == OpenBao.list_keys_names(opts)
+      assert {:ok, [key_name, key_name1, key_name2]} == OpenBao.list_keys_names(opts)
     end
 
     @tag key_type: :es384
@@ -436,7 +436,7 @@ defmodule Astarte.Pairing.FDO.OpenBaoTest do
                "allow_plaintext_backup" => ^allow_key_export_and_backup
              } = key_data2
 
-      assert {:ok, %{"keys" => [key_name, key_name1, key_name2]}} == OpenBao.list_keys_names(opts)
+      assert {:ok, [key_name, key_name1, key_name2]} == OpenBao.list_keys_names(opts)
     end
 
     @tag key_type: :rs256
@@ -474,7 +474,7 @@ defmodule Astarte.Pairing.FDO.OpenBaoTest do
                "allow_plaintext_backup" => ^allow_key_export_and_backup
              } = key_data2
 
-      assert {:ok, %{"keys" => [key_name, key_name1, key_name2]}} == OpenBao.list_keys_names(opts)
+      assert {:ok, [key_name, key_name1, key_name2]} == OpenBao.list_keys_names(opts)
     end
 
     @tag key_type: :rs384
@@ -512,7 +512,7 @@ defmodule Astarte.Pairing.FDO.OpenBaoTest do
                "allow_plaintext_backup" => ^allow_key_export_and_backup
              } = key_data2
 
-      assert {:ok, %{"keys" => [key_name, key_name1, key_name2]}} == OpenBao.list_keys_names(opts)
+      assert {:ok, [key_name, key_name1, key_name2]} == OpenBao.list_keys_names(opts)
     end
   end
 


### PR DESCRIPTION
previously it was returning the response body as a whole