### PR TITLE
refactor(secrets): stop handling vault signatures

### DIFF
--- a/libs/astarte_secrets/lib/astarte_secrets/astarte_secrets.ex
+++ b/libs/astarte_secrets/lib/astarte_secrets/astarte_secrets.ex
@@ -185,7 +185,7 @@ defmodule Astarte.Secrets do
     with {:ok, %HTTPoison.Response{status_code: 200, body: body}} <-
            Client.post(
              "/transit/decrypt/#{key_name}",
-             Jason.encode!(%{ciphertext: "vault:v1:" <> ciphertext}),
+             Jason.encode!(%{ciphertext: ciphertext}),
              headers,
              client_opts
            ),

--- a/libs/astarte_secrets/lib/astarte_secrets/core.ex
+++ b/libs/astarte_secrets/lib/astarte_secrets/core.ex
@@ -166,7 +166,7 @@ defmodule Astarte.Secrets.Core do
            ),
          {:ok, data} <- parse_json_data(body),
          {:ok, plaintext} <- decode_base64_field(data, "plaintext"),
-         {:ok, "vault:v1:" <> ciphertext} <- Map.fetch(data, "ciphertext") do
+         {:ok, ciphertext} <- Map.fetch(data, "ciphertext") do
       {:ok, %{plaintext: plaintext, ciphertext: ciphertext}}
     else
       error ->

--- a/libs/astarte_secrets/test/astarte_secrets/core_test.exs
+++ b/libs/astarte_secrets/test/astarte_secrets/core_test.exs
@@ -635,8 +635,7 @@ defmodule Astarte.Secrets.CoreTest do
                Core.generate_dek(key_name, namespace)
 
       assert byte_size(pt) == 32
-      refute String.starts_with?(ct, "vault:")
-      refute String.starts_with?(ct, "v1:")
+      assert String.starts_with?(ct, "vault:v1:")
     end
   end
 


### PR DESCRIPTION
This PR re add the "vault:v1"prefix to the string returned by OpenBao for the ciphertext