### PR TITLE
docs(appengine): Add missing API docs

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/api_spec/api_spec.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/api_spec/api_spec.ex
@@ -100,6 +100,10 @@ defmodule Astarte.AppEngine.APIWeb.ApiSpec do
         %Tag{
           name: "stats",
           description: "Retrieve stats (e.g. total number of devices, connected devices, etc)."
+        },
+        %Tag{
+          name: "version",
+          description: "Retrieve version information of the API."
         }
       ]
     }

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_by_device_alias_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_by_device_alias_controller.ex
@@ -18,12 +18,181 @@
 
 defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByDeviceAliasController do
   use Astarte.AppEngine.APIWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Astarte.AppEngine.API.Device
   alias Astarte.AppEngine.API.Device.InterfaceValues
+  alias Astarte.AppEngine.APIWeb.ApiSpec.Schemas.Errors
   alias Astarte.AppEngine.APIWeb.InterfaceValuesView
+  alias OpenApiSpex.{Reference, Schema}
 
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
+
+  tags ["device"]
+  security [%{"JWT" => []}]
+
+  operation :index,
+    summary: "Get interfaces list by Device alias",
+    description:
+      "Get a list of interfaces supported by a certain device. Interfaces that are not reported by the device are not reported here. If a device stops to advertise a certain interface, it should be retrieved from a different API, same applies for older versions of a certain interface.",
+    operation_id: "getInterfacesByDeviceAlias",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      device_alias: [in: :path, description: "Device alias", required: true, type: :string]
+    ],
+    responses: [
+      ok:
+        {"Success", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{
+               type: :array,
+               items: %Schema{type: :string},
+               example: ["com.test.foo", "com.test.bar"]
+             }
+           }
+         }},
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found: {"Device not found.", "application/json", Errors.NotFoundError}
+    ]
+
+  operation :show_value,
+    summary: "Get property value by Device alias",
+    description:
+      "Retrieve a value on a given path. This action on a data production path returns the last entry if no query parameters are specified.",
+    operation_id: "getInterfacePropertyValueByDeviceAlias",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      device_alias: [in: :path, description: "Device alias", required: true, type: :string],
+      interface: [in: :path, description: "Interface name", required: true, type: :string],
+      path: [in: :path, description: "Endpoint Path", required: true, type: :string],
+      since: [
+        in: :query,
+        description:
+          "Query all values since a certain timestamp (all entries where timestamp >= since). This query parameter applies only on data streams. It must be a ISO 8601 valid timestamp. It can't be used if since is already used. See also 'since_after', to' and 'limit' parameters.",
+        required: false,
+        type: :string
+      ],
+      since_after: [
+        in: :query,
+        description:
+          "Query all values since after a certain timestamp (all entries where timestamp > since_after). This query parameter applies only on data streams. It must be a ISO 8601 valid timestamp. It can't be used if since is already specified. See also 'since', 'to' and 'limit' parameters.",
+        required: false,
+        type: :string
+      ],
+      to: [
+        in: :query,
+        description:
+          "Query all values up to a certain timestamp. If since is not specified first entry date is assumed by default. This query parameter applies only on data streams. It must be a ISO 8601 valid timestamp. See also 'since' and 'limit' parameters.",
+        required: false,
+        type: :string
+      ],
+      limit: [
+        in: :query,
+        description:
+          "Limit number of retrieved data production entries to 'limit'. This parameter must be always specified when 'since', 'since-after' and 'to' query parameters are used. If limit is specified without any 'since' and 'to' parameter, last 'limit' values are retrieved. When 'limit' entries are returned, it should be checked if any other entry is left by using since-after the last received timestamp. An error is returned if limit exceeds maximum allowed value. See also 'since' and 'to' parameters.",
+        required: false,
+        type: :string
+      ]
+    ],
+    responses: [
+      ok: "Success",
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found:
+        {"Path not found or interface not found in introspection or device not found.",
+         "application/json", Errors.NotFoundError},
+      method_not_allowed: "Invalid Request"
+    ]
+
+  operation :show_values,
+    summary: "Get properties values by Device alias",
+    description:
+      "Get a values snapshot for a given interface on a certain device. This action performed on a data stream interface returns the most recent set of data for each endpoint. More specific APIs should be used for advances data stream actions.",
+    operation_id: "getInterfacePropertiesValuesByDeviceAlias",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      device_alias: [in: :path, description: "Device alias", required: true, type: :string],
+      interface: [in: :path, description: "Interface name", required: true, type: :string]
+    ],
+    responses: [
+      ok: "Success",
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found:
+        {"Interface not found in introspection or device not found.", "application/json",
+         Errors.NotFoundError}
+    ]
+
+  operation :update,
+    summary: "Update and push a value on a path by Device alias",
+    description:
+      "Update and push a property value to the device on a certain endpoint path. interface should be an individual server owned property interface. It mustn't be used to stream data to a device or to update single properties that are members of an object aggregated interface.",
+    operation_id: "updatePathValueByDeviceAlias",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      device_alias: [in: :path, description: "Device alias", required: true, type: :string],
+      interface: [in: :path, description: "Interface name", required: true, type: :string],
+      path: [in: :path, description: "Endpoint Path", required: true, type: :string]
+    ],
+    responses: [
+      ok: "Success",
+      bad_request: "Bad request",
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found:
+        {"Endpoint not found or interface not found in introspection or device not found.",
+         "application/json", Errors.NotFoundError},
+      method_not_allowed: "Invalid object",
+      unprocessable_entity: "Tried to unset a property with `allow_unset` false"
+    ]
+
+  operation :delete,
+    summary: "Delete path and push an unset value message by Device alias",
+    description:
+      "Unset a value on a certain path, path is also deleted. Endpoint must support unset.",
+    operation_id: "deletePathValueByDeviceAlias",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      device_alias: [in: :path, description: "Device alias", required: true, type: :string],
+      interface: [in: :path, description: "Interface name", required: true, type: :string],
+      path: [in: :path, description: "Endpoint Path", required: true, type: :string]
+    ],
+    responses: [
+      no_content: "Success",
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found:
+        {"Path not found or interface not found in introspection or device not found.",
+         "application/json", Errors.NotFoundError}
+    ]
 
   def index(conn, %{"realm_name" => realm_name, "device_alias" => device_alias}) do
     with {:ok, device_id} <- Device.device_alias_to_device_id(realm_name, device_alias),
