### PR TITLE
fix: make msg= field in logfmt output show in Pairing and Housekeeping Logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+- [astarte_housekeeping] Changed logger config to make the metadata fields appear in logfmt log output.
+
 ## [1.3.0-rc.2] - 2026-04-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-- [astarte_housekeeping] Changed logger config to make the metadata fields appear in logfmt log output.
+### Fixed
+
+- [astarte_housekeeping] Changed logger config to make the metadata fields appear in logfmt log output; in particular the msg field
+- [astarte_pairing] Changed logger config to make the metadata fields appear in logfmt log output; in particular the msg field
 
 ## [1.3.0-rc.2] - 2026-04-08
 

--- a/apps/astarte_housekeeping/config/config.exs
+++ b/apps/astarte_housekeeping/config/config.exs
@@ -16,7 +16,7 @@ config :astarte_housekeeping, Astarte.HousekeepingWeb.Endpoint,
   render_errors: [view: Astarte.HousekeepingWeb.ErrorView, accepts: ~w(json)]
 
 # Configures Elixir's Logger
-config :logger, :default_formatter,
+config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:module, :function, :request_id, :tag, :realm, :datacenter, :replication_factor]
 

--- a/apps/astarte_housekeeping/config/dev.exs
+++ b/apps/astarte_housekeeping/config/dev.exs
@@ -32,7 +32,7 @@ config :astarte_housekeeping, Astarte.HousekeepingWeb.Endpoint,
 # Do not include metadata nor timestamps in development logs
 config :logger, :console,
   format: {PrettyLog.LogfmtFormatter, :format},
-  metadata: [:function]
+  metadata: [:module, :function, :request_id, :tag, :realm, :datacenter, :replication_factor]
 
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.

--- a/apps/astarte_housekeeping/config/test.exs
+++ b/apps/astarte_housekeeping/config/test.exs
@@ -9,7 +9,7 @@ config :astarte_housekeeping, Astarte.HousekeepingWeb.Endpoint,
 # Print only warnings and errors during test
 config :logger, :console,
   format: {PrettyLog.UserFriendlyFormatter, :format},
-  metadata: [:function]
+  metadata: [:module, :function, :request_id, :tag, :realm, :datacenter, :replication_factor]
 
 config :astarte_housekeeping,
        :test_priv_key,

--- a/apps/astarte_pairing/config/config.exs
+++ b/apps/astarte_pairing/config/config.exs
@@ -34,7 +34,7 @@ config :astarte_pairing, Astarte.PairingWeb.Endpoint,
   render_errors: [view: Astarte.PairingWeb.ErrorView, accepts: ~w(json)]
 
 # Configures Elixir's Logger
-config :logger, :default_formatter,
+config :logger, :console,
   format: "$time $metadata[$level] $message\n",
   metadata: [:request_id, :tag, :realm, :method, :hw_id, :common_name]
 


### PR DESCRIPTION
This PR aim to solve a problem where astarte_pairing and housekeeping logs lacked the msg= field in logfmt output.