### PR TITLE
refactor(adapters)!: change DSL syntax and macro parsing

### DIFF
--- a/libs/astarte_adapters/.formatter.exs
+++ b/libs/astarte_adapters/.formatter.exs
@@ -1,9 +1,9 @@
 # Used by "mix format"
 locals_without_parens = [
-  transform: 2,
-  transform: 3,
+  transform: 1,
   pre_process: 1,
   keep: :*,
+  field: 1,
   field: 2,
   field: 3,
   post_process: 1

--- a/libs/astarte_adapters/lib/astarte/adapters.ex
+++ b/libs/astarte_adapters/lib/astarte/adapters.ex
@@ -31,13 +31,13 @@ defmodule Astarte.Adapters do
   import the `transform` macro.
 
   A transformation is defined using `transform`, which takes a name for the generated
-  function, an optional keyword list of configuration options, and a `do` block containing
-  the transformation rules.
+  function and a `do` block containing the transformation rules.
 
   ### Mapping Options
 
-  * `:source` - The expected input type (defaults to `any()`).
-  * `:returns` - The expected output type (defaults to `map()`).
+  Optional module attributes can be declared at the top of the block:
+  * `@source` - The expected input type (defaults to `any()`).
+  * `@returns` - The expected output type (defaults to `map()`).
 
   ### Rules
 
@@ -48,9 +48,11 @@ defmodule Astarte.Adapters do
       that receives the raw input data and must return a map for the engine to process.
   2. `keep path1, path2, ...`: (Optional) Syntactic sugar for 1-to-1 mappings. Maps
       an arbitrary number of listed keys without modifications. It must appear at most once.
-  3. `field destination, source, options`: Defines how to map a field.
-      * Standard field: `field :dest, :source, opts`
-      * Computed field: `field :dest, custom: fn source -> ... end`
+  3. `field`: Defines how to map a field.
+      * Standard field: `field :dest <- :source`
+      * Standard field with options: `field :dest <- :source, required: false`
+      * Computed field (Arity 2): `field :dest <- :source, fn val, source -> ... end, opts`
+      * Full source computed field (Arity 1): `field :dest, fn source -> ... end, opts`
   4. `post_process function`: (Optional) The last statement. A function of arity 1
       that will be called with the final mapped structure.
 
@@ -61,12 +63,15 @@ defmodule Astarte.Adapters do
 
         @type string_payload :: String.t()
 
-        transform :json_to_struct, source: string_payload() do
+        transform map_payload do
+          @source string_payload()
+          @returns map()
+
           pre_process &Jason.decode!/1
-          keep "id", "version"
-          field :name, ["data", "attributes", "name"]
-          field :type, "type", custom: fn type, _source -> String.upcase(type) end
-          field :full_name, custom: fn source -> source["first"] <> " " <> source["last"] end
+          keep ["id", "version"]
+          field :name <- ["data", "attributes", "name"]
+          field :type <- "type", fn type, _source -> String.upcase(type) end, required: false
+          field :full_name, fn source -> source["first"] <> " " <> source["last"] end
           post_process &struct!(MyStruct, &1)
         end
       end
@@ -82,26 +87,28 @@ defmodule Astarte.Adapters do
   @doc """
   Defines a transformation ruleset.
   """
-  defmacro transform(name, opts \\ [], do: block) do
-    source_type = Keyword.get(opts, :source, quote(do: any()))
-    return_type = Keyword.get(opts, :returns, quote(do: map()))
+  defmacro transform(name, do: block) do
+    %{
+      pre: pre,
+      fields: fields,
+      post: post,
+      source_type: source_type,
+      return_type: return_type
+    } = parse_block(block, __ENV__)
 
-    %{pre: pre, fields: fields, post: post} = parse_block(block, __ENV__)
+    fun_name =
+      case name do
+        {atom, _, _} when is_atom(atom) -> atom
+        atom when is_atom(atom) -> atom
+      end
 
     source_data_var = Macro.var(:source_data, nil)
     processed_source_var = Macro.var(:processed_source, nil)
 
     pre_ast =
       case pre do
-        nil ->
-          quote do
-            unquote(processed_source_var) = unquote(source_data_var)
-          end
-
-        fun ->
-          quote do
-            unquote(processed_source_var) = unquote(fun).(unquote(source_data_var))
-          end
+        nil -> quote(do: unquote(processed_source_var) = unquote(source_data_var))
+        fun -> quote(do: unquote(processed_source_var) = unquote(fun).(unquote(source_data_var)))
       end
 
     pipeline =
@@ -125,24 +132,26 @@ defmodule Astarte.Adapters do
 
     final_ast =
       case post do
-        nil ->
-          pipeline
-
-        fun ->
-          quote do
-            unquote(fun).(unquote(pipeline))
-          end
+        nil -> pipeline
+        fun -> quote(do: unquote(fun).(unquote(pipeline)))
       end
 
     quote do
-      @doc "Transforms source data using the `#{unquote(name)}` ruleset."
-      @spec unquote(name)(unquote(source_type)) :: unquote(return_type)
-      def unquote(name)(unquote(source_data_var)) do
+      @doc "Transforms source data using the `#{unquote(fun_name)}` ruleset."
+      @spec unquote(fun_name)(unquote(source_type)) :: unquote(return_type)
+      def unquote(fun_name)(unquote(source_data_var)) do
         unquote(pre_ast)
         _ = unquote(processed_source_var)
         unquote(final_ast)
       end
     end
+  end
+
+  defp parse_block({:__block__, _, []}, env) do
+    raise CompileError,
+      file: env.file,
+      line: env.line,
+      description: "Invalid construct in transform block: nil"
   end
 
   defp parse_block({:__block__, _, statements}, env), do: parse_statements(statements, env)
@@ -152,12 +161,25 @@ defmodule Astarte.Adapters do
     result =
       Enum.reduce(
         statements,
-        %{state: :start, pre: nil, fields: [], post: nil},
+        %{
+          state: :start,
+          pre: nil,
+          fields: [],
+          post: nil,
+          source_type: quote(do: any()),
+          return_type: quote(do: %{})
+        },
         &reduce_statement(&1, &2, env)
       )
 
     %{result | fields: Enum.reverse(result.fields)}
   end
+
+  defp reduce_statement({:@, _, [{:source, _, [type]}]}, acc, _env),
+    do: %{acc | source_type: type}
+
+  defp reduce_statement({:@, _, [{:returns, _, [type]}]}, acc, _env),
+    do: %{acc | return_type: type}
 
   defp reduce_statement({:pre_process, _, [fun]}, %{state: :start} = acc, _env),
     do: %{acc | state: :pre_process, pre: fun}
@@ -191,9 +213,8 @@ defmodule Astarte.Adapters do
       )
 
   defp reduce_statement({:field, _, args}, %{state: state} = acc, _env)