@@ -36,15 +205,23 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByDeviceAliasController do
     end
   end
 
-  def show(
-        conn,
-        %{
-          "realm_name" => realm_name,
-          "device_alias" => device_alias,
-          "interface" => interface,
-          "path" => path
-        } = parameters
-      ) do
+  def show_value(conn, parameters) do
+    do_show(conn, parameters)
+  end
+
+  def show_values(conn, parameters) do
+    do_show(conn, parameters)
+  end
+
+  defp do_show(
+         conn,
+         %{
+           "realm_name" => realm_name,
+           "device_alias" => device_alias,
+           "interface" => interface,
+           "path" => path
+         } = parameters
+       ) do
     with {:ok, device_id} <- Device.device_alias_to_device_id(realm_name, device_alias),
          encoded_device_id <- Base.url_encode64(device_id, padding: false),
          _ = Logger.metadata(device_id: encoded_device_id),
@@ -62,11 +239,11 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByDeviceAliasController do
     end
   end
 
-  def show(
-        conn,
-        %{"realm_name" => realm_name, "device_alias" => device_alias, "interface" => interface} =
-          parameters
-      ) do
+  defp do_show(
+         conn,
+         %{"realm_name" => realm_name, "device_alias" => device_alias, "interface" => interface} =
+           parameters
+       ) do
     with {:ok, device_id} <- Device.device_alias_to_device_id(realm_name, device_alias),
          encoded_device_id <- Base.url_encode64(device_id, padding: false),
          _ = Logger.metadata(device_id: encoded_device_id),

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_by_group_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/interface_values_by_group_controller.ex
@@ -18,13 +18,187 @@
 
 defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupController do
   use Astarte.AppEngine.APIWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Astarte.AppEngine.API.Device
   alias Astarte.AppEngine.API.Device.InterfaceValues
   alias Astarte.AppEngine.API.Groups
