### PR TITLE
fix(rm): fix corner case when installing interfaces without data retention ttl

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/engine.ex
@@ -869,7 +869,11 @@ defmodule Astarte.RealmManagement.Engine do
 
   defp mappings_retention_valid?(mappings, max_retention) do
     Enum.all?(mappings, fn %Mapping{database_retention_ttl: retention} ->
-      retention <= max_retention
+      case retention do
+        nil -> true
+        n when n <= max_retention -> true
+        _ -> false
+      end
     end)
   end
 


### PR DESCRIPTION
#### What this PR does / why we need it:
When the database retention TTL for data is set at realm level, interface data retention TTL must be less or equal than it or not set. In the latter case, Astarte will use the realm's TTL for interface data.

However, an inaccurate comparison made so that an unset interface TTL seemed higher than the set realm TTL, resulting in interface not installed. Fix it by making sure to cover that corner case.

