### PR TITLE
chore(fdo_core): add unit tests to increase codecov coverage

### DIFF
--- a/libs/astarte_fdo_core/test/astarte_fdo_core/error_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/error_test.exs
@@ -1,0 +1,58 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.ErrorTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.Error
+
+  @sample_error %Error{
+    error_code: 100,
+    previous_message_id: 5,
+    error_message: "something went wrong",
+    timestamp: nil,
+    correlation_id: 42
+  }
+
+  describe "encode/1" do
+    test "returns a list with all fields in order" do
+      result = Error.encode(@sample_error)
+
+      assert result == [100, 5, "something went wrong", nil, 42]
+    end
+
+    test "preserves nil timestamp" do
+      [_, _, _, timestamp, _] = Error.encode(@sample_error)
+      assert is_nil(timestamp)
+    end
+  end
+
+  describe "encode_cbor/1" do
+    test "returns a binary" do
+      result = Error.encode_cbor(@sample_error)
+      assert is_binary(result)
+    end
+
+    test "roundtrips through CBOR" do
+      cbor = Error.encode_cbor(@sample_error)
+      {:ok, decoded, ""} = CBOR.decode(cbor)
+
+      assert decoded == Error.encode(@sample_error)
+    end
+  end
+end

--- a/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/owner_onboarding/ov_next_entry_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/owner_onboarding/ov_next_entry_test.exs
@@ -1,0 +1,67 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.OwnerOnboarding.OVNextEntryTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.OwnerOnboarding.OVNextEntry
+
+  @ov_entry_binary :crypto.strong_rand_bytes(32)
+
+  @sample %OVNextEntry{
+    entry_num: 0,
+    ov_entry: @ov_entry_binary
+  }
+
+  describe "to_cbor_list/1" do
+    test "returns a 2-element list with entry_num and ov_entry" do
+      result = OVNextEntry.to_cbor_list(@sample)
+      assert result == [0, @ov_entry_binary]
+    end
+
+    test "preserves entry_num" do
+      entry = %OVNextEntry{entry_num: 3, ov_entry: <<1, 2, 3>>}
+      [num, _] = OVNextEntry.to_cbor_list(entry)
+      assert num == 3
+    end
+  end
+
+  describe "encode/1" do
+    test "returns a binary" do
+      result = OVNextEntry.encode(@sample)
+      assert is_binary(result)
+    end
+
+    test "roundtrips through CBOR decoding" do
+      binary = OVNextEntry.encode(@sample)
+      {:ok, [entry_num, ov_entry], ""} = CBOR.decode(binary)
+
+      assert entry_num == @sample.entry_num
+      assert ov_entry == @sample.ov_entry
+    end
+
+    test "encodes different entry_num values correctly" do
+      for num <- [0, 1, 5, 255] do
+        entry = %OVNextEntry{entry_num: num, ov_entry: <<0>>}
+        binary = OVNextEntry.encode(entry)
+        {:ok, [decoded_num, _], ""} = CBOR.decode(binary)
+        assert decoded_num == num
+      end
+    end
+  end
+end