-       when state in [:start, :pre_process, :keep, :field] do
-    %{acc | state: :field, fields: [parse_field_args(args) | acc.fields]}
-  end
+       when state in [:start, :pre_process, :keep, :field],
+       do: %{acc | state: :field, fields: [parse_field_args(args) | acc.fields]}
 
   defp reduce_statement({:field, _, _}, %{state: _}, env),
     do:
@@ -204,9 +225,8 @@ defmodule Astarte.Adapters do
       )
 
   defp reduce_statement({:post_process, _, [fun]}, %{state: state} = acc, _env)
-       when state != :post_process do
-    %{acc | state: :post_process, post: fun}
-  end
+       when state != :post_process,
+       do: %{acc | state: :post_process, post: fun}
 
   defp reduce_statement({:post_process, _, _}, %{state: _}, env),
     do:
@@ -224,23 +244,23 @@ defmodule Astarte.Adapters do
         description: "Invalid construct in transform block: #{inspect(invalid_node)}"
       )
 
-  defp parse_field_args([dest, [{key, _} | _] = opts]) when is_atom(key) do
-    adapted_fun =
-      case Keyword.get(opts, :custom) do
-        nil -> nil
-        fun -> quote do: fn _val, source -> unquote(fun).(source) end
-      end
+  defp parse_field_args([{:<-, _, [dest, source]}, func, opts]) when is_list(opts),
+    do: {dest, source, Keyword.get(opts, :required, true), func}
 
-    {dest, [], false, adapted_fun}
-  end
+  defp parse_field_args([{:<-, _, [dest, source]}, opts]) when is_list(opts),
+    do: {dest, source, Keyword.get(opts, :required, true), nil}
 
-  defp parse_field_args([dest, source]) do
-    {dest, source, true, nil}
-  end
+  defp parse_field_args([{:<-, _, [dest, source]}, func]), do: {dest, source, true, func}
+  defp parse_field_args([{:<-, _, [dest, source]}]), do: {dest, source, true, nil}
 