+  alias Astarte.AppEngine.APIWeb.ApiSpec.Schemas.Errors
   alias Astarte.AppEngine.APIWeb.InterfaceValuesView
+  alias OpenApiSpex.{Reference, Schema}
 
   action_fallback Astarte.AppEngine.APIWeb.FallbackController
+
+  tags ["groups"]
+  security [%{"JWT" => []}]
+
+  operation :index,
+    summary: "Get interfaces list for device in a group",
+    description:
+      "Get a list of interfaces supported by a certain device that belongs to a group. Interfaces that are not reported by the device are not reported here. If a device stops to advertise a certain interface, it should be retrieved from a different API, same applies for older versions of a certain interface.",
+    operation_id: "getGroupDeviceInterfaces",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      group_name: [in: :path, description: "Group name", required: true, type: :string],
+      device_id: [in: :path, description: "Device ID", required: true, type: :string]
+    ],
+    responses: [
+      ok:
+        {"Success", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{
+               type: :array,
+               items: %Schema{type: :string},
+               example: ["com.test.foo", "com.test.bar"]
+             }
+           }
+         }},
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found: {"Device not found.", "application/json", Errors.NotFoundError}
+    ]
+
+  operation :show_value,
+    summary: "Get property value for device in a group",
+    description:
+      "Retrieve a value on a given path for a device that belongs to a group. This action on a data production path returns the last entry if no query parameters are specified.",
+    operation_id: "getGroupDeviceInterfacePropertyValue",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      group_name: [in: :path, description: "Group name", required: true, type: :string],
+      device_id: [in: :path, description: "Device ID", required: true, type: :string],
+      interface: [in: :path, description: "Interface name", required: true, type: :string],
+      path: [in: :path, description: "Endpoint Path", required: true, type: :string],
+      since: [
+        in: :query,
+        description:
+          "Query all values since a certain timestamp (all entries where timestamp >= since). This query parameter applies only on data streams. It must be a ISO 8601 valid timestamp. It can't be used if since is already used. See also 'since_after', to' and 'limit' parameters.",
+        required: false,
+        type: :string
+      ],
+      since_after: [
+        in: :query,
+        description:
+          "Query all values since after a certain timestamp (all entries where timestamp > since_after). This query parameter applies only on data streams. It must be a ISO 8601 valid timestamp. It can't be used if since is already specified. See also 'since', 'to' and 'limit' parameters.",
+        required: false,
+        type: :string
+      ],
+      to: [
+        in: :query,
+        description:
+          "Query all values up to a certain timestamp. If since is not specified first entry date is assumed by default. This query parameter applies only on data streams. It must be a ISO 8601 valid timestamp. See also 'since' and 'limit' parameters.",
+        required: false,
+        type: :string
+      ],
+      limit: [
+        in: :query,
+        description:
+          "Limit number of retrieved data production entries to 'limit'. This parameter must be always specified when 'since', 'since-after' and 'to' query parameters are used. If limit is specified without any 'since' and 'to' parameter, last 'limit' values are retrieved. When 'limit' entries are returned, it should be checked if any other entry is left by using since-after the last received timestamp. An error is returned if limit exceeds maximum allowed value. See also 'since' and 'to' parameters.",
+        required: false,
+        type: :string
+      ]
+    ],
+    responses: [
+      ok: "Success",
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found:
+        {"Path not found or interface not found in introspection or device not found.",
+         "application/json", Errors.NotFoundError},
+      method_not_allowed: "Invalid Request"
+    ]
+
+  operation :show_values,
+    summary: "Get properties values for device in a group",
+    description:
+      "Get a values snapshot for a given interface on a certain device that belongs to a group. This action performed on a data stream interface returns the most recent set of data for each endpoint. More specific APIs should be used for advanced data stream actions.",
+    operation_id: "getGroupDeviceInterfacePropertiesValues",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      group_name: [in: :path, description: "Group name", required: true, type: :string],
+      device_id: [in: :path, description: "Device ID", required: true, type: :string],
+      interface: [in: :path, description: "Interface name", required: true, type: :string]
+    ],
+    responses: [
+      ok: "Success",
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found:
+        {"Interface not found in introspection or device not found.", "application/json",
+         Errors.NotFoundError}
+    ]
+
+  operation :update,
+    summary: "Update and push a value on a path for device in a group",
+    description:
+      "Update and push a property value to the device on a certain endpoint path. interface should be an individual server owned property interface. It mustn't be used to stream data to a device or to update single properties that are members of an object aggregated interface.",
+    operation_id: "updateGroupDevicePathValue",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      group_name: [in: :path, description: "Group name", required: true, type: :string],
+      device_id: [in: :path, description: "Device ID", required: true, type: :string],
+      interface: [in: :path, description: "Interface name", required: true, type: :string],
+      path: [in: :path, description: "Endpoint Path", required: true, type: :string]
+    ],
+    responses: [
+      ok: "Success",
+      bad_request: "Bad request",
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found:
+        {"Endpoint not found or interface not found in introspection or device not found.",
+         "application/json", Errors.NotFoundError},
+      method_not_allowed: "Invalid object",
+      unprocessable_entity: "Tried to unset a property with `allow_unset` false"
+    ]
+
+  operation :delete,
+    summary: "Delete path and push an unset value message for device in a group",
+    description:
+      "Unset a value on a certain path, path is also deleted. Endpoint must support unset.",
+    operation_id: "deleteGroupDevicePathValue",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm which the device belongs to.",
+        required: true,
+        type: :string
+      ],
+      group_name: [in: :path, description: "Group name", required: true, type: :string],
+      device_id: [in: :path, description: "Device ID", required: true, type: :string],
+      interface: [in: :path, description: "Interface name", required: true, type: :string],
+      path: [in: :path, description: "Endpoint Path", required: true, type: :string]
+    ],
+    responses: [
+      no_content: "Success",
+      unauthorized: %Reference{"$ref": "#/components/responses/Unauthorized"},
+      forbidden: %Reference{"$ref": "#/components/responses/AuthorizationPathNotMatched"},
+      not_found:
+        {"Path not found or interface not found in introspection or device not found.",
+         "application/json", Errors.NotFoundError}
+    ]
 
   def index(conn, %{
         "realm_name" => realm_name,
@@ -46,16 +220,24 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupController do
     end
   end
 
-  def show(
-        conn,
-        %{
-          "realm_name" => realm_name,
-          "group_name" => group_name,
-          "device_id" => device_id,
-          "interface" => interface,
-          "path" => path
-        } = parameters
-      ) do
+  def show_value(conn, parameters) do
+    do_show(conn, parameters)
+  end
+
+  def show_values(conn, parameters) do
+    do_show(conn, parameters)
+  end
+
+  defp do_show(
+         conn,
+         %{
+           "realm_name" => realm_name,
+           "group_name" => group_name,
+           "device_id" => device_id,
+           "interface" => interface,
+           "path" => path
+         } = parameters
+       ) do
     with {:ok, true} <- Groups.check_device_in_group(realm_name, group_name, device_id),
          {:ok, %InterfaceValues{} = interface_values} <-
            Device.get_interface_values!(
@@ -78,18 +260,23 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupController do
     end
   end
 
-  def show(
-        conn,
-        %{
-          "realm_name" => realm_name,
-          "group_name" => group_name,
-          "device_id" => device_id,
-          "interface" => interface
-        } = parameters
-      ) do
+  defp do_show(
+         conn,
+         %{
+           "realm_name" => realm_name,
+           "group_name" => group_name,
+           "device_id" => device_id,
+           "interface" => interface
+         } = parameters
+       ) do
     with {:ok, true} <- Groups.check_device_in_group(realm_name, group_name, device_id),
          {:ok, %InterfaceValues{} = interface_values} <-
-           Device.get_interface_values!(realm_name, device_id, interface, parameters) do
+           Device.get_interface_values!(
+             realm_name,
+             device_id,
+             interface,
+             parameters
+           ) do
       conn
       |> put_view(InterfaceValuesView)
       |> render("show.json", interface_values: interface_values)
@@ -132,7 +319,6 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupController do
         {:error, :device_not_found}
 
       {:error, reason} ->
-        # To FallbackController
         {:error, reason}
     end
   end
@@ -152,7 +338,6 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupController do
         {:error, :device_not_found}
 
       {:error, reason} ->
-        # To FallbackController
         {:error, reason}
     end
   end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/version_controller.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/controllers/version_controller.ex
@@ -18,10 +18,59 @@
 
 defmodule Astarte.AppEngine.APIWeb.VersionController do
   use Astarte.AppEngine.APIWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias OpenApiSpex.Schema
 
   @version Mix.Project.config()[:version]
 
+  tags ["version"]
+
+  operation :show,
+    summary: "Retrieve API version",
+    description:
+      "Return the AppEngine API version. This endpoint is available at {base_url}/version (without /v1).",
+    operation_id: "getVersion",
+    responses: [
+      ok:
+        {"Success", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{type: :string, example: "1.3.0"}
+           }
+         }}
+    ]
+
+  operation :show_with_realm,
+    summary: "Retrieve API version",
+    description: "Return the AppEngine API version.",
+    operation_id: "getVersionWithRealm",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ]
+    ],
+    responses: [
+      ok:
+        {"Success", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{type: :string, example: "1.3.0"}
+           }
+         }}
+    ]
+
   def show(conn, _params) do
