### PR TITLE
chore(dup): add MQTT control/keyAgreement topic for Encrypted Endpoints

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -149,6 +149,25 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     end
   end
 
+  @doc """
+  Handles the `/keyAgreement` control topic.
+
+  TODO: implement the key-agreement handshake protocol.
+  For now this clause simply acknowledges the message so routing is confirmed
+  to work end-to-end before the cryptographic logic is added.
+  """
+  def handle_control(state, "/keyAgreement", payload, timestamp) do
+    new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
+
+    final_state = %{
+      new_state
+      | total_received_msgs: new_state.total_received_msgs + 1,
+        total_received_bytes: new_state.total_received_bytes + byte_size(payload)
+    }
+
+    {:ack, :ok, final_state}
+  end
+
   def handle_control(state, path, payload, timestamp) do
     # Track unexpected control messages
     :telemetry.execute(

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -220,4 +220,27 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     assert log =~ "Unexpected control"
     assert new_state.total_received_msgs > state.total_received_msgs
   end
+
+  describe "/keyAgreement" do
+    test "acks any payload and increments message counters", context do
+      %{state: state} = context
+
+      payload = <<1, 2, 3>>
+
+      assert {:ack, :ok, new_state} =
+               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+
+      assert new_state.total_received_msgs == state.total_received_msgs + 1
+      assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
+    end
+
+    test "discards the message if discard_messages is set", context do
+      %{state: state} = context
+
+      state = %{state | discard_messages: true}
+
+      assert {:discard, _result, ^state} =
+               ControlHandler.handle_control(state, "/keyAgreement", <<1>>, 0)
+    end
+  end
 end

--- a/doc/pages/architecture/080-mqtt-v1-protocol.md
+++ b/doc/pages/architecture/080-mqtt-v1-protocol.md
@@ -19,6 +19,7 @@ Astarte MQTT v1 Protocol relies on few well known reserved topics.
 | `<realm name>/<device id>/control/emptyCache`          | Empty Cache      | Device       | 2       | ASCII plain text (always "1")           |
 | `<realm name>/<device id>/control/consumer/properties` | Purge Properties | Astarte      | 2       | deflated plain text                     |
 | `<realm name>/<device id>/control/producer/properties` | Purge Properties | Device       | 2       | deflated plain text                     |
+| `<realm name>/<device id>/control/keyAgreement`        | Key Agreement    | Both         | 1       | CBOR                                    |
 | `<realm name>/<device id>/<interface name>/<path>`     | Publish Data     | Both         | 0, 1, 2 | BSON (or empty)                         |
 
 For clarity reasons all `<realm name>/<device id>` prefixes will be omitted on the following paragraphs, those topics will be called device topics.
@@ -167,6 +168,12 @@ com.example.MyInterface/some/path;org.example.DraftInterface/otherPath
 ```
 
 This protocol feature is fundamental when a device has any interface with an _allow_unset_ mapping, _purge properties_ allows to correct any error due to unhandled unset messages.
+
+## Key Agreement
+
+> **Note:** The `control/keyAgreement` topic is reserved and routed correctly, but the handshake protocol is not yet implemented. This section will be expanded once the cryptographic logic is in place.
+
+Key Agreement will allow a device to obtain a Data Encryption Key (DEK) from Astarte for encrypting data message payloads. Messages published to `<realm>/<device>/control/keyAgreement` are accepted and acknowledged by Astarte, but no response is sent until the feature is fully implemented.
 
 ## Publishing Data
 


### PR DESCRIPTION
This PR aims to add the MQTT control/keyAgreement topic for the Encrypted Endpoints feature, in particular for the handshake between Astarte and Devices to exchange messages