-  defp parse_field_args([dest, source, opts]) when is_list(opts) do
-    {dest, source, Keyword.get(opts, :required, true), Keyword.get(opts, :custom)}
-  end
+  defp parse_field_args([dest, func, opts]) when is_list(opts),
+    do: {dest, [], Keyword.get(opts, :required, true), func}
+
+  defp parse_field_args([dest, opts]) when is_list(opts),
+    do: {dest, [], Keyword.get(opts, :required, true), nil}
+
+  defp parse_field_args([dest, func]), do: {dest, [], true, func}
+  defp parse_field_args([dest]), do: {dest, [], true, nil}
 
   defp normalize_path(path) when is_atom(path) or is_binary(path), do: [path]
   defp normalize_path(path) when is_list(path), do: path

--- a/libs/astarte_adapters/lib/astarte/adapters/engine.ex
+++ b/libs/astarte_adapters/lib/astarte/adapters/engine.ex
@@ -108,18 +108,30 @@ defmodule Astarte.Adapters.Engine do
 
   defp handle_fetched(
          {:ok, _val},
-         _acc,
-         _source_map,
-         _dest_path,
-         _source_path,
-         dest_field_name,
+         acc,
+         source_map,
+         dest_path,
+         [],
+         _dest_field_name,
          _req,
-         invalid_custom
+         custom_fun
        )
-       when not is_nil(invalid_custom) do
-    raise ArgumentError,
-          "Invalid :custom option for field #{inspect(dest_field_name)}. " <>
-            "Expected a function of exactly arity 2"
+       when is_function(custom_fun, 1) do
+    deep_put(acc, dest_path, custom_fun.(source_map))
+  end
+
+  defp handle_fetched(
+         {:ok, val},
+         acc,
+         _source_map,
+         dest_path,
+         _source_path,
+         _dest_field_name,
+         _req,
+         custom_fun
+       )
+       when is_function(custom_fun, 1) do
+    deep_put(acc, dest_path, custom_fun.(val))
   end
 
   defp handle_fetched(
@@ -158,5 +170,27 @@ defmodule Astarte.Adapters.Engine do
          nil
        ) do
     deep_put(acc, dest_path, val)
+  end
+
+  defp handle_fetched(
+         {:ok, _val},
+         _acc,
+         _source_map,
+         _dest_path,
+         _source_path,
+         dest_field_name,
+         _req,
+         invalid_custom
+       )
+       when not is_nil(invalid_custom) do
+    received =
+      if is_function(invalid_custom) do
+        "arity #{:erlang.fun_info(invalid_custom, :arity) |> elem(1)}"
+      else
+        inspect(invalid_custom)
+      end
+
+    raise ArgumentError,
+          "Invalid compute function for field #{inspect(dest_field_name)}. Expected arity 1 or 2, got: #{received}"
   end
 end

--- a/libs/astarte_adapters/test/astarte/adapters/engine_test.exs
+++ b/libs/astarte_adapters/test/astarte/adapters/engine_test.exs
@@ -18,116 +18,133 @@
 
 defmodule Astarte.Adapters.EngineTest do
   use ExUnit.Case, async: true
+  use ExUnitProperties
 
-  alias Astarte.Adapters.Engine
+  import Astarte.Adapters.Engine
+
   alias Astarte.Adapters.MissingFieldError
 
   describe "deep_get/2" do
-    test "extracts value using an atom path" do
-      assert Engine.deep_get(%{a: 42}, :a) == {:ok, 42}
+    test "returns ok with data when path is empty list" do
+      assert {:ok, %{a: 1}} == deep_get(%{a: 1}, [])
     end
 
-    test "returns the original map when path is empty" do
-      assert Engine.deep_get(%{a: 42}, []) == {:ok, %{a: 42}}
+    test "handles atom and binary paths" do
+      assert {:ok, 1} == deep_get(%{a: 1}, :a)
+      assert {:ok, 2} == deep_get(%{"b" => 2}, "b")
     end
 
-    test "extracts value using a single-element list path" do
-      assert Engine.deep_get(%{a: 42}, [:a]) == {:ok, 42}
+    test "returns value for single key" do
+      assert {:ok, 1} == deep_get(%{a: 1}, [:a])
+      assert :error == deep_get(%{a: 1}, [:b])
     end
 
-    test "extracts value deep inside nested maps" do
-      assert Engine.deep_get(%{a: %{b: %{c: 42}}}, [:a, :b, :c]) == {:ok, 42}
+    test "returns value for nested keys" do
+      assert {:ok, 1} == deep_get(%{a: %{b: 1}}, [:a, :b])
     end
 
