### PR TITLE
chore(secrets): add realm kek functionality

### DIFF
--- a/libs/astarte_secrets/lib/astarte_secrets/astarte_secrets.ex
+++ b/libs/astarte_secrets/lib/astarte_secrets/astarte_secrets.ex
@@ -12,7 +12,48 @@ defmodule Astarte.Secrets do
 
   require Logger
 
-  @spec get_key(String.t()) :: {:ok, map()} | :error
+  @realm_kek_key_name "realm_kek"
+
+  @doc """
+  Creates the KEK for the given realm.
+  This function is idempotent when called multiple times with the same arguments.
+  """
+  @spec create_realm_kek(String.t(), Core.key_algorithm(), keyword()) :: term()
+  def create_realm_kek(realm_name, key_type \\ :aes256, options \\ []) do
+    namespace_tokens = Core.realm_kek_namespace_tokens(realm_name)
+    allow_key_export_and_backup = Keyword.get(options, :allow_key_export_and_backup, false)
+
+    with {:ok, key_type_string} <- Core.key_type_to_string(key_type),
+         {:ok, namespace} <- Core.create_nested_namespace(namespace_tokens),
+         :ok <- Core.mount_transit_engine(namespace),
+         {:ok, response} <-
+           Core.create_keypair(
+             @realm_kek_key_name,
+             key_type_string,
+             allow_key_export_and_backup,
+             namespace
+           ),
+         {:ok, key} <- Key.parse(@realm_kek_key_name, namespace, response) do
+      {:ok, key}
+    else
+      result ->
+        "Error creating realm kek for #{realm_name}: #{inspect(result)}"
+        |> Logger.error()
+
+        :error
+    end
+  end
+
+  @doc """
+  Returns the KEK for the given realm
+  """
+  @spec fetch_realm_kek(String.t()) :: {:ok, Key.t()} | :error
+  def fetch_realm_kek(realm_name) do
+    namespace = Core.realm_kek_namespace_tokens(realm_name) |> Enum.join("/")
+    get_key(@realm_kek_key_name, namespace: namespace)
+  end
+
+  @spec get_key(String.t()) :: {:ok, Key.t()} | :error
   def get_key(key_name, opts \\ []) do
     namespace = Keyword.fetch!(opts, :namespace)
 

--- a/libs/astarte_secrets/lib/astarte_secrets/core.ex
+++ b/libs/astarte_secrets/lib/astarte_secrets/core.ex
@@ -30,7 +30,7 @@ defmodule Astarte.Secrets.Core do
 
   require Logger
 
-  @type key_algorithm() :: :es256 | :es384 | :rs256 | :rs384
+  @type key_algorithm() :: :aes128 | :aes256 | :es256 | :es384 | :rs256 | :rs384
   @type digest_type() :: :crypto.sha1() | :crypto.sha2()
 
   # RFC 5649 AES Key Wrap with Padding magic constant
@@ -46,9 +46,19 @@ defmodule Astarte.Secrets.Core do
     ]
   end
 
+  @spec symmetric_key_algorithms() :: [key_algorithm()]
+  def symmetric_key_algorithms do
+    [
+      :aes128,
+      :aes256
+    ]
+  end
+
   @spec key_type_to_string(key_algorithm()) :: {:ok, String.t()} | :error
   def key_type_to_string(key_type) do
     case key_type do
+      :aes128 -> {:ok, "aes128-gcm96"}
+      :aes256 -> {:ok, "aes256-gcm96"}
       :es256 -> {:ok, "ecdsa-p256"}
       :es384 -> {:ok, "ecdsa-p384"}
       :rs256 -> {:ok, "rsa-2048"}
@@ -60,6 +70,8 @@ defmodule Astarte.Secrets.Core do
   @spec string_to_key_type(String.t()) :: {:ok, key_algorithm()} | :error
   def string_to_key_type(string_key_type) do
     case string_key_type do