+    render(conn, "show.json", %{version: @version})
+  end
+
+  def show_with_realm(conn, _params) do
     render(conn, "show.json", %{version: @version})
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api_web/router.ex
@@ -52,7 +52,7 @@ defmodule Astarte.AppEngine.APIWeb.Router do
   scope "/v1/:realm_name", Astarte.AppEngine.APIWeb do
     pipe_through :realm_api
 
-    get "/version", VersionController, :show
+    get "/version", VersionController, :show_with_realm
 
     scope "/stats" do
       get "/devices", StatsController, :show_devices_stats
@@ -100,14 +100,15 @@ defmodule Astarte.AppEngine.APIWeb.Router do
       scope "/:device_alias/interfaces" do
         pipe_through :interface_value_api
 
-        resources "/",
-                  InterfaceValuesByDeviceAliasController,
-                  only: [:index, :show],
-                  param: "interface"
+        get "/", InterfaceValuesByDeviceAliasController, :index
+
+        get "/:interface",
+            InterfaceValuesByDeviceAliasController,
+            :show_values
 
         get "/:interface/*path_tokens",
             InterfaceValuesByDeviceAliasController,
-            :show
+            :show_value
 
         put "/:interface/*path_tokens",
             InterfaceValuesByDeviceAliasController,
@@ -150,11 +151,11 @@ defmodule Astarte.AppEngine.APIWeb.Router do
 
             get "/:interface",
                 InterfaceValuesByGroupController,