-    test "returns :error when the root key is missing" do
-      assert Engine.deep_get(%{a: 42}, [:b]) == :error
+    test "returns error when intermediate key is missing" do
+      assert :error == deep_get(%{a: %{}}, [:a, :b, :c])
     end
 
-    test "returns :error when a nested key is missing" do
-      assert Engine.deep_get(%{a: %{}}, [:a, :b]) == :error
-    end
-
-    test "returns :error when encountering a non-map node midway" do
-      assert Engine.deep_get(%{a: "string"}, [:a, :b]) == :error
-    end
-
-    test "returns :error when the source is entirely nil or not a map" do
-      assert Engine.deep_get(nil, [:a]) == :error
-      assert Engine.deep_get([a: 1], [:a]) == :error
+    test "returns error when trying to get from a non-map" do
+      assert :error == deep_get("not_a_map", [:a])
+      assert :error == deep_get(%{a: "not_a_map"}, [:a, :b])
     end
   end
 
   describe "deep_put/3" do
-    test "inserts value using an atom path" do
-      assert Engine.deep_put(%{}, :a, 42) == %{a: 42}
+    test "handles atom and binary paths" do
+      assert %{a: 1} == deep_put(%{}, :a, 1)
+      assert %{"b" => 2} == deep_put(%{}, "b", 2)
     end
 
-    test "inserts value using a single-element list path" do
-      assert Engine.deep_put(%{}, [:a], 42) == %{a: 42}
+    test "puts value for single key" do
+      assert %{a: 1} == deep_put(%{}, [:a], 1)
     end
 
-    test "inserts value deep into an existing nested structure" do
-      assert Engine.deep_put(%{a: %{b: 1}}, [:a, :c], 42) == %{a: %{b: 1, c: 42}}
+    test "puts value for nested keys" do
+      assert %{a: %{b: %{c: 1}}} == deep_put(%{}, [:a, :b, :c], 1)
     end
 
-    test "creates intermediate empty maps when path goes deeper than existing structure" do
-      assert Engine.deep_put(%{}, [:a, :b, :c], 42) == %{a: %{b: %{c: 42}}}
-    end
-
-    test "overwrites non-map nodes with a new map to proceed with insertion" do
-      assert Engine.deep_put(%{a: "old_string"}, [:a, :b], 42) == %{a: %{b: 42}}
+    test "overwrites scalar value with map via ensure_map/1" do
+      assert %{a: %{b: 2}} == deep_put(%{a: 1}, [:a, :b], 2)
     end
   end
 
-  describe "process_field/7" do
-    test "raises MissingFieldError when a strictly missing key is required" do
+  describe "process_field/7 and handle_fetched/8" do
+    test "raises MissingFieldError when required field is missing" do
       assert_raise MissingFieldError, fn ->
-        Engine.process_field(%{}, %{}, [:dest], [:src], :dest, true, nil)
+        process_field(%{}, %{}, [:dest], [:src], :dest, true, nil)
       end
     end
 
-    test "returns accumulator unchanged when a strictly missing key is optional" do
-      assert Engine.process_field(%{keep: 1}, %{}, [:dest], [:src], :dest, false, nil) == %{
-               keep: 1
-             }
+    test "returns accumulator when optional field is missing" do
+      acc = %{kept: 1}
+      assert acc == process_field(acc, %{}, [:dest], [:src], :dest, false, nil)
     end
 
-    test "raises MissingFieldError when an existing key has a nil value and is required" do
+    test "applies arity 2 custom function" do
+      fun = fn val, source -> val + source.offset end
+      source = %{src: 10, offset: 5}
+      expected = %{dest: 15}
+      assert expected == process_field(%{}, source, [:dest], [:src], :dest, true, fun)
+    end
+
+    test "applies arity 1 custom function with empty source path (entire source passed)" do
+      fun = fn source -> source.a + source.b end
+      source = %{a: 10, b: 5}
+      expected = %{dest: 15}
+      assert expected == process_field(%{}, source, [:dest], [], :dest, true, fun)
+    end
+
+    test "applies arity 1 custom function with specific source path" do
+      fun = fn val -> val * 2 end
+      source = %{src: 10}
+      expected = %{dest: 20}
+      assert expected == process_field(%{}, source, [:dest], [:src], :dest, true, fun)
+    end
+
+    test "raises MissingFieldError when required field is nil and no custom fun" do
       assert_raise MissingFieldError, fn ->
-        Engine.process_field(%{}, %{src: nil}, [:dest], [:src], :dest, true, nil)
+        process_field(%{}, %{src: nil}, [:dest], [:src], :dest, true, nil)
       end
     end
 
