### PR TITLE
ci: Upload autogenerated OpenAPI specs

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -5,8 +5,11 @@ on:
     paths:
       # Documentation pages
       - "doc/**"
-      # Swagger files
-      - "apps/*/priv/static/*.yaml"
+      # API sources used to generate OpenAPI specs
+      - "apps/astarte_appengine_api/**"
+      - "apps/astarte_housekeeping/**"
+      - "apps/astarte_pairing/**"
+      - "apps/astarte_realm_management/**"
       # The action itself
       - ".github/workflows/docs-workflow.yaml"
     branches:
@@ -17,13 +20,61 @@ on:
   create:
 
 jobs:
+  generate_openapi_specs:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        app:
+          - name: astarte_appengine_api
+            spec: Astarte.AppEngine.APIWeb.ApiSpec
+            filename: astarte_appengine_api.yaml
+          - name: astarte_housekeeping
+            spec: Astarte.HousekeepingWeb.ApiSpec
+            filename: astarte_housekeeping_api.yaml
+          - name: astarte_pairing
+            spec: Astarte.PairingWeb.ApiSpec
+            filename: astarte_pairing.yaml
+          - name: astarte_realm_management
+            spec: Astarte.RealmManagementWeb.ApiSpec
+            filename: astarte_realm_management.yaml
+
+    steps:
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - name: Generate ${{ matrix.app.name }} OpenAPI spec
+        uses: team-alembic/staple-actions/actions/mix-task@a74b3b61209d35d45526df174766632f8aee03ed
+        with:
+          working-directory: apps/${{ matrix.app.name }}
+          mix-env: test
+          task: >-
+            openapi.spec.yaml
+            --spec ${{ matrix.app.spec }}
+            --start-app=false
+            --vendor-extensions=false
+            ${{ matrix.app.filename }}
+      - name: Upload ${{ matrix.app.name }} artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ matrix.app.name }}-openapi-spec
+          path: apps/${{ matrix.app.name }}/${{ matrix.app.filename }}
+          if-no-files-found: error
+          retention-days: 1
+
   docs:
+    needs:
+      - generate_openapi_specs
     runs-on: ubuntu-22.04
     steps:
       # Checkout the source
       - uses: actions/checkout@v2
         with:
           path: astarte
+      - name: Download OpenAPI specs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          path: ./astarte/generated-openapi
+          pattern: "*-openapi-spec"
+          merge-multiple: true
       # Checkout the docs repository
       - uses: actions/checkout@v2
         with:
@@ -51,6 +102,7 @@ jobs:
           export DOCS_DIRNAME="astarte/$(echo ${{ github.ref }} | sed 's,refs/heads/,,' | sed 's/master/snapshot/g' | sed 's/release-//g')"
           mkdir docs/$DOCS_DIRNAME/api
           cp swagger-ui/dist/* docs/$DOCS_DIRNAME/api
+          cp astarte/generated-openapi/*.yaml docs/$DOCS_DIRNAME/api/
           rm docs/$DOCS_DIRNAME/api/index.html
           cp astarte/doc/swagger-ui-index.html docs/$DOCS_DIRNAME/api/index.html
       - name: Commit files

--- a/doc/swagger-ui-index.html
+++ b/doc/swagger-ui-index.html
@@ -49,23 +49,19 @@
         urls: [
           {
             name: "AppEngine API",
-            url:
-              "https://raw.githubusercontent.com/astarte-platform/astarte/v1.2.0/apps/astarte_appengine_api/priv/static/astarte_appengine_api.yaml",
+            url: "./astarte_appengine_api.yaml",
           },
           {
             name: "Realm Management API",
-            url:
-              "https://raw.githubusercontent.com/astarte-platform/astarte/v1.2.0/apps/astarte_realm_management_api/priv/static/astarte_realm_management_api.yaml",
+            url: "./astarte_realm_management.yaml",
           },
           {
             name: "Pairing API",
-            url:
-              "https://raw.githubusercontent.com/astarte-platform/astarte/v1.2.0/apps/astarte_pairing/priv/static/astarte_pairing.yaml",
+            url: "./astarte_pairing.yaml",
           },
           {
             name: "Housekeeping API",
-            url:
-              "https://raw.githubusercontent.com/astarte-platform/astarte/v1.2.0/apps/astarte_housekeeping_api/priv/static/astarte_housekeeping_api.yaml",
+            url: "./astarte_housekeeping_api.yaml",
           },
         ],
         dom_id: "#swagger-ui",


### PR DESCRIPTION
OpenApiSpex will generate API documentation yaml files for each Astarte API and commit them into Astarte docs.

Depends on:
- #1896 
- #1880 
- #1876 