-                :show
+                :show_values
 
             get "/:interface/*path_tokens",
                 InterfaceValuesByGroupController,
-                :show
+                :show_value
 
             put "/:interface/*path_tokens",
                 InterfaceValuesByGroupController,

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/api_spec/api_spec_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/api_spec/api_spec_test.exs
@@ -23,24 +23,8 @@ defmodule Astarte.AppEngine.APIWeb.ApiSpecTest do
 
   alias Astarte.AppEngine.APIWeb.{
     ApiSpec,
-    DeviceStatusByAliasController,
-    DeviceStatusByGroupController,
-    DeviceStatusController,
-    GroupsController,
-    InterfaceValuesController,
-    Router,
-    StatsController
+    Router
   }
-
-  # TODO: Remove this once we have all the routes documented
-  @documented_controllers [
-    DeviceStatusByAliasController,
-    DeviceStatusByGroupController,
-    DeviceStatusController,
-    GroupsController,
-    InterfaceValuesController,
-    StatsController
-  ]
 
   test "spec can be generated" do
     spec = ApiSpec.spec()
@@ -63,8 +47,9 @@ defmodule Astarte.AppEngine.APIWeb.ApiSpecTest do
   test "all documented routes are present in the OpenAPI spec" do
     expected_operations =
       Router.__routes__()