-    test "returns accumulator unchanged when an existing key has a nil value and is optional" do
-      assert Engine.process_field(%{keep: 1}, %{src: nil}, [:dest], [:src], :dest, false, nil) ==
-               %{keep: 1}
+    test "returns accumulator when optional field is nil and no custom fun" do
+      acc = %{kept: 1}
+      assert acc == process_field(acc, %{src: nil}, [:dest], [:src], :dest, false, nil)
     end
 
-    test "inserts the extracted value directly when no custom function is provided" do
-      assert Engine.process_field(%{}, %{src: 42}, [:dest], [:src], :dest, true, nil) == %{
-               dest: 42
-             }
+    test "puts value directly when no custom function is provided" do
+      source = %{src: 10}
+      expected = %{dest: 10}
+      assert expected == process_field(%{}, source, [:dest], [:src], :dest, true, nil)
     end
 
-    test "executes the custom function with extracted value and full source map" do
-      custom_fun = fn val, source_map ->
-        assert source_map == %{src: 10, other: 5}
-        val * 2
+    test "raises ArgumentError with arity info when custom function has invalid arity" do
+      fun = fn a, b, c -> a + b + c end
+
+      assert_raise ArgumentError, ~r/Expected arity 1 or 2, got: arity 3/, fn ->
+        process_field(%{}, %{src: 1}, [:dest], [:src], :dest, true, fun)
       end
-
-      assert Engine.process_field(
-               %{},
-               %{src: 10, other: 5},
-               [:dest],
-               [:src],
-               :dest,
-               true,
-               custom_fun
-             ) == %{dest: 20}
     end
 
-    test "returns :error when the first key of a multi-part path is missing (triggers continue_get error fallback)" do
-      assert Engine.deep_get(%{}, [:a, :b]) == :error
+    test "raises ArgumentError with inspect info when custom function is not a function" do
+      assert_raise ArgumentError, ~r/Expected arity 1 or 2, got: "not a function"/, fn ->
+        process_field(%{}, %{src: 1}, [:dest], [:src], :dest, true, "not a function")
+      end
+    end
+  end
+
+  describe "Properties" do
+    property "deep_put followed by deep_get retrieves the exact value" do
+      check all path <- list_of(one_of([atom(:alphanumeric), string(:ascii)]), min_length: 1),
+                value <- term(),
+                map <- map_of(atom(:alphanumeric), term()) do
+        updated_map = deep_put(map, path, value)
+        assert {:ok, value} == deep_get(updated_map, path)
+      end
     end
   end
 end

--- a/libs/astarte_adapters/test/astarte/adapters_test.exs
+++ b/libs/astarte_adapters/test/astarte/adapters_test.exs
@@ -149,7 +149,7 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestPreProcessFail do
         use Astarte.Adapters
-        transform :fail do
+        transform fail do
           keep :a
           pre_process fn x -> x end
         end
@@ -165,7 +165,7 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestKeepFail do
         use Astarte.Adapters
-        transform :fail do
+        transform fail do
           keep :a
           keep :b
         end
@@ -181,8 +181,8 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestKeepAfterFieldFail do
         use Astarte.Adapters
-        transform :fail do
-          field :b, :c
+        transform fail do
+          field :b <- :c
           keep :a
         end
       end
@@ -199,9 +199,9 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestFieldAfterPostProcessFail do
         use Astarte.Adapters
-        transform :fail do
+        transform fail do
           post_process fn x -> x end
-          field :a, :b
+          field :a <- :b
         end
       end
       """
@@ -215,7 +215,7 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestPostProcessFail do
         use Astarte.Adapters
-        transform :fail do
+        transform fail do
           post_process fn x -> x end
           post_process fn x -> x end
         end
@@ -231,7 +231,7 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestInvalidConstruct do
         use Astarte.Adapters
-        transform :fail do
+        transform fail do
           :invalid_atom
         end
       end
@@ -244,11 +244,57 @@ defmodule Astarte.AdaptersTest do
   end
 
   describe "Astarte.Adapters edge cases for 100% coverage" do
+    test "parses @source and @returns correctly" do
+      code = """
+      defmodule TestAttrs do
+        use Astarte.Adapters
+        transform run do
+          @source map()
+          @returns map()
+          field :a <- :b
+        end
+      end
+      """
+
+      assert {{:module, _, _, _}, _} = Code.eval_string(code)
+    end
+
+    test "covers all field parse combinations and path normalizations" do
+      code = """
+      defmodule TestFieldCombos do
+        use Astarte.Adapters
+        transform run do
+          field [:dest, :path] <- ["source", "path"], fn x, _ -> x end, required: false
+          field :f2 <- :s2, required: false
+          field :f3 <- :s3, fn x, _ -> x end
+          field :f4 <- :s4
+          field :f5, fn x -> x end, required: false
+          field :f6, required: false
+          field :f7, fn x -> x end
+          field :f8
+        end
+      end
+      """
+
+      assert {{:module, _, _, _}, _} = Code.eval_string(code)
+    end
+
+    test "handles inline single statement block" do
+      code = """
+      defmodule TestInline do
+        use Astarte.Adapters
+        transform run, do: field(:a <- :b)
+      end
+      """
+
+      assert {{:module, _, _, _}, _} = Code.eval_string(code)
+    end
+
     test "keep accepts a list of keys" do
       code = """
       defmodule TestKeepList do
         use Astarte.Adapters