--- a/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/owner_onboarding/prove_device_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/owner_onboarding/prove_device_test.exs
@@ -1,0 +1,89 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.OwnerOnboarding.ProveDeviceTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.OwnerOnboarding.ProveDevice
+  alias COSE.Keys.ECC
+
+  describe "generate/0" do
+    test "returns a ProveDevice struct" do
+      result = ProveDevice.generate()
+      assert %ProveDevice{} = result
+    end
+
+    test "generates 16-byte nonces" do
+      %ProveDevice{
+        nonce_to2_prove_dv: nonce_prove,
+        nonce_to2_setup_dv: nonce_setup
+      } = ProveDevice.generate()
+
+      assert byte_size(nonce_prove) == 16
+      assert byte_size(nonce_setup) == 16
+    end
+
+    test "generates a 16-byte guid" do
+      %ProveDevice{guid: guid} = ProveDevice.generate()
+      assert byte_size(guid) == 16
+    end
+
+    test "each call generates different nonces" do
+      a = ProveDevice.generate()
+      b = ProveDevice.generate()
+      assert a.nonce_to2_prove_dv != b.nonce_to2_prove_dv
+    end
+  end
+
+  describe "euph_nonce_claim_key/0" do
+    test "returns -259" do
+      assert ProveDevice.euph_nonce_claim_key() == -259
+    end
+  end
+
+  describe "encode_sign/2 and decode/2 roundtrip" do
+    setup do
+      key = ECC.generate(:es256)
+      device = ProveDevice.generate()
+      %{key: key, device: device}
+    end
+
+    test "encode_sign returns a binary", %{key: key, device: device} do
+      assert {:ok, binary} = ProveDevice.encode_sign(device, key)
+      assert is_binary(binary)
+    end
+
+    test "decode recovers original fields", %{key: key, device: device} do
+      {:ok, binary} = ProveDevice.encode_sign(device, key)
+
+      assert {:ok, decoded} = ProveDevice.decode(binary, key)
+
+      assert decoded.xb_key_exchange == device.xb_key_exchange
+      assert decoded.nonce_to2_prove_dv == device.nonce_to2_prove_dv
+      assert decoded.nonce_to2_setup_dv == device.nonce_to2_setup_dv
+      assert decoded.guid == device.guid
+    end
+
+    test "decode with wrong key returns error", %{key: key, device: device} do
+      {:ok, binary} = ProveDevice.encode_sign(device, key)
+      wrong_key = ECC.generate(:es256)
+
+      assert {:error, _} = ProveDevice.decode(binary, wrong_key)
+    end
+  end
+end

--- a/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/owner_onboarding/prove_ov_hdr_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/owner_onboarding/prove_ov_hdr_test.exs
@@ -1,0 +1,104 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.OwnerOnboarding.ProveOVHdrTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.Hash
+  alias Astarte.FDO.Core.OwnerOnboarding.ProveOVHdr
+  alias COSE.Keys.ECC
+
+  defp build_sample_proveovhdr do
+    # Pre-encoded CBOR-compatible value for OV header (raw binary as CBOR-bstr source)
+    cbor_ov_header = CBOR.encode("ov-header-placeholder")
+    # Hash.encode returns a list [type_id, bstr] compatible to embed in a CBOR list
+    cbor_hmac = Hash.encode(Hash.new(:sha256, "test-ov-header"))
+
+    %ProveOVHdr{
+      cbor_ov_header: cbor_ov_header,
+      ov_header: nil,
+      num_ov_entries: 2,
+      hmac: nil,
+      cbor_hmac: cbor_hmac,
+      nonce_to2_prove_ov: :crypto.strong_rand_bytes(16),
+      eb_sig_info: :es256,
+      xa_key_exchange: :crypto.strong_rand_bytes(32),
+      hello_device_hash: Hash.new(:sha256, "hello-device-msg"),
+      max_owner_message_size: 65_536
+    }
+  end
+
+  describe "encode/1" do
+    test "returns a list with 8 elements" do
+      result = ProveOVHdr.encode(build_sample_proveovhdr())
+      assert length(result) == 8
+    end
+
+    test "second element is num_ov_entries" do
+      p = build_sample_proveovhdr()
+      result = ProveOVHdr.encode(p)
+      assert Enum.at(result, 1) == p.num_ov_entries
+    end
+
+    test "last element is max_owner_message_size" do
+      p = build_sample_proveovhdr()
+      result = ProveOVHdr.encode(p)
+      assert List.last(result) == p.max_owner_message_size
+    end
+
+    test "raises when both cbor_ov_header and ov_header are nil" do
+      p = %{build_sample_proveovhdr() | cbor_ov_header: nil, ov_header: nil}
+      assert_raise RuntimeError, fn -> ProveOVHdr.encode(p) end
+    end
+
+    test "raises when both cbor_hmac and hmac are nil" do
+      p = %{build_sample_proveovhdr() | cbor_hmac: nil, hmac: nil}
+      assert_raise RuntimeError, fn -> ProveOVHdr.encode(p) end
+    end
+  end
+
+  describe "encode_cbor/1" do
+    test "returns a binary" do
+      result = ProveOVHdr.encode_cbor(build_sample_proveovhdr())
+      assert is_binary(result)
+    end
+
+    test "decodes back to an 8-element list" do
+      cbor = ProveOVHdr.encode_cbor(build_sample_proveovhdr())
+      {:ok, list, ""} = CBOR.decode(cbor)
+      assert length(list) == 8
+    end
+  end
+
+  describe "encode_sign/4" do
+    setup do
+      owner_key = ECC.generate(:es256)
+      # owner_pub_key is embedded as-is in the COSE unprotected header
+      owner_pub_key = :crypto.strong_rand_bytes(32)
+      dv_nonce = :crypto.strong_rand_bytes(16)
+      p = build_sample_proveovhdr()
+
+      %{owner_key: owner_key, owner_pub_key: owner_pub_key, dv_nonce: dv_nonce, p: p}
+    end
+
+    test "returns a binary", %{owner_key: k, owner_pub_key: pub, dv_nonce: nonce, p: p} do
+      assert {:ok, result} = ProveOVHdr.encode_sign(p, nonce, pub, k)
+      assert is_binary(result)
+    end
+  end
+end