-      |> Enum.filter(&documented_route?/1)
       |> MapSet.new(&normalize_route/1)
+      |> Enum.reject(&ignore_swagger_route/1)
+      |> MapSet.new()
 
     actual_operations =
       ApiSpec.spec().paths
@@ -84,8 +69,8 @@ defmodule Astarte.AppEngine.APIWeb.ApiSpecTest do
     String.replace(path, "/*path_tokens", "/{path}")
   end
 
-  defp documented_route?(route) do
-    route.plug in @documented_controllers
+  defp ignore_swagger_route({path, _verb}) do
+    String.starts_with?(path, "/swagger")
   end
 
   defp normalize_route(route) do

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_by_device_alias_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_by_device_alias_controller_test.exs
@@ -76,7 +76,7 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByDeviceAliasControllerTest do
           conn,
           interface_values_by_device_alias_path(
             conn,
-            :show,
+            :show_values,
             "autotestrealm",
             "device_a",
             "com.test.LCDMonitor"
@@ -122,6 +122,23 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByDeviceAliasControllerTest do
         )
 
       assert json_response(object_conn, 200)["data"] == expected_reply
+    end
+
+    test "get interface value by path", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          interface_values_by_device_alias_path(
+            conn,
+            :show_value,
+            "autotestrealm",
+            "device_a",
+            "com.test.LCDMonitor",
+            ["time", "to"]
+          )
+        )
+
+      assert json_response(conn, 200)["data"] == 20
     end
   end
 

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_by_group_controller_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/controllers/interface_values_by_group_controller_test.exs
@@ -119,7 +119,7 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupControllerTest do
           conn,
           interface_values_by_group_path(
             conn,
-            :show,
+            :show_values,
             @realm,
             @group_name,
             "nwsmmgqkQiODs9IWBz3yRw",
@@ -136,7 +136,7 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupControllerTest do
           conn,
           interface_values_by_group_path(
             conn,
-            :show,
+            :show_values,
             @realm,
             @group_name,
             @device_id_not_in_group,
@@ -163,7 +163,7 @@ defmodule Astarte.AppEngine.APIWeb.InterfaceValuesByGroupControllerTest do
           conn,
           interface_values_by_group_path(
             conn,
-            :show,
+            :show_values,
             @realm,
             @group_name,
             @device_id,


### PR DESCRIPTION
Specify API documentation for all AppEngine endpoints.

Described version endpoints.
Described device by alias actions and device by group actions.
Renamed show functions to able to separate API specification for different endpoints.

API specification can be generated using command:
`mix openapi.spec.yaml --spec Astarte.AppEngine.APIWeb.ApiSpec --start-app=false --vendor-extensions=false`