-        transform :run do
+        transform run do
           keep [:a, :b]
         end
       end
@@ -262,7 +308,7 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestKeepSingle do
         use Astarte.Adapters
-        transform :run do
+        transform run do
           keep :a
         end
       end
@@ -276,7 +322,7 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestComputedNoCustom do
         use Astarte.Adapters
-        transform :run do
+        transform run do
           field :a, required: false
         end
       end
@@ -286,24 +332,40 @@ defmodule Astarte.AdaptersTest do
       assert %{a: %{b: 1}} == mod.run(%{b: 1})
     end
 
-    test "empty block returns empty map" do
+    test "raises CompileError on empty block" do
       code = """
       defmodule TestEmpty do
         use Astarte.Adapters
-        transform :run do
+        transform run do
         end
       end
       """
 
-      {{:module, mod, _, _}, _} = Code.eval_string(code)
-      assert %{} == mod.run(%{a: 1, b: 2})
+      assert_raise CompileError, ~r/Invalid construct in transform block: nil/, fn ->
+        Code.eval_string(code)
+      end
+    end
+
+    test "single statement None value raises CompileError" do
+      code = """
+      defmodule TestSingleNil do
+        use Astarte.Adapters
+        transform run do
+          nil
+        end
+      end
+      """
+
+      assert_raise CompileError, ~r/Invalid construct in transform block: nil/, fn ->
+        Code.eval_string(code)
+      end
     end
 
     test "allows only pre_process" do
       code = """
       defmodule TestPreOnly do
         use Astarte.Adapters
-        transform :run do
+        transform run do
           pre_process fn x -> %{x: x} end
         end
       end
@@ -317,7 +379,7 @@ defmodule Astarte.AdaptersTest do
       code = """
       defmodule TestPostOnly do
         use Astarte.Adapters
-        transform :run do
+        transform run do
           post_process fn x -> Map.put(x, :ok, true) end
         end
       end
@@ -326,24 +388,17 @@ defmodule Astarte.AdaptersTest do
       {{:module, mod, _, _}, _} = Code.eval_string(code)
       assert %{ok: true} == mod.run(%{})
     end
-  end
 
-  describe "Astarte.Adapters.Engine runtime constraints" do
-    test "raises ArgumentError when custom option is invalid" do
+    test "transform macro with pure atom name" do
       code = """
-      defmodule TestRuntimeArity do
+      defmodule TestPureAtomName do
         use Astarte.Adapters
-        transform :run do
-          field :a, :b, custom: "not a function"
-        end
+        transform(:run_pure, do: field(:a <- :b))
       end
       """
 
       {{:module, mod, _, _}, _} = Code.eval_string(code)
-
-      assert_raise ArgumentError, ~r/Invalid :custom option for field :a/, fn ->
-        mod.run(%{b: 1})
-      end
+      assert mod.run_pure(%{b: 1}) == %{a: 1}
     end
   end
 end

--- a/libs/astarte_adapters/test/support/mappings.ex
+++ b/libs/astarte_adapters/test/support/mappings.ex
@@ -23,63 +23,75 @@ defmodule Astarte.Adapters.Mappings do
   alias Astarte.Adapters.ComplexStruct
   alias Astarte.Adapters.SimpleStruct
 
-  transform :map_to_simple_struct, returns: SimpleStruct.t() do
-    field :id, :id
-    field :name, :name, required: false
+  transform map_to_simple_struct do
+    @source map()
+    @returns SimpleStruct.t()
+    field :id <- :id
+    field :name <- :name, required: false
     post_process &struct!(SimpleStruct, &1)
   end
 