--- a/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/owner_onboarding/setup_device_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/owner_onboarding/setup_device_test.exs
@@ -1,0 +1,96 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.OwnerOnboarding.SetupDevicePayloadTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.OwnerOnboarding.SetupDevicePayload
+  alias Astarte.FDO.Core.OwnershipVoucher.RendezvousInfo
+  alias Astarte.FDO.Core.PublicKey
+  alias COSE.Keys.ECC
+
+  @rendezvous_info_cbor [
+    [
+      [5, %CBOR.Tag{tag: :bytes, value: "ufdo.astarte.localhost"}],
+      [12, %CBOR.Tag{tag: :bytes, value: <<1>>}],
+      [3, %CBOR.Tag{tag: :bytes, value: <<24, 80>>}],
+      [4, %CBOR.Tag{tag: :bytes, value: <<25, 31, 105>>}],
+      [13, %CBOR.Tag{tag: :bytes, value: "\n"}]
+    ]
+  ]
+
+  defp build_payload do
+    {:ok, rv_info} = RendezvousInfo.decode(@rendezvous_info_cbor)
+
+    owner2_key = %PublicKey{
+      type: :secp256r1,
+      encoding: :x509,
+      body: :crypto.strong_rand_bytes(32)
+    }
+
+    %SetupDevicePayload{
+      rendezvous_info: rv_info,
+      guid: :crypto.strong_rand_bytes(16),
+      nonce_setup_device: :crypto.strong_rand_bytes(16),
+      owner2_key: owner2_key
+    }
+  end
+
+  describe "to_cbor_list/1" do
+    test "returns a 4-element list" do
+      result = SetupDevicePayload.to_cbor_list(build_payload())
+      assert length(result) == 4
+    end
+
+    test "guid is wrapped as a bstr tag" do
+      p = build_payload()
+      [_, guid_tagged, _, _] = SetupDevicePayload.to_cbor_list(p)
+      assert %CBOR.Tag{tag: :bytes, value: p_guid} = guid_tagged
+      assert p_guid == p.guid
+    end
+
+    test "nonce is wrapped as a bstr tag" do
+      p = build_payload()
+      [_, _, nonce_tagged, _] = SetupDevicePayload.to_cbor_list(p)
+      assert %CBOR.Tag{tag: :bytes} = nonce_tagged
+    end
+  end
+
+  describe "encode/1" do
+    test "returns a binary" do
+      result = SetupDevicePayload.encode(build_payload())
+      assert is_binary(result)
+    end
+
+    test "decodes back to a 4-element list" do
+      cbor = SetupDevicePayload.encode(build_payload())
+      {:ok, list, ""} = CBOR.decode(cbor)
+      assert length(list) == 4
+    end
+  end
+
+  describe "encode_sign/2" do
+    test "returns {:ok, cbor_tag} when given a valid owner key" do
+      key = ECC.generate(:es256)
+      p = build_payload()
+
+      assert {:ok, signed} = SetupDevicePayload.encode_sign(p, key)
+      assert %CBOR.Tag{} = signed
+    end
+  end
+end

