### PR TITLE
feat(housekeeping): default realm keyspace replication uses data from db

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -59,6 +59,35 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
+  def fetch_keyspace_replication do
+    astarte_keyspace = Realm.astarte_keyspace_name()
+    consistency = Consistency.domain_model(:read)
+
+    result =
+      KvStore.fetch_value("astarte", "db_default_replication", :binary,
+        error: :replication_not_found,
+        consistency: consistency,
+        prefix: astarte_keyspace
+      )
+
+    case result do
+      {:ok, binary_replication} ->
+        try do
+          {:ok, :erlang.binary_to_term(binary_replication)}
+        rescue
+          _ ->
+            Logger.error("Failed to deserialize replication data from KvStore",
+              tag: "corrupted_replication_data"
+            )
+
+            {:error, :corrupted_replication_data}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   def get_realm(realm_name) do
     keyspace_name = Realm.keyspace_name(realm_name)
     do_get_realm(realm_name, keyspace_name)
@@ -1203,8 +1232,12 @@ defmodule Astarte.Housekeeping.Realms.Queries do
       value_type: :binary
     }
 
-    with {:error, xandra_error} <- KvStore.insert(kv_store, opts) do
-      raise xandra_error
+    case KvStore.insert(kv_store, opts) do
+      :ok ->
+        :ok
+
+      {:error, xandra_error} ->
+        {:error, xandra_error}
     end
   end
 

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/realm.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/realm.ex
@@ -27,9 +27,6 @@ defmodule Astarte.Housekeeping.Realms.Realm do
 
   require Logger
 