-  @type my_source :: %{a: %{id: integer(), name: String.t() | nil}, b: [map()]}
-  transform :map_to_complex_struct, source: my_source(), returns: ComplexStruct.t() do
-    field :id, [:a, :id]
-    field :name, [:a, :name], required: false
+  transform map_to_complex_struct do
+    @source %{a: %{id: integer(), name: String.t() | nil}, b: [map()]}
+    @returns ComplexStruct.t()
 
-    field :children, :b,
-      custom: fn children, _source ->
-        Enum.map(children, &map_to_simple_struct/1)
-      end
+    field :id <- [:a, :id]
+    field :name <- [:a, :name], required: false
+
+    field :children <- :b, fn children, _source -> Enum.map(children, &map_to_simple_struct/1) end
 
     post_process &struct!(ComplexStruct, &1)
   end
 
-  transform :complex_struct_to_map do
-    field [:a, :id], :id
-    field [:a, :name], :name, required: false
+  transform complex_struct_to_map do
+    @source ComplexStruct.t()
+    @returns %{a: %{id: integer(), name: String.t()}, b: [%{id: integer(), name: String.t()}]}
 
-    field :b, :children,
-      custom: fn children, _source ->
-        Enum.map(children, &Map.from_struct/1)
-      end
+    field [:a, :id] <- :id
+    field [:a, :name] <- :name, required: false
+
+    field :b <- :children, fn children, _source -> Enum.map(children, &Map.from_struct/1) end
   end
 
-  @type string_source :: %{
-          required(String.t()) => String.t(),
-          required(String.t()) => String.t()
-        }
-  @type string_result :: String.t()
-  transform :string_map_to_string, source: string_source(), returns: string_result() do
+  transform string_map_to_string do
+    @source %{required(String.t()) => String.t(), required(String.t()) => String.t()}
+    @returns String.t()
     keep "a", "b"
     post_process fn %{"a" => a, "b" => b} -> a <> b end
   end
 
-  transform :full_dsl_test do
+  transform full_dsl_test do
+    @source {integer(), String.t(), String.t(), String.t()}
+    @returns %{
+      id: integer(),
+      role: String.t(),
+      is_active: bool(),
+      role_upper: String.t(),
+      full_name: String.t(),
+      processed_at: atom()
+    }
+
     pre_process fn {id, first, last, role} ->
       %{id: id, first: first, last: last, role: role, meta: %{active: true}}
     end
 
     keep :id, :role
-    field :is_active, [:meta, :active]
-    field :role_upper, :role, custom: fn role, _source -> String.upcase(role) end
-    field :full_name, custom: fn source -> "#{source.first} #{source.last}" end
+    field :is_active <- [:meta, :active]
+    field :role_upper <- :role, fn role, _source -> String.upcase(role) end
+    field :full_name, fn source -> "#{source.first} #{source.last}" end
     post_process fn result -> Map.put(result, :processed_at, :now) end
   end
 
-  transform :computed_fields_only do
-    field :combined, custom: fn src -> src.x + src.y end
-    field :static, custom: fn _src -> "always_this" end
+  transform computed_fields_only do
+    @source %{x: integer(), y: integer()}
+    @source %{combined: integer(), static: String.t()}
+    field :combined, fn src -> src.x + src.y end
+    field :static, fn _src -> "always_this" end
   end
 
-  transform :mixed_keep_test do
+  transform mixed_keep_test do
+    @source %{x: integer(), y: integer()}
+    @source %{combined: integer(), static: String.t()}
     keep :atom_key, "string_key", :another_atom
   end
 end

--- a/libs/astarte_data_access/lib/astarte_data_access/adapters/core/interface_mapping.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/adapters/core/interface_mapping.ex
@@ -30,47 +30,40 @@ defmodule Astarte.DataAccess.Adapters.Core.InterfaceMapping do
   alias Astarte.DataAccess.Realms.Endpoint
   alias Astarte.DataAccess.Realms.Interface
 
