### PR TITLE
chore(secrets): add DEK support via OpenBao transit

### DIFF
--- a/libs/astarte_secrets/lib/astarte_secrets/astarte_secrets.ex
+++ b/libs/astarte_secrets/lib/astarte_secrets/astarte_secrets.ex
@@ -165,6 +165,48 @@ defmodule Astarte.Secrets do
   end
 
   @doc """
+  Generates a new Data Encryption Key (DEK) wrapped under the named transit key.
+  Optional `:bits` (128 or 256, default 256).
+  """
+  @spec generate_dek(String.t(), String.t(), keyword()) ::
+          {:ok, %{plaintext: binary(), ciphertext: String.t()}} | :error
+  def generate_dek(key_name, namespace, opts \\ []) do
+    Core.generate_dek(key_name, namespace, opts)
+  end
+
+  @doc """
+  Unwraps a DEK ciphertext using the named transit key.
+  """
+  @spec unwrap_dek(String.t(), String.t(), String.t(), keyword()) :: {:ok, binary()} | :error
+  def unwrap_dek(key_name, ciphertext, namespace, opts \\ []) do
+    client_opts = [namespace: namespace] ++ Keyword.take(opts, [:token])
+    headers = [{"Content-Type", "application/json"}]
+
+    case Client.post(
+           "/transit/decrypt/#{key_name}",
+           Jason.encode!(%{ciphertext: ciphertext}),
+           headers,
+           client_opts
+         ) do
+      {:ok, %HTTPoison.Response{status_code: 200, body: body}} ->
+        with {:ok, data} <- Core.parse_json_data(body),
+             plaintext_b64 when is_binary(plaintext_b64) <- Map.get(data, "plaintext"),
+             {:ok, plaintext} <- Base.decode64(plaintext_b64) do
+          {:ok, plaintext}
+        else
+          _ -> :error
+        end
+
+      error_resp ->
+        Logger.error(
+          "Failed to unwrap DEK with key #{key_name} in namespace #{namespace}: #{inspect(error_resp)}"
+        )
+
+        :error
+    end
+  end
+
+  @doc """
   Decrypts the provided ciphertext using OpenBao Transit Engine.
   Useful for ASYMKEX where the device encrypts a secret with the owner's RSA public key.
   """

--- a/libs/astarte_secrets/lib/astarte_secrets/core.ex
+++ b/libs/astarte_secrets/lib/astarte_secrets/core.ex
@@ -109,6 +109,76 @@ defmodule Astarte.Secrets.Core do
     :error
   end
 
+  # TODO: add a proper public API (Astarte.Secrets) for creating/managing the KEK
+  # (mount transit + create AES-256 key)
+  def create_encryption_key(key_name, namespace) do
+    headers = [{"Content-Type", "application/json"}]
+
+    case Client.post(
+           "/transit/keys/#{key_name}",
+           Jason.encode!(%{type: "aes256-gcm96"}),
+           headers,
+           namespace: namespace
+         ) do
+      {:ok, %{status_code: s}} when s in [200, 204] ->
+        :ok
+
+      {:ok, %{status_code: 400, body: body}} when is_binary(body) ->
+        if body =~ "already in use", do: :ok, else: :error
+
+      other ->
+        Logger.error(
+          "Failed to create KEK #{key_name} in namespace #{namespace}: #{inspect(other)}"
+        )
+
+        :error
+    end
+  end
+
+  @doc """
+  Generates a new Data Encryption Key (DEK) wrapped under the named transit key.
+
+  Returns `{:ok, %{plaintext: binary(), ciphertext: String.t()}}` where:
+  - `plaintext` — raw DEK bytes
+  - `ciphertext` — vault-formatted wrapped DEK
+  """
+  @spec generate_dek(String.t(), String.t(), keyword()) ::
+          {:ok, %{plaintext: binary(), ciphertext: String.t()}} | :error
+  def generate_dek(key_name, namespace, opts \\ []) do
+    bits = Keyword.get(opts, :bits, 256)
+    headers = [{"Content-Type", "application/json"}]
+    client_opts = [namespace: namespace] ++ Keyword.take(opts, [:token])
+
+    with {:ok, %{status_code: 200, body: body}} <-
+           Client.post(
+             "/transit/datakey/plaintext/#{key_name}",
+             Jason.encode!(%{bits: bits}),
+             headers,
+             client_opts
+           ),
+         {:ok, data} <- parse_json_data(body),
+         {:ok, plaintext} <- decode_base64_field(data, "plaintext"),
+         {:ok, ciphertext} <- Map.fetch(data, "ciphertext") do
+      {:ok, %{plaintext: plaintext, ciphertext: ciphertext}}
+    else
+      error ->
+        Logger.error(
+          "Failed to generate DEK with key #{key_name} in namespace #{namespace}: #{inspect(error)}"
+        )
+
+        :error
+    end
+  end
+
+  defp decode_base64_field(data, field) do
+    with b64 when is_binary(b64) <- Map.get(data, field),
+         {:ok, decoded} <- Base.decode64(b64) do
+      {:ok, decoded}
+    else
+      _ -> :error
+    end
+  end
+
   @spec create_keypair(String.t(), String.t(), boolean(), String.t()) ::
           :error | {:error, Jason.DecodeError.t()} | {:ok, any()}
   def create_keypair(key_name, key_type, allow_key_export_and_backup, namespace) do

--- a/libs/astarte_secrets/test/astarte_secrets/core_test.exs
+++ b/libs/astarte_secrets/test/astarte_secrets/core_test.exs
@@ -626,4 +626,43 @@ defmodule Astarte.Secrets.CoreTest do
       assert :aes256 in Core.symmetric_key_algorithms()
     end
   end
+
+  describe "generate_dek/3 integration" do
+    setup do
+      {:ok, namespace} = Secrets.create_namespace("test", :es256)
+      # TODO: replace with Secrets.create_encryption_key once the public API exists.
+      :ok = Core.create_encryption_key("test-kek", namespace)
+      %{namespace: namespace, key_name: "test-kek"}
+    end
+
+    test "generates a 256-bit DEK wrapped under an AES-256-GCM key", %{
+      namespace: namespace,
+      key_name: key_name
+    } do
+      assert {:ok, %{plaintext: pt, ciphertext: ct}} =
+               Core.generate_dek(key_name, namespace)
+
+      assert byte_size(pt) == 32
+      assert String.starts_with?(ct, "vault:v1:")
+    end
+  end
+
+  describe "unwrap_dek/4 integration" do
+    setup do
+      {:ok, namespace} = Secrets.create_namespace("test", :es256)
+      # TODO: replace with Secrets.create_encryption_key once the public API exists.
+      :ok = Core.create_encryption_key("test-kek", namespace)
+      %{namespace: namespace, key_name: "test-kek"}
+    end
+
+    test "round-trips: generate then unwrap recovers the plaintext", %{
+      namespace: namespace,
+      key_name: key_name
+    } do
+      assert {:ok, %{plaintext: original_pt, ciphertext: ct}} =
+               Core.generate_dek(key_name, namespace)
+
+      assert {:ok, ^original_pt} = Secrets.unwrap_dek(key_name, ct, namespace)
+    end
+  end
 end


### PR DESCRIPTION
This PR aim to add DEK generation logic for the Encrypted Endpoints feature