-  @default_replication_factor 1
-  @default_replication_class "SimpleStrategy"
-
   @required_create_fields [:realm_name, :jwt_public_key_pem]
   @allowed_create_fields [
     :replication_factor,
@@ -66,9 +63,8 @@ defmodule Astarte.Housekeeping.Realms.Realm do
     |> validate_change(:realm_name, &validate_realm_name/2)
     |> validate_number(:replication_factor, greater_than: 0)
     |> validate_change(:jwt_public_key_pem, &validate_pem_public_key/2)
-    |> put_default_if_missing(:replication_class, @default_replication_class)
     |> validate_inclusion(:replication_class, [
-      @default_replication_class,
+      "SimpleStrategy",
       "NetworkTopologyStrategy"
     ])
     |> validate_replication()
@@ -125,11 +121,31 @@ defmodule Astarte.Housekeeping.Realms.Realm do
     end
   end
 
+  def apply_replication(%Astarte.Housekeeping.Realms.Realm{} = realm, %{
+        strategy: :network_topology,
+        dc_factors: dc_factors
+      }) do
+    dc_factors_map = Enum.into(Enum.to_list(dc_factors), %{})
+
+    %{
+      realm
+      | replication_class: "NetworkTopologyStrategy",
+        datacenter_replication_factors: dc_factors_map
+    }
+  end
+
+  def apply_replication(%Astarte.Housekeeping.Realms.Realm{} = realm, %{
+        strategy: :simple,
+        factor: factor
+      }) do
+    %{realm | replication_class: "SimpleStrategy", replication_factor: factor}
+  end
+
   defp maybe_put_default_replication_factor(changeset) do
     replication_class = get_field(changeset, :replication_class)
 
-    if replication_class == @default_replication_class do
-      put_default_if_missing(changeset, :replication_factor, @default_replication_factor)
+    if replication_class == "SimpleStrategy" do
+      put_default_if_missing(changeset, :replication_factor, 1)
     else
       changeset
     end

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/realms.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/realms.ex
@@ -70,7 +70,8 @@ defmodule Astarte.Housekeeping.Realms do
     changeset = Realm.changeset(%Realm{}, attrs)
 
     with {:ok, %Realm{} = realm} <-
-           Ecto.Changeset.apply_action(changeset, :insert) do
+           Ecto.Changeset.apply_action(changeset, :insert),
+         {:ok, realm} <- resolve_replication(realm) do
       case Core.create_realm(realm, opts) do
         :ok -> {:ok, realm}
         {:ok, :started} -> {:ok, realm}
@@ -78,6 +79,14 @@ defmodule Astarte.Housekeeping.Realms do
       end
     end
   end
+
+  defp resolve_replication(%Realm{replication_class: nil} = realm) do
+    with {:ok, replication} <- Queries.fetch_keyspace_replication() do
+      {:ok, Realm.apply_replication(realm, replication)}
+    end
+  end
+
+  defp resolve_replication(realm), do: {:ok, realm}
 
   @doc """
   Updates a realm with the provided list of attributes.

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
@@ -163,6 +163,21 @@ defmodule Astarte.Housekeeping.MigratorTest do
     end
   end
 
+  describe "save_default_replication/0" do
+    setup do
+      on_exit(fn ->
+        Database.teardown_astarte_keyspace()
+      end)
+
+      Queries.initialize_database()
+      :ok
+    end
+
+    test "saves the keyspace replication successfully" do
+      assert :ok = Migrator.save_default_replication()
+    end
+  end
+
   defp realm_schema_version(realm_name) do
     keyspace = DatabaseRealm.keyspace_name(realm_name)
 

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
@@ -24,6 +24,7 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
   alias Astarte.DataAccess.Repo
   alias Astarte.Housekeeping.Config
   alias Astarte.Housekeeping.Helpers.Database
+  alias Astarte.Housekeeping.Migrator
   alias Astarte.Housekeeping.Realms
   alias Astarte.Housekeeping.Realms.Queries
   alias Astarte.Housekeeping.Realms.Realm, as: HKRealm
@@ -119,6 +120,75 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
       assert datacenter_replication == 1
     end
 
+    @tag :inspect_replication
+    test "inspects auto-detected replication from live cluster when no strategy is configured" do
+      Config
+      |> expect(:astarte_keyspace_replication_strategy!, fn -> nil end)
+      |> reject(:astarte_keyspace_replication_factor!, 0)
+      |> reject(:astarte_keyspace_network_replication_map!, 0)
+
+      assert :ok = Queries.initialize_database()
+
+      astarte_keyspace = Realm.astarte_keyspace_name()
+
+      Migrator.save_default_replication()
+
+      {:ok, replication_map} = Queries.fetch_keyspace_replication()
+
+      replication =
+        from(k in "system_schema.keyspaces", select: k.replication)
+        |> Repo.get_by!(keyspace_name: astarte_keyspace)
+
+      assert replication["class"] == "org.apache.cassandra.locator.NetworkTopologyStrategy"
+      assert replication_map == %{strategy: :network_topology, dc_factors: %{@datacenter => 1}}
+    end
+
+    @tag :inspect_replication
+    test "inspects replication when simple strategy is configured" do
+      Config
+      |> expect(:astarte_keyspace_replication_strategy!, fn -> :simple_strategy end)
+      |> expect(:astarte_keyspace_replication_factor!, fn -> 1 end)
+      |> reject(:astarte_keyspace_network_replication_map!, 0)
+
+      assert :ok = Queries.initialize_database()
+
+      astarte_keyspace = Realm.astarte_keyspace_name()
+
+      Migrator.save_default_replication()
+
+      {:ok, replication_map} = Queries.fetch_keyspace_replication()
+
+      replication =
+        from(k in "system_schema.keyspaces", select: k.replication)
+        |> Repo.get_by!(keyspace_name: astarte_keyspace)
+
+      assert replication["class"] == "org.apache.cassandra.locator.SimpleStrategy"
+      assert replication_map == %{strategy: :simple, factor: 1}
+    end
+
+    @tag :inspect_replication
+    test "inspects replication when network topology strategy is configured" do
+      Config
+      |> expect(:astarte_keyspace_replication_strategy!, fn -> :network_topology_strategy end)
+      |> reject(:astarte_keyspace_replication_factor!, 0)
+      |> expect(:astarte_keyspace_network_replication_map!, fn -> @map_replication_factor end)
+
+      assert :ok = Queries.initialize_database()
+
+      astarte_keyspace = Realm.astarte_keyspace_name()
+
+      Migrator.save_default_replication()
+
+      {:ok, replication_map} = Queries.fetch_keyspace_replication()
+
+      replication =
+        from(k in "system_schema.keyspaces", select: k.replication)
+        |> Repo.get_by!(keyspace_name: astarte_keyspace)
+
+      assert replication["class"] == "org.apache.cassandra.locator.NetworkTopologyStrategy"
+      assert replication_map == %{strategy: :network_topology, dc_factors: %{"datacenter1" => 1}}
+    end
+
     test "returns database error" do
       Mimic.stub(Xandra, :execute, fn _, _, _, _ -> {:error, %Xandra.Error{}} end)
       assert {:error, :database_error} = Queries.initialize_database()
@@ -143,6 +213,8 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
         Database.setup_database_access(astarte_instance_id)
         Database.teardown_realm_keyspace(realm_name)
       end)
+
+      Database.save_default_replication(%{strategy: :simple, factor: 1})
 
       %{realm_name: realm_name}
     end
@@ -500,6 +572,9 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
     setup %{astarte_instance_id: astarte_instance_id, realm_name: realm_name} do
       other_realm_name = "realm#{System.unique_integer([:positive])}"
 
+      {:ok, live_topology} = Queries.fetch_network_topology()
+      Database.save_default_replication(%{strategy: :network_topology, dc_factors: live_topology})
+
       on_exit(fn ->
         Database.setup_database_access(astarte_instance_id)
         Queries.set_datastream_maximum_storage_retention(realm_name, 50)
@@ -538,6 +613,43 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
                  jwt_public_key_pem: @public_key_pem,
                  replication_factor: nil
                })
+    end
+
+    test "realm created without explicit replication inherits NetworkTopologyStrategy from astarte keyspace",
+         %{
+           other_realm_name: realm_name
+         } do
+      assert {:ok, _} =
+               Realms.create_realm(%{
+                 realm_name: realm_name,
+                 jwt_public_key_pem: @public_key_pem
+               })
+
+      assert {:ok, realm} = Queries.get_realm(realm_name)
+
+      assert realm.replication_class == "NetworkTopologyStrategy"
+      assert map_size(realm.datacenter_replication_factors) > 0
+    end
+
+    @tag :inspect_replication
+    test "realm created without explicit replication inherits replication matching live cluster topology",
+         %{other_realm_name: realm_name} do
+      assert {:ok, live_topology} = Queries.fetch_network_topology()
+
+      assert {:ok, _} =
+               Realms.create_realm(%{
+                 realm_name: realm_name,
+                 jwt_public_key_pem: @public_key_pem
+               })
+
+      assert {:ok, realm} = Queries.get_realm(realm_name)
+
+      assert realm.replication_class == "NetworkTopologyStrategy"
+
+      for {dc, node_count} <- live_topology do
+        assert realm.datacenter_replication_factors[dc] == node_count,
+               "expected #{dc} replication_factor=#{node_count} (nodes in DC), got #{realm.datacenter_replication_factors[dc]}"
+      end
     end
 
     test "Realm creation succeeds when device_registration_limit is nil", %{
@@ -583,6 +695,7 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
                Realms.create_realm(%{
                  realm_name: realm_name,
                  jwt_public_key_pem: @public_key_pem,
+                 replication_class: "SimpleStrategy",
                  replication_factor: 9
                })
     end
@@ -665,6 +778,52 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
 
       assert {:error, :timeout} =
                Queries.get_keyspace_replication("any_ks")
+    end
+  end
+
+  describe "save_keyspace_replication/1" do
+    test "saves and retrieves simple strategy replication" do
+      replication = %{strategy: :simple, factor: 2}
+      assert :ok = Queries.save_keyspace_replication(replication)
+      assert {:ok, ^replication} = Queries.fetch_keyspace_replication()
+    end
+
+    test "saves and retrieves network topology strategy replication" do
+      replication = %{strategy: :network_topology, dc_factors: %{"datacenter1" => 1}}
+      assert :ok = Queries.save_keyspace_replication(replication)
+      assert {:ok, ^replication} = Queries.fetch_keyspace_replication()
+    end
+  end
+
+  describe "fetch_keyspace_replication/0" do
+    test "returns error when replication has not been saved" do
+      Mimic.stub(Astarte.DataAccess.KvStore, :fetch_value, fn _, _, _, _ ->
+        {:error, :replication_not_found}
+      end)
+
+      assert {:error, :replication_not_found} = Queries.fetch_keyspace_replication()
+    end
+
+    test "returns error when stored replication data is corrupted" do
+      Mimic.stub(Astarte.DataAccess.KvStore, :fetch_value, fn _, _, _, _ ->
+        {:ok, <<0xFF, 0x00, 0xAB>>}
+      end)
+
+      assert {:error, :corrupted_replication_data} = Queries.fetch_keyspace_replication()
+    end
+
+    test "returns successfully stored replication after save" do
+      replication = %{strategy: :simple, factor: 1}
+      :ok = Queries.save_keyspace_replication(replication)
+      assert {:ok, ^replication} = Queries.fetch_keyspace_replication()
+    end
+  end
+
+  describe "fetch_network_topology/0" do
+    test "returns ok with a map of datacenters to node counts" do
+      assert {:ok, topology} = Queries.fetch_network_topology()
+      assert is_map(topology)
+      assert Map.has_key?(topology, "datacenter1")
     end
   end
 end

--- a/apps/astarte_housekeeping/test/astarte_housekeeping_web/controllers/realm_controller_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping_web/controllers/realm_controller_test.exs
@@ -54,6 +54,14 @@ defmodule Astarte.HousekeepingWeb.RealmControllerTest do
       "replication_factor" => 1
     }
   }
+  @simple_strategy_attrs %{
+    "data" => %{
+      "realm_name" => "testrealm3",
+      "jwt_public_key_pem" => pubkey(),
+      "replication_class" => "SimpleStrategy",
+      "replication_factor" => 1
+    }
+  }
   @network_topology_attrs %{
     "data" => %{
       "realm_name" => "testrealm3",
@@ -127,7 +135,9 @@ defmodule Astarte.HousekeepingWeb.RealmControllerTest do
   end
 
   describe "create realm" do
-    test "renders realm when data is valid", %{auth_conn: conn} do
+    test "renders realm when data is valid and replication is not explicitly set", %{
+      auth_conn: conn
+    } do
       conn = post(conn, realm_path(conn, :create), @create_attrs)
       assert response(conn, 201)
       conn = get(conn, realm_path(conn, :show, @create_attrs["data"]["realm_name"]))
@@ -136,8 +146,8 @@ defmodule Astarte.HousekeepingWeb.RealmControllerTest do
                "data" => %{
                  "realm_name" => @create_attrs["data"]["realm_name"],
                  "jwt_public_key_pem" => @create_attrs["data"]["jwt_public_key_pem"],
-                 "replication_class" => "SimpleStrategy",
-                 "replication_factor" => 1,
+                 "replication_class" => "NetworkTopologyStrategy",
+                 "datacenter_replication_factors" => %{@local_datacenter => 1},
                  "device_registration_limit" => nil,
                  "datastream_maximum_storage_retention" => nil
                }
@@ -146,7 +156,28 @@ defmodule Astarte.HousekeepingWeb.RealmControllerTest do
       Database.teardown_realm_keyspace(@create_attrs["data"]["realm_name"])
     end
 
-    test "renders realm with explicit replication_factor", %{auth_conn: conn} do
+    test "renders realm when data is valid and replication is explicitly set", %{auth_conn: conn} do
+      conn = post(conn, realm_path(conn, :create), @simple_strategy_attrs)
+      assert response(conn, 201)
+      conn = get(conn, realm_path(conn, :show, @simple_strategy_attrs["data"]["realm_name"]))
+
+      assert json_response(conn, 200) == %{
+               "data" => %{
+                 "realm_name" => @simple_strategy_attrs["data"]["realm_name"],
+                 "jwt_public_key_pem" => @simple_strategy_attrs["data"]["jwt_public_key_pem"],
+                 "replication_class" => "SimpleStrategy",
+                 "replication_factor" => @simple_strategy_attrs["data"]["replication_factor"],
+                 "device_registration_limit" => nil,
+                 "datastream_maximum_storage_retention" => nil
+               }
+             }
+
+      Database.teardown_realm_keyspace(@simple_strategy_attrs["data"]["realm_name"])
+    end
+
+    test "renders realm with default replication when only replication_factor is given", %{
+      auth_conn: conn
+    } do
       conn = post(conn, realm_path(conn, :create), @explicit_replication_attrs)
       assert response(conn, 201)
       conn = get(conn, realm_path(conn, :show, @explicit_replication_attrs["data"]["realm_name"]))
@@ -156,9 +187,8 @@ defmodule Astarte.HousekeepingWeb.RealmControllerTest do
                  "realm_name" => @explicit_replication_attrs["data"]["realm_name"],
                  "jwt_public_key_pem" =>
                    @explicit_replication_attrs["data"]["jwt_public_key_pem"],
-                 "replication_class" => "SimpleStrategy",
-                 "replication_factor" =>
-                   @explicit_replication_attrs["data"]["replication_factor"],
+                 "replication_class" => "NetworkTopologyStrategy",
+                 "datacenter_replication_factors" => %{@local_datacenter => 1},
                  "device_registration_limit" => nil,
                  "datastream_maximum_storage_retention" => nil
                }

--- a/apps/astarte_housekeeping/test/support/helpers/database.ex
+++ b/apps/astarte_housekeeping/test/support/helpers/database.ex
@@ -21,6 +21,7 @@ defmodule Astarte.Housekeeping.Helpers.Database do
   alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Realms.Realm
   alias Astarte.DataAccess.Repo
+  alias Astarte.Housekeeping.Realms.Queries
 
   @create_keyspace """
   CREATE KEYSPACE :keyspace
@@ -347,8 +348,13 @@ defmodule Astarte.Housekeeping.Helpers.Database do
     execute(astarte_keyspace, @create_keyspace)
     execute(astarte_keyspace, @create_kv_store)
     execute(astarte_keyspace, @create_realms_table)
+    save_default_replication(%{strategy: :network_topology, dc_factors: %{"datacenter1" => 1}})
 
     :ok
+  end
+
+  def save_default_replication(replication) do
+    Queries.save_keyspace_replication(replication)
   end
 
   def teardown(realm_name) do

--- a/apps/astarte_housekeeping/test/test_helper.exs
+++ b/apps/astarte_housekeeping/test/test_helper.exs
@@ -18,6 +18,7 @@
 
 Mimic.copy(Astarte.DataAccess.Config)
 Mimic.copy(Astarte.DataAccess.Health)
+Mimic.copy(Astarte.DataAccess.KvStore)
 Mimic.copy(Astarte.DataAccess.Repo)
 Mimic.copy(Astarte.Events.AMQP)
 Mimic.copy(Astarte.Events.AMQP.Vhost)


### PR DESCRIPTION
This PR introduces the following change: when a realm is created without specyfing replication strategy and factor, the default strategy stored in kv store is used