-  @type interface_core :: InterfaceCore.t()
-  @type mapping_core :: MappingCore.t()
-
-  @type from_core_source :: interface_core()
-  @type from_core_returns :: %{interface: Changeset.t(), endpoints: list(Changeset.t())}
-  transform :from_core,
-    source: from_core_source(),
-    returns: from_core_returns() do
-    field [:interface, :interface_id], :interface_id
-    field [:interface, :name], :name
-    field [:interface, :major_version], :major_version
-    field [:interface, :minor_version], :minor_version
-    field [:interface, :aggregation], :aggregation
-    field [:interface, :ownership], :ownership
-    field [:interface, :type], :type
-    field [:interface, :storage], custom: &Interface.storage/1
-    field [:interface, :storage_type], custom: &Interface.storage_type/1
-    field [:interface, :doc], :doc, required: false
-    field [:interface, :description], :description, required: false
-    field :endpoints, :mappings, custom: &from_core_mappings/2
+  transform from_core_interface do
+    @source InterfaceCore.t()
+    @returns %{interface: Changeset.t(), endpoints: list(Changeset.t())}
+    field [:interface, :interface_id] <- :interface_id
+    field [:interface, :name] <- :name
+    field [:interface, :major_version] <- :major_version
+    field [:interface, :minor_version] <- :minor_version
+    field [:interface, :aggregation] <- :aggregation
+    field [:interface, :ownership] <- :ownership
+    field [:interface, :type] <- :type
+    field [:interface, :storage], &Interface.storage/1
+    field [:interface, :storage_type], &Interface.storage_type/1
+    field [:interface, :doc] <- :doc, required: false
+    field [:interface, :description] <- :description, required: false
+    field :endpoints <- :mappings, &from_core_mappings/2
     post_process &from_core_post_process/1
   end
 
-  @type from_core_mapping_source :: %{interface_id: String.t(), mapping: mapping_core()}
-  @type from_core_mapping_returns :: Changeset.t()
-  transform :from_core_mapping,
-    source: from_core_mapping_source(),
-    results: from_core_mapping_returns do
+  transform from_core_mapping do
+    @source %{interface_id: String.t(), mapping: MappingCore.t()}
+    @returns Changeset.t()
     keep :interface_id
-    field :endpoint, [:mapping, :endpoint]
-    field :value_type, [:mapping, :value_type]
-    field :reliability, [:mapping, :reliability]
-    field :retention, [:mapping, :retention]
-    field :expiry, [:mapping, :expiry]
-    field :database_retention_policy, [:mapping, :database_retention_policy]
-    field :database_retention_ttl, [:mapping, :database_retention_ttl], required: false
-    field :allow_unset, [:mapping, :allow_unset]
-    field :explicit_timestamp, [:mapping, :explicit_timestamp]
-    field :endpoint_id, [:mapping, :endpoint_id]
-    field :doc, [:mapping, :doc], required: false
-    field :description, [:mapping, :description], required: false
+    field :endpoint <- [:mapping, :endpoint]
+    field :value_type <- [:mapping, :value_type]
+    field :reliability <- [:mapping, :reliability]
+    field :retention <- [:mapping, :retention]
+    field :expiry <- [:mapping, :expiry]
+    field :database_retention_policy <- [:mapping, :database_retention_policy]
+    field :database_retention_ttl <- [:mapping, :database_retention_ttl], required: false
+    field :allow_unset <- [:mapping, :allow_unset]
+    field :explicit_timestamp <- [:mapping, :explicit_timestamp]
+    field :endpoint_id <- [:mapping, :endpoint_id]
+    field :doc <- [:mapping, :doc], required: false
+    field :description <- [:mapping, :description], required: false
     post_process &from_core_mapping_post_process/1
   end
 

--- a/libs/astarte_data_access/test/adapters/core/interface_mapping_test.exs
+++ b/libs/astarte_data_access/test/adapters/core/interface_mapping_test.exs
@@ -42,7 +42,7 @@ defmodule Astarte.DataAccess.Adapters.Core.InterfaceMappingTest do
   describe "from core interface" do
     property "ensure all changesets are valid" do
       check all interface <- interface() do
-        %{interface: interface, endpoints: endpoints} = from_core(interface)
+        %{interface: interface, endpoints: endpoints} = from_core_interface(interface)
 
         assert interface.valid?
         assert Enum.all?(endpoints, & &1.valid?)
@@ -52,7 +52,7 @@ defmodule Astarte.DataAccess.Adapters.Core.InterfaceMappingTest do
     property "ensure all changesets have source fields data" do
       check all %InterfaceCore{} = interface_core <- interface() |> filter(&valid_interface?/1) do
         %{interface: interface_changeset, endpoints: endpoint_changesets} =
-          from_core(interface_core)
+          from_core_interface(interface_core)
 
         assert interface_core.interface_id ==
                  Changeset.get_field(interface_changeset, :interface_id)


### PR DESCRIPTION
- Introduce `<-` operator
- Positional custom functions
- In-block type attributes @source and @returns
- refactor `astarte_data_access` usage

BREAKING CHANGE: macro `transform` is not retro-compatible anymore