### PR TITLE
docs(pairing): Add missing API docs

### DIFF
--- a/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/api_spec.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/api_spec.ex
@@ -123,6 +123,17 @@ defmodule Astarte.PairingWeb.ApiSpec do
             For accessing the device API a valid Credentials Secret must be passed in all the queries in the 'Authorization' header.
             The following syntax must be used in the 'Authorization' header : Bearer xxxxxxxxxxxxxxxxxxxxx
             """
+          },
+          "FDOSessionToken" => %SecurityScheme{
+            type: "apiKey",
+            name: "Authorization",
+            in: "header",
+            description: """
+            FDO session token. Must be provided in the Authorization header as a bearer token.
+            The token is validated and decoded to extract the device GUID and nonce.
+            Example: Authorization: Bearer <FDO-session-token>.
+            Token must match the session and nonce for the device in the current realm.
+            """
           }
         }
       },
@@ -142,6 +153,10 @@ defmodule Astarte.PairingWeb.ApiSpec do
             description: "Find out more",
             url: "https://docs.astarte-platform.org/astarte/1.0/050-pairing_mechanism.html"
           }
+        },
+        %Tag{
+          name: "fdo",
+          description: "FDO onboarding API"
         }
       ]
     }

--- a/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/schemas/fdo.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/schemas/fdo.ex
@@ -1,0 +1,152 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.PairingWeb.ApiSpec.Schemas.Fdo do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+
+  defmodule HelloDeviceRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "HelloDeviceRequest",
+      type: :array,
+      description: """
+      TO2.HelloDevice CBOR array:
+      [maxDeviceMessageSize, Guid, NonceTO2ProveOV, kexSuiteName, cipherSuiteName, eASigInfo]
+      """,
+      items: %Schema{
+        type: :string,
+        format: :binary
+      },
+      minItems: 6,
+      maxItems: 6,
+      example: [
+        1400,
+        "123e4567-e89b-12d3-a456-426614174000",
+        "nonce",
+        "kex",
+        "cipher",
+        "sig"
+      ]
+    })
+  end
+
+  defmodule GetOVNextEntryRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "GetOVNextEntryRequest",
+      type: :array,
+      description:
+        "Acknowledges the previous message and requests the next Ownership Voucher Entry. The integer argument,
+OVEntryNum, is the number of the entry, where the first entry is zero (0).",
+      items: %Schema{
+        type: :string,
+        format: :binary
+      },
+      example: [
+        1
+      ]
+    })
+  end
+
+  defmodule ProveDeviceRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "ProveDeviceRequest",
+      type: :array,
+      description:
+        "Proves the provenance of the Device to the new owner, using the entity attestation token based on the challenge
+                      NonceTO2ProveDv sent as TO2.ProveOVHdr.UnprotectedHeaders.CUPHNonce. The signature is verified using the
+                      device certificate chain contained in the Ownership Voucher. If the signature cannot be verified, or fails to verify,
+                      the connection is terminated with an error message.",
+      items: %Schema{
+        type: :string,
+        format: :binary
+      },
+      example: [
+        "xBKeyExchange"
+      ]
+    })
+  end
+
+  defmodule DeviceServiceInfoStartRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "DeviceServiceInfoStartRequest",
+      type: :array,
+      description:
+        "This message signals a state change between the authentication phase of the protocol and the provisioning
+        phase (ServiceInfo) negotiation.",
+      items: %Schema{
+        type: :string,
+        format: :binary
+      },
+      example: [
+        "ReplacementHMac",
+        "maxOwnerServiceInfoSz"
+      ]
+    })
+  end
+
+  defmodule DeviceServiceInfoRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "DeviceServiceInfoRequest",
+      type: :array,
+      description:
+        "Sends as many Device to Owner ServiceInfo entries as will conveniently fit into a message, based on protocol
+and Device constraints. This message is part of a loop with TO2.OwnerServiceInfo.",
+      items: %Schema{
+        type: :string,
+        format: :binary
+      },
+      example: [
+        "IsMoreServiceInfo",
+        "ServiceInfo"
+      ]
+    })
+  end
+
+  defmodule DoneRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "DoneRequest",
+      type: :array,
+      description: "Indicates successful completion of the Transfer of Ownership.",
+      items: %Schema{
+        type: :string,
+        format: :binary
+      },
+      example: [
+        "NonceTO2ProveDv"
+      ]
+    })
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/schemas/fdo_errors.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/schemas/fdo_errors.ex
@@ -1,0 +1,159 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+defmodule Astarte.PairingWeb.ApiSpec.Schemas.FDOErrors do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+
+  defmodule InvalidJWTTokenResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "FDOInvalidJWTTokenResponse",
+      type: :object,
+      properties: %{
+        error_code: %Schema{
+          type: :integer,
+          example: 1,
+          description: "FDO error code: 1 (invalid_jwt_token)"
+        },
+        correlation_id: %Schema{
+          type: :integer,
+          description: "Correlation ID for tracing the request."
+        }
+      },
+      required: [:error_code],
+      example: %{error_code: 1, correlation_id: 123_456_789}
+    })
+  end
+
+  defmodule ResourceNotFoundResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "FDOResourceNotFoundResponse",
+      type: :object,
+      properties: %{
+        error_code: %Schema{
+          type: :integer,
+          example: 6,
+          description: "FDO error code: 6 (resource_not_found)"
+        },
+        correlation_id: %Schema{
+          type: :integer,
+          description: "Correlation ID for tracing the request."
+        }
+      },
+      required: [:error_code],
+      example: %{error_code: 6, correlation_id: 123_456_789}
+    })
+  end
+
+  defmodule MessageBodyErrorResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "FDOMessageBodyErrorResponse",
+      type: :object,
+      properties: %{
+        error_code: %Schema{
+          type: :integer,
+          example: 100,
+          description: "FDO error code: 100 (message_body_error)"
+        },
+        correlation_id: %Schema{
+          type: :integer,
+          description: "Correlation ID for tracing the request."
+        }
+      },
+      required: [:error_code],
+      example: %{error_code: 100, correlation_id: 123_456_789}
+    })
+  end
+
+  defmodule InvalidMessageErrorResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "FDOInvalidMessageErrorResponse",
+      type: :object,
+      properties: %{
+        error_code: %Schema{
+          type: :integer,
+          example: 101,
+          description: "FDO error code: 101 (invalid_message_error)"
+        },
+        correlation_id: %Schema{
+          type: :integer,
+          description: "Correlation ID for tracing the request."
+        }
+      },
+      required: [:error_code],
+      example: %{error_code: 101, correlation_id: 123_456_789}
+    })
+  end
+
+  defmodule CredReuseErrorResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "FDOCredReuseErrorResponse",
+      type: :object,
+      properties: %{
+        error_code: %Schema{
+          type: :integer,
+          example: 102,
+          description: "FDO error code: 102 (cred_reuse_error)"
+        },
+        correlation_id: %Schema{
+          type: :integer,
+          description: "Correlation ID for tracing the request."
+        }
+      },
+      required: [:error_code],
+      example: %{error_code: 102, correlation_id: 123_456_789}
+    })
+  end
+
+  defmodule InternalServerErrorResponse do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "FDOInternalServerErrorResponse",
+      type: :object,
+      properties: %{
+        error_code: %Schema{
+          type: :integer,
+          example: 500,
+          description: "FDO error code: 500 (internal_server_error)"
+        },
+        correlation_id: %Schema{
+          type: :integer,
+          description: "Correlation ID for tracing the request."
+        }
+      },
+      required: [:error_code],
+      example: %{error_code: 500, correlation_id: 123_456_789}
+    })
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/fdo_onboarding_controller.ex
@@ -18,14 +18,345 @@
 
 defmodule Astarte.PairingWeb.FDOOnboardingController do
   use Astarte.PairingWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
   alias Astarte.Pairing.FDO.OwnerOnboarding
   alias Astarte.Pairing.FDO.OwnerOnboarding.DeviceServiceInfo
   alias Astarte.Pairing.FDO.OwnerOnboarding.DeviceServiceInfoReady
   alias Astarte.Pairing.FDO.ServiceInfo
+  alias Astarte.PairingWeb.ApiSpec.Schemas.Fdo
+  alias Astarte.PairingWeb.ApiSpec.Schemas.FDOErrors
+  alias OpenApiSpex.{MediaType, Response, Schema}
 
   require Logger
 
   action_fallback Astarte.PairingWeb.FDOFallbackController
+
+  tags ["fdo"]
+
+  operation :hello_device,
+    summary: "FDO TO2 Hello Device",
+    operation_id: "FDOHelloDevice",
+    description: "Sets up new owner for proof of ownership.",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm the device belongs to.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body: {
+      "TO2 Hello Device",
+      "application/cbor",
+      Fdo.HelloDeviceRequest,
+      required: true
+    },
+    responses: [
+      ok: {
+        "TO2 ProveOVHdr",
+        "application/cbor",
+        %Schema{
+          type: :array,
+          description:
+            "ProveOVHdr response is a CBOR array with the following items: [OVHeader, NumOvEntries, HMac, NonceTO2ProveOV, eBSigInfo, xAKeyExchange, helloDeviceHash, maxOwnerMessageSize]",
+          items: %Schema{
+            type: :string,
+            format: :binary
+          },
+          example: [
+            "OVHeader",
+            "NumOvEntries",
+            "HMac",
+            "NonceTO2ProveOV",
+            "eBSigInfo",
+            "xAKeyExchange",
+            "helloDeviceHash",
+            "maxOwnerMessageSize"
+          ]
+        }
+      },
+      internal_server_error: %Response{
+        description: "FDO error response",
+        content: %{
+          "application/cbor" => %MediaType{
+            schema: %Schema{
+              oneOf: [
+                FDOErrors.ResourceNotFoundResponse,
+                FDOErrors.MessageBodyErrorResponse,
+                FDOErrors.InvalidMessageErrorResponse,
+                FDOErrors.CredReuseErrorResponse,
+                FDOErrors.InternalServerErrorResponse
+              ]
+            }
+          }
+        }
+      }
+    ]
+
+  operation :ov_next_entry,
+    security: [%{"FDOSessionToken" => []}],
+    summary: "FDO TO2 GetOVNextEntry",
+    operation_id: "FDOGetOVNextEntry",
+    description: "Requests the next Ownership Voucher Entry.",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm the device belongs to.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body: {
+      "TO2 GetOVNextEntry",
+      "application/cbor",
+      Fdo.GetOVNextEntryRequest,
+      required: true
+    },
+    responses: [
+      ok:
+        {"TO2 OVNextEntry", "application/cbor",
+         %Schema{
+           type: :string,
+           format: :binary,
+           description:
+             "Transmits the requested Ownership Voucher entry from the Owner Onboarding Service.",
+           example: [
+             "OVEntryNum",
+             "OVEntry"
+           ]
+         }},
+      internal_server_error: %Response{
+        description: "FDO error response",
+        content: %{
+          "application/cbor" => %MediaType{
+            schema: %Schema{
+              oneOf: [
+                FDOErrors.InvalidJWTTokenResponse,
+                FDOErrors.ResourceNotFoundResponse,
+                FDOErrors.MessageBodyErrorResponse,
+                FDOErrors.InvalidMessageErrorResponse,
+                FDOErrors.CredReuseErrorResponse,
+                FDOErrors.InternalServerErrorResponse
+              ]
+            }
+          }
+        }
+      }
+    ]
+
+  operation :prove_device,
+    security: [%{"FDOSessionToken" => []}],
+    summary: "FDO TO2 ProveDevice",
+    operation_id: "FDOProveDevice",
+    description: "Proves the provenance of the Device to the new owner.",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm the device belongs to.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body: {
+      "TO2 ProveDeviceRequest",
+      "application/cbor",
+      Fdo.ProveDeviceRequest,
+      required: true
+    },
+    responses: [
+      ok:
+        {"TO2 Setup Device", "application/cbor",
+         %Schema{
+           type: :string,
+           format: :binary,
+           description:
+             "This message prepares for ownership transfer, where the credentials previously used to take over the device are
+              replaced, based on the new credentials downloaded from the Owner Onboarding Service.",
+           example: [
+             "RendezvousInfo",
+             "Guid",
+             "NonceTO2SetupDv",
+             "Owner2Key"
+           ]
+         }},
+      internal_server_error: %Response{
+        description: "FDO error response",
+        content: %{
+          "application/cbor" => %MediaType{
+            schema: %Schema{
+              oneOf: [
+                FDOErrors.InvalidJWTTokenResponse,
+                FDOErrors.ResourceNotFoundResponse,
+                FDOErrors.MessageBodyErrorResponse,
+                FDOErrors.InvalidMessageErrorResponse,
+                FDOErrors.CredReuseErrorResponse,
+                FDOErrors.InternalServerErrorResponse
+              ]
+            }
+          }
+        }
+      }
+    ]
+
+  operation :done,
+    security: [%{"FDOSessionToken" => []}],
+    summary: "FDO TO2 Done",
+    operation_id: "FDODone",
+    description: "Indicates successful completion of the Transfer of Ownership.",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm the device belongs to.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body: {
+      "TO2 Done",
+      "application/cbor",
+      Fdo.DoneRequest,
+      required: true
+    },
+    responses: [
+      ok:
+        {"TO2 Done2", "application/cbor",
+         %Schema{
+           type: :string,
+           format: :binary,
+           description:
+             "This message provides an opportunity for a final ACK after the Owner has invoked the System Info block to
+                          establish agent-to-server communications between the Device and its final Owner.",
+           example: [
+             "NonceTO2SetupDv"
+           ]
+         }},
+      internal_server_error: %Response{
+        description: "FDO error response",
+        content: %{
+          "application/cbor" => %MediaType{
+            schema: %Schema{
+              oneOf: [
+                FDOErrors.InvalidJWTTokenResponse,
+                FDOErrors.ResourceNotFoundResponse,
+                FDOErrors.MessageBodyErrorResponse,
+                FDOErrors.InvalidMessageErrorResponse,
+                FDOErrors.CredReuseErrorResponse,
+                FDOErrors.InternalServerErrorResponse
+              ]
+            }
+          }
+        }
+      }
+    ]
+
+  operation :service_info_start,
+    security: [%{"FDOSessionToken" => []}],
+    summary: "FDO TO2 Service Info Ready",
+    operation_id: "FDOServiceInfoReady",
+    description:
+      "This message signals a state change between the authentication phase of the protocol and the provisioning
+                  phase (ServiceInfo) negotiation.",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm the device belongs to.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body: {
+      "TO2 Service Info Ready",
+      "application/cbor",
+      Fdo.DeviceServiceInfoStartRequest,
+      required: true
+    },
+    responses: [
+      ok:
+        {"TO2 OwnerServiceInfoReady", "application/cbor",
+         %Schema{
+           type: :string,
+           format: :binary,
+           description:
+             "This message responds to TO2.DeviceServiceInfoReady and indicates that the Owner Onboarding Service is
+                        ready to start ServiceInfo.",
+           example: [
+             "maxDeviceServiceInfoSz"
+           ]
+         }},
+      internal_server_error: %Response{
+        description: "FDO error response",
+        content: %{
+          "application/cbor" => %MediaType{
+            schema: %Schema{
+              oneOf: [
+                FDOErrors.InvalidJWTTokenResponse,
+                FDOErrors.ResourceNotFoundResponse,
+                FDOErrors.MessageBodyErrorResponse,
+                FDOErrors.InvalidMessageErrorResponse,
+                FDOErrors.CredReuseErrorResponse,
+                FDOErrors.InternalServerErrorResponse
+              ]
+            }
+          }
+        }
+      }
+    ]
+
+  operation :service_info_end,
+    security: [%{"FDOSessionToken" => []}],
+    summary: "FDO TO2 Service Info",
+    operation_id: "FDOServiceInfoEnd",
+    description:
+      "Sends as many Device to Owner ServiceInfo entries as will conveniently fit into a message, based on protocol
+            and Device constraints.",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm the device belongs to.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body: {
+      "CBOR Service Info End",
+      "application/cbor",
+      Fdo.DeviceServiceInfoRequest,
+      required: true
+    },
+    responses: [
+      ok:
+        {"TO2 OwnerServiceInfo", "application/cbor",
+         %Schema{
+           type: :string,
+           format: :binary,
+           description:
+             "Sends as many Owner to Device ServiceInfo entries as will conveniently fit into a message, based on protocol
+                          and implementation constraints. This message is part of a loop with TO2.DeviceServiceInfo.",
+           example: [
+             "IsMoreServiceInfo,",
+             "IsDone",
+             "ServiceInfo"
+           ]
+         }},
+      internal_server_error: %Response{
+        description: "FDO error response",
+        content: %{
+          "application/cbor" => %MediaType{
+            schema: %Schema{
+              oneOf: [
+                FDOErrors.InvalidJWTTokenResponse,
+                FDOErrors.ResourceNotFoundResponse,
+                FDOErrors.MessageBodyErrorResponse,
+                FDOErrors.InvalidMessageErrorResponse,
+                FDOErrors.CredReuseErrorResponse,
+                FDOErrors.InternalServerErrorResponse
+              ]
+            }
+          }
+        }
+      }
+    ]
 
   def hello_device(conn, _params) do
     realm_name = Map.fetch!(conn.params, "realm_name")

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/health_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/health_controller.ex
@@ -18,8 +18,28 @@
 
 defmodule Astarte.PairingWeb.HealthController do
   use Astarte.PairingWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Astarte.Pairing.Health
+
+  tags ["health"]
+
+  operation :show,
+    summary: "Retrieve API health",
+    description: "Return the health status of the Pairing API.",
+    operation_id: "getHealth",
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ]
+    ],
+    responses: [
+      ok: {"Success", nil, nil},
+      service_unavailable: {"Service unavailable", nil, nil}
+    ]
 
   def show(conn, _params) do
     send_health(conn)

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/ownership_voucher_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/ownership_voucher_controller.ex
@@ -18,12 +18,61 @@
 
 defmodule Astarte.PairingWeb.OwnershipVoucherController do
   use Astarte.PairingWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
   alias Astarte.Pairing.FDO
   alias Astarte.Pairing.FDO.OwnershipVoucher
   alias Astarte.Pairing.FDO.OwnershipVoucher.CreateRequest
+  alias OpenApiSpex.Schema
 
   action_fallback Astarte.PairingWeb.FallbackController
+
+  tags ["fdo"]
+
+  operation :create,
+    summary: "Create an ownership voucher",
+    description: "Create an ownership voucher for a device and claim it.",
+    operation_id: "createOwnershipVoucher",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body:
+      {"Ownership Voucher Creation Request", "application/json",
+       %Schema{
+         type: :object,
+         properties: %{
+           data: %Schema{
+             type: :object,
+             properties: %{
+               ownership_voucher: %Schema{
+                 type: :string,
+                 description:
+                   "The ownership voucher. It should be a base64-encoded string containing the CBOR representation of the ownership voucher."
+               },
+               private_key: %Schema{
+                 type: :string,
+                 description:
+                   "The private key in PEM format corresponding to the public key used in the ownership voucher."
+               }
+             },
+             required: [:ownership_voucher, :private_key]
+           }
+         },
+         required: [:data]
+       }},
+    responses: [
+      ok: {"Ownership voucher created successfully", nil, nil},
+      bad_request: {"Invalid request body", nil, nil},
+      unauthorized: {"Unauthorized", nil, nil},
+      not_found: {"Realm not found", nil, nil},
+      internal_server_error: {"Internal server error", nil, nil}
+    ]
 
   def create(conn, %{
         "data" => data,

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/version_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/version_controller.ex
@@ -18,10 +18,59 @@
 
 defmodule Astarte.PairingWeb.VersionController do
   use Astarte.PairingWeb, :controller
+  use OpenApiSpex.ControllerSpecs
+
+  alias OpenApiSpex.Schema
 
   @version Mix.Project.config()[:version]
 
+  tags ["version"]
+
+  operation :show,
+    summary: "Retrieve API version",
+    description:
+      "Return the Pairing API version. This endpoint is available at {base_url}/version (without /v1).",
+    operation_id: "getVersion",
+    responses: [
+      ok:
+        {"Success", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{type: :string, example: "1.3.0"}
+           }
+         }}
+    ]
+
+  operation :show_with_realm,
+    summary: "Retrieve API version",
+    description: "Return the Pairing API version.",
+    operation_id: "getVersionWithRealm",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ]
+    ],
+    responses: [
+      ok:
+        {"Success", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{type: :string, example: "1.3.0"}
+           }
+         }}
+    ]
+
   def show(conn, _params) do
+    render(conn, "show.json", %{version: @version})
+  end
+
+  def show_with_realm(conn, _params) do
     render(conn, "show.json", %{version: @version})
   end
 end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
@@ -76,7 +76,7 @@ defmodule Astarte.PairingWeb.Router do
   scope "/v1/:realm_name", Astarte.PairingWeb do
     pipe_through :realm_api
 
-    get "/version", VersionController, :show
+    get "/version", VersionController, :show_with_realm
     get "/health", HealthController, :show
 
     scope "/ownership" do

--- a/apps/astarte_pairing/test/astarte_pairing_web/api_spec/api_spec_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/api_spec/api_spec_test.exs
@@ -21,10 +21,7 @@ defmodule Astarte.PairingWeb.ApiSpecTest do
 
   import ExUnit.CaptureIO
 
-  alias Astarte.PairingWeb.{AgentController, ApiSpec, DeviceController, Router}
-
-  # TODO: Remove this once we have all the routes documented
-  @documented_controllers [AgentController, DeviceController]
+  alias Astarte.PairingWeb.{ApiSpec, Router}
 
   test "spec can be generated" do
     spec = ApiSpec.spec()
@@ -47,7 +44,6 @@ defmodule Astarte.PairingWeb.ApiSpecTest do
   test "all documented routes are present in the OpenAPI spec" do
     expected_operations =
       Router.__routes__()
-      |> Enum.filter(&documented_route?/1)
       |> MapSet.new(&normalize_route/1)
 
     actual_operations =
@@ -62,10 +58,6 @@ defmodule Astarte.PairingWeb.ApiSpecTest do
 
     assert MapSet.subset?(expected_operations, actual_operations),
            missing_operations_message(expected_operations, actual_operations)
-  end
-
-  defp documented_route?(route) do
-    route.plug in @documented_controllers
   end
 
   defp normalize_route(route) do


### PR DESCRIPTION
Describe version, health and FDO APIs.
API docs can be generated using command `mix openapi.spec.yaml --spec Astarte.PairingWeb.ApiSpec --start-app=false --vendor-extensions=false`