### PR TITLE
fix(housekeeping): ensure realms are created correctly

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -218,7 +218,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     if opts[:async] do
       {:ok, _pid} =
         Task.start(fn ->
-          do_create_realm(
+          do_execute_realm_creation(
             realm_name,
             keyspace_name,
             public_key_pem,
@@ -230,7 +230,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
 
       {:ok, :started}
     else
-      do_create_realm(
+      do_execute_realm_creation(
         realm_name,
         keyspace_name,
         public_key_pem,
@@ -239,6 +239,26 @@ defmodule Astarte.Housekeeping.Realms.Queries do
         max_retention
       )
     end
+  end
+
+  defp do_execute_realm_creation(
+         realm_name,
+         keyspace_name,
+         public_key_pem,
+         replication_map_str,
+         device_limit,
+         max_retention
+       ) do
+    Repo.checkout(fn ->
+      do_create_realm(
+        realm_name,
+        keyspace_name,
+        public_key_pem,
+        replication_map_str,
+        device_limit,
+        max_retention
+      )
+    end)
   end
 
   defp do_create_realm(


### PR DESCRIPTION
#### What this PR does / why we need it:

just like for the astarte keyspace, realms may also suffer from the same consistency issue with `CREATE` operations.

by running all queries on the same connection and having the last operation be a write with consistency: all, we should have guaranteed consistency once we exit the `do_create_realm` function

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

depends on #1881

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Astarte development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.astarte-platform.org/astarte/snapshot/001-dev_guide.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