--- a/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/rendezvous/owner_sign/owner_sign_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/rendezvous/owner_sign/owner_sign_test.exs
@@ -1,0 +1,84 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.Rendezvous.OwnerSignTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.Rendezvous.OwnerSign
+  alias Astarte.FDO.Core.Rendezvous.OwnerSign.TO0D
+  alias Astarte.FDO.Core.Rendezvous.OwnerSign.TO1D
+  alias Astarte.FDO.Core.Rendezvous.RvTO2Addr
+  alias COSE.Keys.ECC
+
+  defp build_owner_sign do
+    to0d = %TO0D{
+      cbor_decoded_ownership_voucher: [1, 2, 3],
+      wait_seconds: 3600,
+      nonce_to0_sign: :crypto.strong_rand_bytes(16)
+    }
+
+    to1d = %TO1D{
+      rv_to2_addr: [
+        %RvTO2Addr{ip: nil, dns: "owner.example.com", port: 8042, protocol: :https}
+      ],
+      # to0d_hash is computed inside encode_sign_with_hash, so nil is fine here
+      to0d_hash: nil
+    }
+
+    %OwnerSign{to0d: to0d, to1d: to1d}
+  end
+
+  describe "encode_sign_with_hash/2" do
+    setup do
+      %{key: ECC.generate(:es256)}
+    end
+
+    test "returns {:ok, [bstr, signed_to1d]}", %{key: key} do
+      owner_sign = build_owner_sign()
+      assert {:ok, [bstr, to1d_signed]} = OwnerSign.encode_sign_with_hash(owner_sign, key)
+      assert %CBOR.Tag{tag: :bytes} = bstr
+      assert %CBOR.Tag{} = to1d_signed
+    end
+
+    test "each call produces a different to0d bstr (different nonce)", %{key: key} do
+      a = build_owner_sign()
+      b = build_owner_sign()
+      {:ok, [bstr_a, _]} = OwnerSign.encode_sign_with_hash(a, key)
+      {:ok, [bstr_b, _]} = OwnerSign.encode_sign_with_hash(b, key)
+      assert bstr_a.value != bstr_b.value
+    end
+  end
+
+  describe "encode_sign_cbor_with_hash/2" do
+    setup do
+      %{key: ECC.generate(:es256)}
+    end
+
+    test "returns {:ok, binary}", %{key: key} do
+      owner_sign = build_owner_sign()
+      assert {:ok, cbor_binary} = OwnerSign.encode_sign_cbor_with_hash(owner_sign, key)
+      assert is_binary(cbor_binary)
+    end
+
+    test "result is valid CBOR", %{key: key} do
+      owner_sign = build_owner_sign()
+      {:ok, cbor_binary} = OwnerSign.encode_sign_cbor_with_hash(owner_sign, key)
+      assert {:ok, _, ""} = CBOR.decode(cbor_binary)
+    end
+  end
+end

--- a/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/rendezvous/owner_sign/to0d_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/rendezvous/owner_sign/to0d_test.exs
@@ -1,0 +1,70 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.Rendezvous.OwnerSign.TO0DTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.Rendezvous.OwnerSign.TO0D
+
+  defp sample do
+    %TO0D{
+      cbor_decoded_ownership_voucher: [1, 2, 3],
+      wait_seconds: 3600,
+      nonce_to0_sign: :crypto.strong_rand_bytes(16)
+    }
+  end
+
+  describe "encode/1" do
+    test "returns a 3-element list" do
+      result = TO0D.encode(sample())
+      assert length(result) == 3
+    end
+
+    test "first element is the decoded ownership voucher" do
+      t = sample()
+      [ov, _, _] = TO0D.encode(t)
+      assert ov == t.cbor_decoded_ownership_voucher
+    end
+
+    test "second element is wait_seconds" do
+      t = sample()
+      [_, wait, _] = TO0D.encode(t)
+      assert wait == t.wait_seconds
+    end
+
+    test "nonce is wrapped as a CBOR bstr tag" do
+      t = sample()
+      [_, _, nonce_tagged] = TO0D.encode(t)
+      assert %CBOR.Tag{tag: :bytes, value: nonce_val} = nonce_tagged
+      assert nonce_val == t.nonce_to0_sign
+    end
+  end
+
+  describe "encode_cbor/1" do
+    test "returns a binary" do
+      result = TO0D.encode_cbor(sample())
+      assert is_binary(result)
+    end
+
+    test "CBOR decodes back to a 3-element list" do
+      cbor = TO0D.encode_cbor(sample())
+      {:ok, list, ""} = CBOR.decode(cbor)
+      assert length(list) == 3
+    end
+  end
+end

