### PR TITLE
feat(housekeeping): default astarte keyspace replication to NetworkTopologyStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Changed
+
+- [astarte_housekeeping] When `HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_STRATEGY` is not set, the `astarte` keyspace is now created using `NetworkTopologyStrategy` with a replication map derived from the current ScyllaDB network topology (one replica per node in each datacenter), instead of falling back to `SimpleStrategy` with replication factor 1.
+
 ### Fixed
 
 - [astarte_housekeeping] Changed logger config to make the metadata fields appear in logfmt log output; in particular the msg field

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/config.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/config.ex
@@ -50,21 +50,24 @@ defmodule Astarte.Housekeeping.Config do
     type: :boolean,
     default: false
 
-  @envdoc "Replication strategy for the `astarte` keyspace, either `simple` or `network`. Defaults to `simple`"
+  @envdoc """
+  Replication strategy for the `astarte` keyspace, either `SimpleStrategy` or
+  `NetworkTopologyStrategy`. When unset, the astarte keyspace defaults to
+  `NetworkTopologyStrategy` using the current ScyllaDB network topology
+  (one replica per node in each datacenter).
+  """
   app_env :astarte_keyspace_replication_strategy,
           :astarte_housekeeping,
           :astarte_keyspace_replication_strategy,
           os_env: "HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_STRATEGY",
-          type: Astarte.Housekeeping.Config.ReplicationStrategy,
-          default: :simple_strategy
+          type: Astarte.Housekeeping.Config.ReplicationStrategy
 
-  @envdoc "Replication factor for the astarte keyspace, used when simple strategy is used for the astarte keyspace. defaults to 1"
+  @envdoc "Replication factor for the astarte keyspace, used when simple strategy is used for the astarte keyspace."
   app_env :astarte_keyspace_replication_factor,
           :astarte_housekeeping,
           :astarte_keyspace_replication_factor,
           os_env: "HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_FACTOR",
-          type: :integer,
-          default: 1
+          type: :integer
 
   @envdoc "Replication map for the astarte keyspace, used when network topology strategy is used for the astarte keyspace."
   app_env :astarte_keyspace_network_replication_map,
@@ -109,13 +112,16 @@ defmodule Astarte.Housekeeping.Config do
   end
 
   @doc """
-  Returns :ok if at least one of HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_FACTOR or HOUSEKEEPING_ASTARTE_KEYSPACE_NETWORK_REPLICATION_MAP is valid, based on HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_STRATEGY value.
+  Returns :ok if the configured astarte keyspace replication settings are
+  consistent. When no replication strategy is explicitly configured, the
+  default behaviour (auto-detecting the ScyllaDB network topology) is applied
+  at keyspace creation time and no validation is required here.
   """
   def validate_astarte_replication! do
     case astarte_keyspace_replication_strategy!() do
       :simple_strategy -> validate_astarte_replication_factor!()
       :network_topology_strategy -> validate_astarte_replication_map!()
-      nil -> raise "Invalid replication strategy set for the astarte keyspace"
+      nil -> :ok
     end
   end
 

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -1232,13 +1232,8 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     keyspace = Realm.astarte_keyspace_name()
     consistency = Consistency.domain_model(:write)
 
-    replication =
-      case Config.astarte_keyspace_replication_strategy!() do
-        :simple_strategy -> Config.astarte_keyspace_replication_factor!()
-        :network_topology_strategy -> Config.astarte_keyspace_network_replication_map!()
-      end
-
-    with {:ok, replication_map_str} <- build_replication_map_str(replication),
+    with {:ok, replication} <- astarte_keyspace_replication(),
+         {:ok, replication_map_str} <- build_replication_map_str(replication),
          :ok <- do_create_astarte_keyspace(keyspace, replication_map_str, consistency) do
       :ok
     else
@@ -1247,6 +1242,52 @@ defmodule Astarte.Housekeeping.Realms.Queries do
           tag: "astarte_keyspace_creation_failed"
         )
 
