### PR TITLE
ci: Fix versions dropdown on Astarte github pages

### DIFF
--- a/.github/workflows/docs-workflow.yaml
+++ b/.github/workflows/docs-workflow.yaml
@@ -93,6 +93,7 @@ jobs:
           rm -rf docs/$DOCS_DIRNAME
           mkdir docs/$DOCS_DIRNAME
           cp -r astarte/doc/doc/* docs/$DOCS_DIRNAME/
+          cp astarte/common_vars.js docs/$DOCS_DIRNAME/docs_config.js
       - name: Checkout Swagger UI
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Generate `docs_config.js` required by `ex_doc` to autogenerate app version dropdown on page.