### PR TITLE
ci: stop running end to end tests twice on push

### DIFF
--- a/.github/workflows/astarte-end-to-end-test-workflow.yaml
+++ b/.github/workflows/astarte-end-to-end-test-workflow.yaml
@@ -1,15 +1,6 @@
 name: Astarte end-to-end test
 
 on:
-  # Run when pushing to stable branches
-  push:
-    paths:
-      - "apps/**"
-      - "tools/astarte_e2e/**"
-      - ".github/workflows/astarte-end-to-end-test-workflow.yaml"
-    branches:
-      - "master"
-      - "release-*"
   # Run on branch/tag creation
   create:
   # Run on pull requests matching apps


### PR DESCRIPTION
end to end tests are already run as part of the publish-snapshot ci,
we don't need to run them a second time