+      "aes128-gcm96" -> {:ok, :aes128}
+      "aes256-gcm96" -> {:ok, :aes256}
       "ecdsa-p256" -> {:ok, :es256}
       "ecdsa-p384" -> {:ok, :es384}
       "rsa-2048" -> {:ok, :rs256}
@@ -71,6 +83,8 @@ defmodule Astarte.Secrets.Core do
   @spec key_algorithm_enum :: Keyword.t(String.t())
   def key_algorithm_enum do
     [
+      aes128: "aes128-gcm96",
+      aes256: "aes256-gcm96",
       es256: "ecdsa-p256",
       es384: "ecdsa-p384",
       rs256: "rsa-2048",
@@ -312,6 +326,14 @@ defmodule Astarte.Secrets.Core do
 
         :error
     end
+  end
+
+  @doc """
+  Returns the namespace name for the realm KEKs namespace, represented as a list of tokens
+  """
+  def realm_kek_namespace_tokens(realm_name) do
+    ["astarte_encrypted_messages_kek", instance_tokens(), realm_name]
+    |> List.flatten()
   end
 
   @doc """

--- a/libs/astarte_secrets/lib/astarte_secrets/key/key.ex
+++ b/libs/astarte_secrets/lib/astarte_secrets/key/key.ex
@@ -43,11 +43,17 @@ defmodule Astarte.Secrets.Key do
   """
   @spec parse(String.t(), String.t(), map()) :: {:ok, t()} | {:error, term()}
   def parse(key_name, namespace, data) do
+    revisions =
+      Map.new(data["keys"], fn {revision, params} ->
+        params = %{params: params, revision: revision}
+        {revision, params}
+      end)
+
     params = %{
       "namespace" => namespace,
       "name" => key_name,
       "alg" => data["type"],
-      "revisions" => data["keys"]
+      "revisions" => revisions
     }
 
     changeset = changeset(%Key{}, params)
@@ -65,7 +71,7 @@ defmodule Astarte.Secrets.Key do
   defp cast_revisions(changeset, key) when changeset.valid? do
     # SAFETY: `:alg` is required and the changeset is valid
     alg = fetch_field!(changeset, :alg)
-    cast_fun = fn revision, params, index -> Revision.changeset(revision, alg, index, params) end
+    cast_fun = fn revision, params -> Revision.changeset(revision, alg, params) end
 
     changeset
     |> cast_embed(key, required: true, with: cast_fun)

--- a/libs/astarte_secrets/lib/astarte_secrets/key/revision.ex
+++ b/libs/astarte_secrets/lib/astarte_secrets/key/revision.ex
@@ -29,26 +29,29 @@ defmodule Astarte.Secrets.Key.Revision do
   alias Ecto.Changeset
 
   @asymmetric_key_algorithms Core.asymmetric_key_algorithms()
+  @symmetric_key_algorithms Core.symmetric_key_algorithms()
 
   @primary_key false
   typed_embedded_schema do
     field :key_algorithm, Ecto.Enum, values: Core.key_algorithm_enum()
-    field :index, :integer
+    field :revision, :integer
     field :public_key, :string
+    field :creation_timestamp, :integer
   end
 
-  @spec changeset(t(), Core.key_algorithm(), integer(), term()) :: Changeset.t()
-  def changeset(revision, key_algorithm, index, params = %{})
+  @spec changeset(t(), Core.key_algorithm(), term()) :: Changeset.t()
+  def changeset(revision, key_algorithm, %{params: params = %{}, revision: revision_number})
       when key_algorithm in @asymmetric_key_algorithms do
-    attrs = %{key_algorithm: key_algorithm, index: index}
+    attrs = %{key_algorithm: key_algorithm}
 
     revision
     |> cast(params, [:public_key])
+    |> cast(%{revision: revision_number}, [:revision])
     |> validate_required([:public_key])
     |> change(attrs)
   end
 
-  def changeset(revision, key_algorithm, _index, params)
+  def changeset(revision, key_algorithm, params)
       when key_algorithm in @asymmetric_key_algorithms do
     revision
     |> change()
@@ -57,7 +60,25 @@ defmodule Astarte.Secrets.Key.Revision do
     )
   end
 
