### PR TITLE
test(pairing): Fix failing tests

### DIFF
--- a/.github/workflows/astarte-apps-build-workflow.yaml
+++ b/.github/workflows/astarte-apps-build-workflow.yaml
@@ -122,6 +122,7 @@ jobs:
         ports:
           - 8041:8041
         options: >-
+          --tmpfs /var/lib/fdo
           --restart on-failure
         command: '--log-level=debug rendezvous 0.0.0.0:8041 --db-type sqlite --db-dsn "file:/var/lib/fdo/rendezvous.db"'
 

--- a/apps/astarte_pairing/README.md
+++ b/apps/astarte_pairing/README.md
@@ -34,7 +34,7 @@ docker run --rm -d -p 9042:9042 --name scylla scylladb/scylla
 docker run --rm  -d -p 5672:5672 -p 15672:15672 --name rabbit rabbitmq:3.12.0-management
 docker run --rm -d --net=host -p 8080/tcp ispirata/docker-alpine-cfssl-autotest:astarte
 docker run --rm -d -p 8200:8200 --name openbao openbao/openbao:latest server -dev -dev-root-token-id=astarte_token
-docker run -rm -d -p 8041:8041 --name rendezvous astarte/go-fdo-server:ade68cda47-20251128 --log-level=debug rendezvous 0.0.0.0:8041 --db-type sqlite --db-dsn "file:/var/lib/fdo/rendezvous.db"
+docker run --rm -d -p 8041:8041 --name rendezvous astarte/go-fdo-server:ade68cda47-20251128 --log-level=debug rendezvous 0.0.0.0:8041 --db-type sqlite --db-dsn "file:/tmp/rendezvous.db"
 ```
 
 by default `CASSANDRA_NODES` and `CFSSL_API_URL` environment variables map to localhost, so that

--- a/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/schemas/owner_key.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/schemas/owner_key.ex
@@ -1,0 +1,55 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.PairingWeb.ApiSpec.Schemas.OwnerKey do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+
+  defmodule CreateOrUploadOwnerKeyRequest do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      title: "CreateOrUploadOwnerKeyRequest",
+      type: :object,
+      properties: %{
+        action: %Schema{
+          type: :string,
+          enum: ["create", "upload"],
+          description: "Whether to create a new key or upload an existing one."
+        },
+        key_name: %Schema{
+          type: :string,
+          description: "The name to assign to the key."
+        },
+        key_algorithm: %Schema{
+          type: :string,
+          enum: ["ecdsa-p256", "ecdsa-p384", "rsa-2048", "rsa-3072"],
+          description:
+            "The algorithm to use for key creation. Required when action is \"create\"."
+        },
+        key_data: %Schema{
+          type: :string,
+          description:
+            "The PEM-encoded private key to upload. Required when action is \"upload\"."
+        }
+      },
+      required: [:action, :key_name]
+    })
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/schemas/ownership_voucher.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/api_spec/schemas/ownership_voucher.ex
@@ -1,0 +1,109 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.PairingWeb.ApiSpec.Schemas.OwnershipVoucher do
+  @moduledoc false
+  alias OpenApiSpex.Schema
+
+  defmodule RequestBody do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :object,
+          properties: %{
+            ownership_voucher: %Schema{
+              type: :string,
+              description:
+                "The ownership voucher. It should be a base64-encoded string containing the CBOR representation of the ownership voucher."
+            },
+            key_name: %Schema{
+              type: :string,
+              description:
+                "The name of the owner key stored in the secrets store to use for this voucher."
+            },
+            key_algorithm: %Schema{
+              type: :string,
+              enum: ["ecdsa-p256", "ecdsa-p384", "rsa-2048", "rsa-3072"],
+              description: "The algorithm of the owner key."
+            },
+            replacement_guid: %Schema{
+              type: :string,
+              nullable: true,
+              description: "Optional base64-encoded replacement GUID."
+            },
+            replacement_rendezvous_info: %Schema{
+              type: :string,
+              nullable: true,
+              description: "Optional base64-encoded CBOR-encoded replacement rendezvous info."
+            },
+            replacement_public_key: %Schema{
+              type: :string,
+              nullable: true,
+              description: "Optional PEM-encoded replacement public key."
+            }
+          },
+          required: [:ownership_voucher, :key_name, :key_algorithm]
+        }
+      },
+      required: [:data]
+    })
+  end
+
+  defmodule List do
+    @moduledoc false
+    require OpenApiSpex
+
+    OpenApiSpex.schema(%{
+      type: :object,
+      properties: %{
+        data: %Schema{
+          type: :array,
+          items: %Schema{
+            type: :object,
+            properties: %{
+              guid: %Schema{type: :string, description: "The GUID of the device."},
+              status: %Schema{
+                type: :string,
+                description: "The status of the ownership voucher."
+              },
+              output_guid: %Schema{
+                type: :string,
+                nullable: true,
+                description: "The replacement GUID, if any."
+              },
+              input_voucher: %Schema{
+                type: :string,
+                nullable: true,
+                description: "The PEM-encoded input ownership voucher."
+              },
+              output_voucher: %Schema{
+                type: :string,
+                nullable: true,
+                description: "The PEM-encoded output ownership voucher, if any."
+              }
+            }
+          }
+        }
+      }
+    })
+  end
+end

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/owner_key_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/owner_key_controller.ex
@@ -18,14 +18,170 @@
 
 defmodule Astarte.PairingWeb.OwnerKeyController do
   use Astarte.PairingWeb, :controller
+  use OpenApiSpex.ControllerSpecs
 
+  alias Astarte.PairingWeb.ApiSpec.Schemas.OwnerKey
   alias Astarte.Secrets
   alias Astarte.Secrets.OwnerKeyInitialization
   alias Astarte.Secrets.OwnerKeyInitializationOptions
+  alias OpenApiSpex.Schema
 
   require Logger
 
   action_fallback Astarte.PairingWeb.FallbackController
+
+  tags ["fdo"]
+
+  operation :create_or_upload_key,
+    summary: "Create or upload an owner key",
+    description:
+      "Creates a new owner key with the given algorithm, or uploads an existing private key.",
+    operation_id: "createOrUploadOwnerKey",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body:
+      {"Create or Upload Owner Key Request", "application/json",
+       OwnerKey.CreateOrUploadOwnerKeyRequest},
+    responses: [
+      ok:
+        {"Owner key created or uploaded successfully", "text/plain",
+         %Schema{
+           type: :string,
+           description:
+             "The PEM-encoded public key when action is \"create\", or an empty string when action is \"upload\"."
+         }},
+      bad_request: {"Invalid request body", nil, nil},
+      unauthorized: {"Unauthorized", nil, nil},
+      not_found: {"Realm not found", nil, nil},
+      unprocessable_entity: {"Validation error", nil, nil},
+      internal_server_error: {"Internal server error", nil, nil}
+    ]
+
+  operation :list_keys,
+    summary: "List owner keys",
+    description: "Returns all registered owner keys grouped by algorithm.",
+    operation_id: "listOwnerKeys",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ]
+    ],
+    responses: [
+      ok:
+        {"Owner keys grouped by algorithm", "application/json",
+         %Schema{
+           type: :object,
+           description: "A map from algorithm name to list of key names.",
+           additionalProperties: %Schema{
+             type: :array,
+             items: %Schema{type: :string}
+           }
+         }},
+      unauthorized: {"Unauthorized", nil, nil},
+      not_found: {"Realm not found", nil, nil},
+      internal_server_error: {"Internal server error", nil, nil}
+    ]
+
+  operation :get_keys_for_algorithm,
+    summary: "List owner keys for an algorithm",
+    description: "Returns all registered owner keys for the specified algorithm.",
+    operation_id: "getOwnerKeysForAlgorithm",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ],
+      key_algorithm: [
+        in: :path,
+        description: "The key algorithm (e.g. es256, es384, rs256, rs384).",
+        type: :string,
+        required: true
+      ]
+    ],
+    responses: [
+      ok:
+        {"Owner keys for the algorithm", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{
+               type: :object,
+               description: "A map from algorithm name to list of key names.",
+               additionalProperties: %Schema{
+                 type: :array,
+                 items: %Schema{type: :string}
+               }
+             }
+           }
+         }},
+      unauthorized: {"Unauthorized", nil, nil},
+      not_found: {"Realm not found", nil, nil},
+      unprocessable_entity: {"Unknown key algorithm", nil, nil},
+      internal_server_error: {"Internal server error", nil, nil}
+    ]
+
+  operation :get_key,
+    summary: "Get an owner key",
+    description: "Returns a specific owner key by algorithm and name.",
+    operation_id: "getOwnerKey",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ],
+      key_algorithm: [
+        in: :path,
+        description: "The key algorithm (e.g. es256, es384, rs256, rs384).",
+        type: :string,
+        required: true
+      ],
+      key_name: [
+        in: :path,
+        description: "The name of the key.",
+        type: :string,
+        required: true
+      ]
+    ],
+    responses: [
+      ok:
+        {"Owner key details", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{
+               type: :object,
+               properties: %{
+                 key_name: %Schema{type: :string, description: "The name of the key."},
+                 public_key: %Schema{
+                   type: :string,
+                   description: "The PEM-encoded public key."
+                 }
+               }
+             }
+           }
+         }},
+      unauthorized: {"Unauthorized", nil, nil},
+      not_found: {"Key not found", nil, nil},
+      unprocessable_entity: {"Unknown key algorithm", nil, nil},
+      internal_server_error: {"Internal server error", nil, nil}
+    ]
 
   def create_or_upload_key(
         conn,

--- a/apps/astarte_pairing/lib/astarte_pairing_web/controllers/ownership_voucher_controller.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/controllers/ownership_voucher_controller.ex
@@ -23,6 +23,7 @@ defmodule Astarte.PairingWeb.OwnershipVoucherController do
   alias Astarte.FDO.OwnershipVoucher
   alias Astarte.FDO.OwnershipVoucher.LoadRequest
   alias Astarte.FDO.TO0
+  alias Astarte.PairingWeb.ApiSpec.Schemas.OwnershipVoucher, as: OVApiSpec
   alias Astarte.PairingWeb.OwnershipVoucherView
   alias Astarte.Secrets.Core, as: SecretsCore
   alias OpenApiSpex.Schema
@@ -31,10 +32,10 @@ defmodule Astarte.PairingWeb.OwnershipVoucherController do
 
   tags ["fdo"]
 
-  operation :create,
-    summary: "Create an ownership voucher",
-    description: "Create an ownership voucher for a device and claim it.",
-    operation_id: "createOwnershipVoucher",
+  operation :register,
+    summary: "Register an ownership voucher",
+    description: "Register an ownership voucher for a device and claim it.",
+    operation_id: "registerOwnershipVoucher",
     security: [%{"JWT" => []}],
     parameters: [
       realm_name: [
@@ -45,7 +46,51 @@ defmodule Astarte.PairingWeb.OwnershipVoucherController do
       ]
     ],
     request_body:
-      {"Ownership Voucher Creation Request", "application/json",
+      {"Ownership Voucher Registration Request", "application/json", OVApiSpec.RequestBody},
+    responses: [
+      ok: {"Ownership voucher registered successfully", nil, nil},
+      bad_request: {"Invalid request body", nil, nil},
+      unauthorized: {"Unauthorized", nil, nil},
+      not_found: {"Realm not found", nil, nil},
+      internal_server_error: {"Internal server error", nil, nil}
+    ]
+
+  operation :list_ownership_vouchers,
+    summary: "List ownership vouchers",
+    description: "Returns the list of all ownership vouchers registered in the realm.",
+    operation_id: "listOwnershipVouchers",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ]
+    ],
+    responses: [
+      ok: {"List of ownership vouchers", "application/json", OVApiSpec.List},
+      unauthorized: {"Unauthorized", nil, nil},
+      not_found: {"Realm not found", nil, nil},
+      internal_server_error: {"Internal server error", nil, nil}
+    ]
+
+  operation :owner_keys_for_voucher,
+    summary: "List owner keys compatible with an ownership voucher",
+    description:
+      "Returns the list of registered owner keys that are compatible with the given ownership voucher.",
+    operation_id: "ownerKeysForVoucher",
+    security: [%{"JWT" => []}],
+    parameters: [
+      realm_name: [
+        in: :path,
+        description: "Name of the realm.",
+        type: :string,
+        required: true
+      ]
+    ],
+    request_body:
+      {"Owner Keys for Voucher Request", "application/json",
        %Schema{
          type: :object,
          properties: %{
@@ -54,25 +99,34 @@ defmodule Astarte.PairingWeb.OwnershipVoucherController do
              properties: %{
                ownership_voucher: %Schema{
                  type: :string,
-                 description:
-                   "The ownership voucher. It should be a base64-encoded string containing the CBOR representation of the ownership voucher."
-               },
-               private_key: %Schema{
-                 type: :string,
-                 description:
-                   "The private key in PEM format corresponding to the public key used in the ownership voucher."
+                 description: "The base64-encoded ownership voucher to match keys against."
                }
              },
-             required: [:ownership_voucher, :private_key]
+             required: [:ownership_voucher]
            }
          },
          required: [:data]
        }},
     responses: [
-      ok: {"Ownership voucher created successfully", nil, nil},
+      ok:
+        {"Compatible owner keys", "application/json",
+         %Schema{
+           type: :object,
+           properties: %{
+             data: %Schema{
+               type: :object,
+               description: "A map from key algorithm name to the list of compatible key names.",
+               additionalProperties: %Schema{
+                 type: :array,
+                 items: %Schema{type: :string}
+               }
+             }
+           }
+         }},
       bad_request: {"Invalid request body", nil, nil},
       unauthorized: {"Unauthorized", nil, nil},
       not_found: {"Realm not found", nil, nil},
+      unprocessable_entity: {"Missing ownership_voucher parameter", nil, nil},
       internal_server_error: {"Internal server error", nil, nil}
     ]
 

--- a/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
+++ b/apps/astarte_pairing/lib/astarte_pairing_web/router.ex
@@ -102,12 +102,6 @@ defmodule Astarte.PairingWeb.Router do
       get "/ownership_vouchers", OwnershipVoucherController, :list_ownership_vouchers
       post "/ownership_vouchers", OwnershipVoucherController, :register
     end
-
-    scope "/ownership" do
-      pipe_through :agent_api
-
-      post "/", OwnershipVoucherController, :create
-    end
   end
 
   scope "/version", Astarte.PairingWeb do

--- a/apps/astarte_pairing/test/astarte_pairing/certs/engine_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing/certs/engine_test.exs
@@ -53,8 +53,6 @@ defmodule Astarte.Pairing.EngineTest do
 
   describe "get_agent_public_key_pem" do
     test "fails with non-existing realm" do
-      realm_keyspace = Realm.keyspace_name("nonexisting")
-
       assert {:error, :realm_not_found} == Engine.get_agent_public_key_pems("nonexisting")
     end
 

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/fdo_onboarding_controller_test.exs
@@ -27,7 +27,6 @@ defmodule Astarte.PairingWeb.FDOOnboardingControllerTest do
   alias Astarte.FDO.Core.OwnerOnboarding.Session
   alias Astarte.FDO.OwnerOnboarding
   alias Astarte.FDO.ServiceInfo
-  alias Astarte.Pairing.Config
 
   setup :verify_on_exit!
 

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/owner_key_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/owner_key_controller_test.exs
@@ -21,7 +21,6 @@ defmodule Astarte.PairingWeb.Controllers.OwnerKeyControllerTest do
   use Astarte.Cases.Data
   use Mimic
 
-  alias Astarte.Pairing.Config
   alias Astarte.Secrets
   alias Astarte.Secrets.Key
   alias Astarte.Secrets.OwnerKeyInitialization

--- a/apps/astarte_pairing/test/astarte_pairing_web/controllers/ownership_voucher_controller_test.exs
+++ b/apps/astarte_pairing/test/astarte_pairing_web/controllers/ownership_voucher_controller_test.exs
@@ -21,7 +21,6 @@ defmodule Astarte.PairingWeb.Controllers.OwnershipVoucherControllerTest do
   use Astarte.Cases.Data
   use Mimic
 
-  alias Astarte.Pairing.Config
   alias Astarte.Secrets
   alias Astarte.Secrets.Key
 
@@ -66,16 +65,24 @@ defmodule Astarte.PairingWeb.Controllers.OwnershipVoucherControllerTest do
     }
   }
 
+  setup context do
+    realm_name = Map.fetch!(context, :realm_name)
+    alg = Map.get(context, :key_algorithm, :es256)
+    {:ok, namespace} = Secrets.create_namespace(realm_name, alg)
+    on_exit(fn -> cleanup_namespace(namespace) end)
+
+    %{namespace: namespace}
+  end
+
   setup :verify_on_exit!
 
   describe "/fdo/ownership_vouchers" do
     setup :register_setup
 
     test "returns 200 with the owner public key on a valid matching key", context do
-      %{auth_conn: conn, register_path: path, realm_name: realm_name} = context
+      %{auth_conn: conn, register_path: path, namespace: namespace} = context
 
       {:ok, owner_cose_key} = COSE.Keys.from_pem(@sample_private_key_pem)
-      {:ok, namespace} = Secrets.create_namespace(realm_name, :es256)
       :ok = Secrets.import_key(@sample_key_name, :es256, owner_cose_key, namespace: namespace)
 
       {:ok, %Key{public_pem: expected_public_key}} =
@@ -238,10 +245,9 @@ defmodule Astarte.PairingWeb.Controllers.OwnershipVoucherControllerTest do
   end
 
   defp store_sample_voucher(context) do
-    %{auth_conn: conn, realm_name: realm_name} = context
+    %{auth_conn: conn, namespace: namespace} = context
     %{register_path: path} = register_setup(context)
     {:ok, owner_cose_key} = COSE.Keys.from_pem(@sample_private_key_pem)
-    {:ok, namespace} = Secrets.create_namespace(realm_name, :es256)
     :ok = Secrets.import_key(@sample_key_name, :es256, owner_cose_key, namespace: namespace)
 
     params = %{
@@ -263,5 +269,14 @@ defmodule Astarte.PairingWeb.Controllers.OwnershipVoucherControllerTest do
     %{auth_conn: conn, realm_name: realm_name} = context
     path = ownership_voucher_path(conn, :list_ownership_vouchers, realm_name)
     %{path: path}
+  end
+
+  defp cleanup_namespace(namespace) do
+    {:ok, keys_to_delete} = Secrets.list_keys_names(namespace: namespace)
+
+    Enum.each(keys_to_delete, fn key ->
+      Secrets.enable_key_deletion(key, namespace: namespace)
+      Secrets.delete_key(key, namespace: namespace)
+    end)
   end
 end


### PR DESCRIPTION
Some tests failing after fwd release 1.3

Fix README typo, add missing OpenApiSpex specs, CI fixup, and clean up FDO controller/tests

- Fix --rm flag typo in README.md rendezvous docker run command
- Add missing OpenApiSpex operation specs to OwnershipVoucherController and OwnerKeyController; API spec tests now pass
- Update register endpoint spec and add new endpoint spec to OwnershipVoucherController
- Remove non-existent `create` route from router
- Remove unused aliases
- Add cleanup_keys/1 helper and on_exit hooks in FDO controller tests to enable async test execution
- Added missing path for SQLite in Rendezvous container in CI, and make Renezvous server running