+        {:error, reason}
+    end
+  end
+
+  defp astarte_keyspace_replication do
+    case Config.astarte_keyspace_replication_strategy!() do
+      :simple_strategy ->
+        {:ok, Config.astarte_keyspace_replication_factor!()}
+
+      :network_topology_strategy ->
+        {:ok, Config.astarte_keyspace_network_replication_map!()}
+
+      nil ->
+        # No explicit replication has been configured, so the replication
+        # map is derived from the current ScyllaDB network topology
+        fetch_network_topology()
+    end
+  end
+
+  def fetch_network_topology do
+    with {:ok, local_datacenter} <- get_local_datacenter(),
+         {:ok, peer_datacenters} <- fetch_peer_datacenters() do
+      peer_counts = Enum.frequencies(peer_datacenters)
+
+      # `system.peers` does not include the local node, so 1 is added to the local
+      # datacenter count to account for it (same as in
+      # `check_replication_for_datacenter/3`).
+      local_dc_node_count = Map.get(peer_counts, local_datacenter, 0) + 1
+      topology = Map.put(peer_counts, local_datacenter, local_dc_node_count)
+
+      {:ok, topology}
+    end
+  end
+
+  defp fetch_peer_datacenters do
+    query =
+      from sp in "system.peers",
+        select: sp.data_center
+
+    opts = [consistency: Consistency.domain_model(:read)]
+
+    case Repo.fetch_all(query, opts) do
+      {:ok, datacenters} ->
+        {:ok, datacenters}
+
+      {:error, reason} ->
         {:error, reason}
     end
   end

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
@@ -93,6 +93,32 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
       assert {:ok, _} = Database.lightweight_transaction_check(astarte_keyspace)
     end
 
+    test "defaults to NetworkTopologyStrategy derived from the live Scylla topology when no replication strategy is configured" do
+      # When the replication strategy env var is not set, Config returns `nil`
+      # and `create_astarte_keyspace/0` is expected to derive the replication
+      # map from the actual ScyllaDB network topology, instead of falling back
+      # to SimpleStrategy/RF=1. The test cluster has a single node in
+      # `datacenter1`, so the resulting map must be %{"datacenter1" => 1} and
+      # the keyspace class must be NetworkTopologyStrategy.
+      Config
+      |> expect(:astarte_keyspace_replication_strategy!, fn -> nil end)
+      |> reject(:astarte_keyspace_replication_factor!, 0)
+      |> reject(:astarte_keyspace_network_replication_map!, 0)
+
+      assert :ok = Queries.initialize_database()
+
+      astarte_keyspace = Realm.astarte_keyspace_name()
+
+      replication =
+        from(k in "system_schema.keyspaces", select: k.replication)
+        |> Repo.get_by!(keyspace_name: astarte_keyspace)
+
+      {datacenter_replication, ""} = replication[@datacenter] |> Integer.parse()
+
+      assert replication["class"] == "org.apache.cassandra.locator.NetworkTopologyStrategy"
+      assert datacenter_replication == 1
+    end
+
     test "returns database error" do
       Mimic.stub(Xandra, :execute, fn _, _, _, _ -> {:error, %Xandra.Error{}} end)
       assert {:error, :database_error} = Queries.initialize_database()

--- a/libs/astarte_data_access/lib/astarte_data_access/repo.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/repo.ex
@@ -180,7 +180,7 @@ defmodule Astarte.DataAccess.Repo do
     astarte_keyspace = Realm.astarte_keyspace_name()
     %Xandra.Error{message: message} = error
 
-    case Regex.run(~r/Keyspace (.*) does not exist/, message) do
+    case Regex.run(~r/Keyspace (.*) does not exist/, message || "") do
       [_message, ^astarte_keyspace] ->
         Logger.warning("Database error: astarte keyspace does not exist", tag: "database_error")
         {:error, :database_error}


### PR DESCRIPTION
This PR introduces the following change: when HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_STRATEGY is not set, derive the replication map from the live ScyllaDB network topology (one replica per node in each datacenter) instead of falling back to SimpleStrategy with replication_factor=1)