-  def changeset(revision, key_algorithm, _index, _params) do
+  def changeset(revision, key_algorithm, %{params: timestamp, revision: revision_number})
+      when key_algorithm in @symmetric_key_algorithms and is_integer(timestamp) do
+    attrs = %{key_algorithm: key_algorithm, creation_timestamp: timestamp}
+
+    revision
+    |> cast(%{revision: revision_number}, [:revision])
+    |> change(attrs)
+  end
+
+  def changeset(revision, key_algorithm, params)
+      when key_algorithm in @symmetric_key_algorithms do
+    revision
+    |> change()
+    |> add_error(:key_algorithm, "unknown parameter format for symmetric key algorithm",
+      params: params
+    )
+  end
+
+  def changeset(revision, key_algorithm, _params) do
     revision
     |> change()
     |> add_error(:key_algorithm, "is not supported", key_algorithm: key_algorithm)

--- a/libs/astarte_secrets/test/astarte_secrets/astarte_secrets_test.exs
+++ b/libs/astarte_secrets/test/astarte_secrets/astarte_secrets_test.exs
@@ -232,6 +232,46 @@ defmodule Astarte.SecretsTest do
     end
   end
 
+  describe "create_realm_kek/3" do
+    setup :realm_kek_setup
+
+    test "returns an `%Astarte.Secrets.Key{}`", context do
+      %{realm_name: realm_name, key_name: key_name, key_algorithm: key_algorithm} = context
+      assert {:ok, %Key{name: ^key_name}} = Secrets.create_realm_kek(realm_name, key_algorithm)
+    end
+
+    test "is idepmotent when called multiple times", context do
+      %{realm_name: realm_name, key_algorithm: key_algorithm} = context
+      opts = [allow_key_export_and_backup: true]
+
+      assert {:ok, key} = Secrets.create_realm_kek(realm_name, key_algorithm, opts)
+
+      # key has more than one revision
+      assert [_ | _] = key.revisions
+
+      assert {:ok, ^key} = Secrets.create_realm_kek(realm_name, key_algorithm, opts)
+    end
+
+    test "returns :error in case of error", context do
+      %{realm_name: realm_name, key_algorithm: key_algorithm} = context
+
+      Core
+      |> expect(:create_keypair, fn _key_name, _key_type, _allow_export, _namespace -> :error end)
+
+      assert :error = Secrets.create_realm_kek(realm_name, key_algorithm)
+    end
+  end
+
+  describe "fetch_realm_kek/1" do
+    setup :realm_kek_setup
+    setup :create_realm_kek
+
+    test "returns the realm kek", context do
+      %{realm_name: realm_name, key: key} = context
+      assert {:ok, ^key} = Secrets.fetch_realm_kek(realm_name)
+    end
+  end
+
   describe "successfully create and fetch a key pair in Secrets" do
     setup context do
       key_type = Map.get(context, :key_type)

--- a/libs/astarte_secrets/test/astarte_secrets/core_test.exs
+++ b/libs/astarte_secrets/test/astarte_secrets/core_test.exs
@@ -141,6 +141,8 @@ defmodule Astarte.Secrets.CoreTest do
 
   describe "key_type_to_string/1" do
     test "converts known key types to their string representation" do
+      assert {:ok, "aes128-gcm96"} = Core.key_type_to_string(:aes128)
+      assert {:ok, "aes256-gcm96"} = Core.key_type_to_string(:aes256)
       assert {:ok, "ecdsa-p256"} = Core.key_type_to_string(:es256)
       assert {:ok, "ecdsa-p384"} = Core.key_type_to_string(:es384)
       assert {:ok, "rsa-2048"} = Core.key_type_to_string(:rs256)
@@ -290,6 +292,8 @@ defmodule Astarte.Secrets.CoreTest do
 
   describe "string_to_key_type/1" do
     test "converts string key types to their atom representation" do