--- a/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/rendezvous/owner_sign/to1d_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/rendezvous/owner_sign/to1d_test.exs
@@ -1,0 +1,74 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.Rendezvous.OwnerSign.TO1DTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.Hash
+  alias Astarte.FDO.Core.Rendezvous.OwnerSign.TO1D
+  alias Astarte.FDO.Core.Rendezvous.RvTO2Addr
+  alias COSE.Keys.ECC
+
+  defp sample do
+    %TO1D{
+      rv_to2_addr: [
+        %RvTO2Addr{ip: nil, dns: "owner.example.com", port: 8042, protocol: :https}
+      ],
+      to0d_hash: Hash.new(:sha256, "some-to0d-content")
+    }
+  end
+
+  describe "encode/1" do
+    test "returns a 2-element list" do
+      result = TO1D.encode(sample())
+      assert length(result) == 2
+    end
+
+    test "first element is a list of encoded rv_to2_addr" do
+      [rv_list, _] = TO1D.encode(sample())
+      assert is_list(rv_list)
+      assert length(rv_list) == 1
+    end
+
+    test "second element is a hash encoding (2-element list)" do
+      [_, hash_encoded] = TO1D.encode(sample())
+      assert [_type_id, %CBOR.Tag{tag: :bytes}] = hash_encoded
+    end
+  end
+
+  describe "encode_cbor/1" do
+    test "returns a binary" do
+      result = TO1D.encode_cbor(sample())
+      assert is_binary(result)
+    end
+
+    test "decodes back to a 2-element list" do
+      cbor = TO1D.encode_cbor(sample())
+      {:ok, list, ""} = CBOR.decode(cbor)
+      assert length(list) == 2
+    end
+  end
+
+  describe "encode_sign/2" do
+    test "returns {:ok, cbor_tag} with a valid key" do
+      key = ECC.generate(:es256)
+      assert {:ok, signed} = TO1D.encode_sign(sample(), key)
+      assert %CBOR.Tag{} = signed
+    end
+  end
+end

--- a/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/rendezvous/rv_to2_addr_test.exs
+++ b/libs/astarte_fdo_core/test/astarte_fdo_core/fdo/rendezvous/rv_to2_addr_test.exs
@@ -1,0 +1,38 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.FDO.Core.Rendezvous.RvTO2AddrTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.FDO.Core.Rendezvous.RvTO2Addr
+
+  describe "encode_protocol/1" do
+    test "encodes all supported protocols" do
+      assert RvTO2Addr.encode_protocol(:tcp) == 1
+      assert RvTO2Addr.encode_protocol(:tls) == 2
+      assert RvTO2Addr.encode_protocol(:http) == 3
+      assert RvTO2Addr.encode_protocol(:coap) == 4
+      assert RvTO2Addr.encode_protocol(:https) == 5
+      assert RvTO2Addr.encode_protocol(:coaps) == 6
+    end
+
+    test "raises for unknown protocol" do
+      assert_raise KeyError, fn -> RvTO2Addr.encode_protocol(:ftp) end
+    end
+  end
+end


### PR DESCRIPTION
This PR aims to add unit tests to increase astarte_fdo_core library codecov coverage to at least 80%