### PR TITLE
ci: Fix 403 on Astarte docs push

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -121,6 +121,6 @@ jobs:
           echo "${{ secrets.DOCS_DEPLOY_KEY }}" | ssh-add -
           mkdir -p ~/.ssh/
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git remote add topush "git@github.com:astarte-platform/docs.git"
-          git fetch topush
-          git push topush master
+          git config --global --unset-all url."https://${{ github.token }}:x-oauth-basic@github.com/".insteadOf || true
+          git remote set-url origin git@github.com:astarte-platform/docs.git
+          git push origin master


### PR DESCRIPTION
[Docs generation for Github Pages](https://github.com/astarte-platform/astarte/actions/workflows/docs-workflow.yaml) failing on docs push.

<img width="870" height="396" alt="image" src="https://github.com/user-attachments/assets/2d9c7ef7-2469-435e-8a49-175c9bae8388" />


`staple-actions` [configures](https://github.com/team-alembic/staple-actions/blob/41b1e46995448f976551fedad3ef6bf6ba7df873/actions/mix-deps-get/action.yml#L54) a global git insteadOf rewrite during mix deps.get, converting GitHub SSH/HTTPS remotes to HTTPS with github.token credentials. That makes the final docs push use the Actions token instead of the deploy key and fail with 403.

Remove the rewrite before push and reset origin to the SSH remote so the deploy key is used.