+      assert {:ok, :aes128} = Core.string_to_key_type("aes128-gcm96")
+      assert {:ok, :aes256} = Core.string_to_key_type("aes256-gcm96")
       assert {:ok, :es256} = Core.string_to_key_type("ecdsa-p256")
       assert {:ok, :es384} = Core.string_to_key_type("ecdsa-p384")
       assert {:ok, :rs256} = Core.string_to_key_type("rsa-2048")
@@ -612,6 +616,14 @@ defmodule Astarte.Secrets.CoreTest do
       Secrets.create_keypair("find-me", :es256, namespace: ns)
 
       assert :not_found = Core.find_key(realm_name, "find-me", :es384)
+    end
+  end
+
+  describe "symmetric_key_algorithm/0" do
+    test "returns a list of allowed symmetric key algorithms" do
+      assert is_list(Core.symmetric_key_algorithms())
+      assert Enum.all?(Core.symmetric_key_algorithms(), &is_atom/1)
+      assert :aes256 in Core.symmetric_key_algorithms()
     end
   end
 end

--- a/libs/astarte_secrets/test/astarte_secrets/key/revision_test.exs
+++ b/libs/astarte_secrets/test/astarte_secrets/key/revision_test.exs
@@ -23,11 +23,17 @@ defmodule Astarte.Secrets.Key.RevisionTest do
 
   describe "changeset/4" do
     test "returns an error when the parameters are in unexpected format for asymmetric keys" do
-      assert %{valid?: false} = Revision.changeset(%Revision{}, :es256, 1, 123)
+      params = %{params: 123, revision: 1}
+      assert %{valid?: false} = Revision.changeset(%Revision{}, :es256, params)
+    end
+
+    test "returns an error when the parameters are in unexpected format for symmetric keys" do
+      params = %{params: %{}, revision: 1}
+      assert %{valid?: false} = Revision.changeset(%Revision{}, :aes256, params)
     end
 
     test "returns an error for invalid key algorithms" do
-      assert %{valid?: false} = Revision.changeset(%Revision{}, :invalid, 1, %{})
+      assert %{valid?: false} = Revision.changeset(%Revision{}, :invalid, %{})
     end
   end
 end

--- a/libs/astarte_secrets/test/support/helpers/namespace.ex
+++ b/libs/astarte_secrets/test/support/helpers/namespace.ex
@@ -21,6 +21,7 @@ defmodule Astarte.Helpers.Namespace do
   import Mimic
 
   alias Astarte.DataAccess.Config, as: DataAccessConfig
+  alias Astarte.Secrets
 
   def namespace_tokens_setup(context) do
     realm_name = "realm#{System.unique_integer([:positive])}"
@@ -33,5 +34,23 @@ defmodule Astarte.Helpers.Namespace do
     stub(DataAccessConfig, :astarte_instance_id!, fn -> instance end)
 
     %{realm_name: realm_name, user_id: user_id, key_algorithm: key_algorithm, instance: instance}
+  end
+
+  def realm_kek_setup(context) do
+    realm_name = "realm#{System.unique_integer([:positive])}"
+    key_name = "realm_kek"
+    key_algorithm = [:aes256] |> Enum.random()
+    instance = Map.get(context, :instance, "")
+
+    stub(DataAccessConfig, :astarte_instance_id, fn -> {:ok, instance} end)
+    stub(DataAccessConfig, :astarte_instance_id!, fn -> instance end)
+
+    %{realm_name: realm_name, key_name: key_name, key_algorithm: key_algorithm}
+  end
+
+  def create_realm_kek(context) do
+    %{realm_name: realm_name, key_algorithm: key_algorithm} = context
+    {:ok, key} = Secrets.create_realm_kek(realm_name, key_algorithm)
+    %{key: key}
   end
 end


### PR DESCRIPTION
revision now works for both asymmetrical and symmetrical key algorithms

parameters are wrapped inside a map, as ecto expects a map or array
to be passed from cast_embed, while for symmetrical keys vault returns
a simple integer as value.

given this situation, the chance was taken to use vault's revision ids
instead of indexes as revision id, by embedding them into the
parameters