### PR TITLE
fix: Use network topology as default realm replication

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/config.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/config.ex
@@ -67,7 +67,8 @@ defmodule Astarte.Housekeeping.Config do
           :astarte_housekeeping,
           :astarte_keyspace_replication_factor,
           os_env: "HOUSEKEEPING_ASTARTE_KEYSPACE_REPLICATION_FACTOR",
-          type: :integer
+          type: :pos_integer,
+          default: 1
 
   @envdoc "Replication map for the astarte keyspace, used when network topology strategy is used for the astarte keyspace."
   app_env :astarte_keyspace_network_replication_map,

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/migrator.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/migrator.ex
@@ -31,12 +31,6 @@ defmodule Astarte.Housekeeping.Migrator do
 
   @query_timeout 60_000
 
-  def save_default_replication do
-    with {:ok, replication} <- Queries.get_keyspace_replication(Realm.astarte_keyspace_name()) do
-      Queries.save_keyspace_replication(replication)
-    end
-  end
-
   def run_astarte_keyspace_migrations do
     _ = Logger.info("Starting to migrate Astarte keyspace.", tag: "astarte_migration_started")
 

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/core.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/core.ex
@@ -96,7 +96,7 @@ defmodule Astarte.Housekeeping.Realms.Core do
     do_create_realm(
       realm_name,
       pem,
-      replication_factor,
+      {:simple_strategy, replication_factor},
       device_registration_limit,
       datastream_maximum_storage_retention,
       opts
@@ -119,7 +119,7 @@ defmodule Astarte.Housekeeping.Realms.Core do
     do_create_realm(
       realm_name,
       pem,
-      datacenter_replication_factors_map,
+      {:network_topology_strategy, datacenter_replication_factors_map},
       device_registration_limit,
       datastream_maximum_storage_retention,
       opts

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -32,7 +32,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
 
   require Logger
 
-  @default_replication_factor 1
+  @default_replication_factor {:simple_strategy, 1}
 
   def realm_existing?(realm_name) do
     keyspace_name = Realm.astarte_keyspace_name()
@@ -378,8 +378,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp build_replication_map_str(replication_factor)
-       when is_integer(replication_factor) and replication_factor > 0 do
+  defp build_replication_map_str({:simple_strategy, replication_factor}) do
     with :ok <- check_replication(replication_factor) do
       replication_map_str =
         "{'class': 'SimpleStrategy', 'replication_factor': #{replication_factor}}"
@@ -388,8 +387,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp build_replication_map_str(datacenter_replication_factors)
-       when is_map(datacenter_replication_factors) do
+  defp build_replication_map_str({:network_topology_strategy, datacenter_replication_factors}) do
     with :ok <- check_replication(datacenter_replication_factors) do
       datacenter_replications_str =
         Enum.map_join(datacenter_replication_factors, ",", fn {datacenter, replication_factor} ->
@@ -1160,13 +1158,15 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     :ok
   end
 
-  def initialize_database do
+  def initialize_database(default_replication \\ {:simple_strategy, 1}) do
     Logger.info("Starting Astarte keyspace initialization")
 
-    with :ok <- create_astarte_keyspace(),
+    with :ok <- create_astarte_keyspace(default_replication),
          :ok <- create_realms_table(),
          :ok <- create_astarte_kv_store(),
-         :ok <- insert_astarte_schema_version() do
+         :ok <- insert_astarte_schema_version(),
+         keyspace_replication_map = keyspace_replication_map(default_replication),
+         :ok <- save_keyspace_replication(keyspace_replication_map) do
       :ok
     else
       {:error, %Xandra.Error{} = err} ->
@@ -1195,28 +1195,18 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  @doc """
-  Returns the replication strategy and factor for a given keyspace.
-  Returns {:ok, %{strategy: :network_topology, dc_factors: %{"dc1" => 3}}}
-  or {:ok, %{strategy: :simple, factor: 3}}
-  """
-  def get_keyspace_replication(keyspace_name, opts \\ []) do
-    query =
-      from k in "system_schema.keyspaces",
-        where: k.keyspace_name == ^keyspace_name,
-        select: k.replication
+  defp keyspace_replication_map({:simple_strategy, replication_factor}) do
+    %{
+      strategy: :simple,
+      factor: replication_factor
+    }
+  end
 
-    case Repo.safe_fetch_one(query, opts) do
-      {:ok, %{"class" => class} = replication} ->
-        parse_replication(class, replication)
-
-      {:error, :not_found} ->
-        {:error, :keyspace_not_found}
-
-      {:error, reason} ->
-        Logger.error("Failed to fetch keyspace replication: #{inspect(reason)}")
-        {:error, reason}
-    end
+  defp keyspace_replication_map({:network_topology_strategy, network_topology}) do
+    %{
+      strategy: :network_topology,
+      dc_factors: network_topology
+    }
   end
 
   def save_keyspace_replication(replication) do
@@ -1241,32 +1231,12 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp parse_replication("org.apache.cassandra.locator.NetworkTopologyStrategy", map) do
-    # Filter out the 'class' key to leave only the DC names and their factors
-    dc_factors =
-      map
-      |> Map.delete("class")
-      |> Map.new(fn {dc, factor} -> {dc, String.to_integer(factor)} end)
-
-    {:ok, %{strategy: :network_topology, dc_factors: dc_factors}}
-  end
-
-  defp parse_replication("org.apache.cassandra.locator.SimpleStrategy", %{
-         "replication_factor" => rf
-       }) do
-    {:ok, %{strategy: :simple, factor: String.to_integer(rf)}}
-  end
-
-  defp parse_replication(unknown_class, _map) do
-    {:error, {:unknown_strategy, unknown_class}}
-  end
-
-  defp create_astarte_keyspace do
+  defp create_astarte_keyspace(default_replication) do
     keyspace = Realm.astarte_keyspace_name()
     consistency = Consistency.domain_model(:write)
+    replication = astarte_keyspace_replication(default_replication)
 
-    with {:ok, replication} <- astarte_keyspace_replication(),
-         {:ok, replication_map_str} <- build_replication_map_str(replication),
+    with {:ok, replication_map_str} <- build_replication_map_str(replication),
          :ok <- do_create_astarte_keyspace(keyspace, replication_map_str, consistency) do
       :ok
     else
@@ -1279,18 +1249,18 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp astarte_keyspace_replication do
+  defp astarte_keyspace_replication(default_replication) do
     case Config.astarte_keyspace_replication_strategy!() do
       :simple_strategy ->
-        {:ok, Config.astarte_keyspace_replication_factor!()}
+        {:simple_strategy, Config.astarte_keyspace_replication_factor!()}
 
       :network_topology_strategy ->
-        {:ok, Config.astarte_keyspace_network_replication_map!()}
+        {:network_topology_strategy, Config.astarte_keyspace_network_replication_map!()}
 
       nil ->
         # No explicit replication has been configured, so the replication
         # map is derived from the current ScyllaDB network topology
-        fetch_network_topology()
+        default_replication
     end
   end
 

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/release_task.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/release_task.ex
@@ -44,10 +44,11 @@ defmodule Astarte.Housekeeping.ReleaseTasks do
   end
 
   defp do_ensure_migrated! do
-    with :ok <- Queries.initialize_database(),
+    with {:ok, network_topology} <- Queries.fetch_network_topology(),
+         default_replication = {:network_topology_strategy, network_topology},
+         :ok <- Queries.initialize_database(default_replication),
          :ok <- Migrator.run_astarte_keyspace_migrations(),
-         :ok <- Migrator.run_realms_migrations(),
-         :ok <- Migrator.save_default_replication() do
+         :ok <- Migrator.run_realms_migrations() do
       "Astarte database correctly initialized"
       |> Logger.info(tag: "astarte_db_initialization_finished")
 

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/migrator_test.exs
@@ -163,21 +163,6 @@ defmodule Astarte.Housekeeping.MigratorTest do
     end
   end
 
-  describe "save_default_replication/0" do
-    setup do
-      on_exit(fn ->
-        Database.teardown_astarte_keyspace()
-      end)
-
-      Queries.initialize_database()
-      :ok
-    end
-
-    test "saves the keyspace replication successfully" do
-      assert :ok = Migrator.save_default_replication()
-    end
-  end
-
   defp realm_schema_version(realm_name) do
     keyspace = DatabaseRealm.keyspace_name(realm_name)
 

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/realms/queries_test.exs
@@ -24,7 +24,6 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
   alias Astarte.DataAccess.Repo
   alias Astarte.Housekeeping.Config
   alias Astarte.Housekeeping.Helpers.Database
-  alias Astarte.Housekeeping.Migrator
   alias Astarte.Housekeeping.Realms
   alias Astarte.Housekeeping.Realms.Queries
   alias Astarte.Housekeeping.Realms.Realm, as: HKRealm
@@ -94,101 +93,6 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
       assert {:ok, _} = Database.lightweight_transaction_check(astarte_keyspace)
     end
 
-    test "defaults to NetworkTopologyStrategy derived from the live Scylla topology when no replication strategy is configured" do
-      # When the replication strategy env var is not set, Config returns `nil`
-      # and `create_astarte_keyspace/0` is expected to derive the replication
-      # map from the actual ScyllaDB network topology, instead of falling back
-      # to SimpleStrategy/RF=1. The test cluster has a single node in
-      # `datacenter1`, so the resulting map must be %{"datacenter1" => 1} and
-      # the keyspace class must be NetworkTopologyStrategy.
-      Config
-      |> expect(:astarte_keyspace_replication_strategy!, fn -> nil end)
-      |> reject(:astarte_keyspace_replication_factor!, 0)
-      |> reject(:astarte_keyspace_network_replication_map!, 0)
-
-      assert :ok = Queries.initialize_database()
-
-      astarte_keyspace = Realm.astarte_keyspace_name()
-
-      replication =
-        from(k in "system_schema.keyspaces", select: k.replication)
-        |> Repo.get_by!(keyspace_name: astarte_keyspace)
-
-      {datacenter_replication, ""} = replication[@datacenter] |> Integer.parse()
-
-      assert replication["class"] == "org.apache.cassandra.locator.NetworkTopologyStrategy"
-      assert datacenter_replication == 1
-    end
-
-    @tag :inspect_replication
-    test "inspects auto-detected replication from live cluster when no strategy is configured" do
-      Config
-      |> expect(:astarte_keyspace_replication_strategy!, fn -> nil end)
-      |> reject(:astarte_keyspace_replication_factor!, 0)
-      |> reject(:astarte_keyspace_network_replication_map!, 0)
-
-      assert :ok = Queries.initialize_database()
-
-      astarte_keyspace = Realm.astarte_keyspace_name()
-
-      Migrator.save_default_replication()
-
-      {:ok, replication_map} = Queries.fetch_keyspace_replication()
-
-      replication =
-        from(k in "system_schema.keyspaces", select: k.replication)
-        |> Repo.get_by!(keyspace_name: astarte_keyspace)
-
-      assert replication["class"] == "org.apache.cassandra.locator.NetworkTopologyStrategy"
-      assert replication_map == %{strategy: :network_topology, dc_factors: %{@datacenter => 1}}
-    end
-
-    @tag :inspect_replication
-    test "inspects replication when simple strategy is configured" do
-      Config
-      |> expect(:astarte_keyspace_replication_strategy!, fn -> :simple_strategy end)
-      |> expect(:astarte_keyspace_replication_factor!, fn -> 1 end)
-      |> reject(:astarte_keyspace_network_replication_map!, 0)
-
-      assert :ok = Queries.initialize_database()
-
-      astarte_keyspace = Realm.astarte_keyspace_name()
-
-      Migrator.save_default_replication()
-
-      {:ok, replication_map} = Queries.fetch_keyspace_replication()
-
-      replication =
-        from(k in "system_schema.keyspaces", select: k.replication)
-        |> Repo.get_by!(keyspace_name: astarte_keyspace)
-
-      assert replication["class"] == "org.apache.cassandra.locator.SimpleStrategy"
-      assert replication_map == %{strategy: :simple, factor: 1}
-    end
-
-    @tag :inspect_replication
-    test "inspects replication when network topology strategy is configured" do
-      Config
-      |> expect(:astarte_keyspace_replication_strategy!, fn -> :network_topology_strategy end)
-      |> reject(:astarte_keyspace_replication_factor!, 0)
-      |> expect(:astarte_keyspace_network_replication_map!, fn -> @map_replication_factor end)
-
-      assert :ok = Queries.initialize_database()
-
-      astarte_keyspace = Realm.astarte_keyspace_name()
-
-      Migrator.save_default_replication()
-
-      {:ok, replication_map} = Queries.fetch_keyspace_replication()
-
-      replication =
-        from(k in "system_schema.keyspaces", select: k.replication)
-        |> Repo.get_by!(keyspace_name: astarte_keyspace)
-
-      assert replication["class"] == "org.apache.cassandra.locator.NetworkTopologyStrategy"
-      assert replication_map == %{strategy: :network_topology, dc_factors: %{"datacenter1" => 1}}
-    end
-
     test "returns database error" do
       Mimic.stub(Xandra, :execute, fn _, _, _, _ -> {:error, %Xandra.Error{}} end)
       assert {:error, :database_error} = Queries.initialize_database()
@@ -220,7 +124,8 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
     end
 
     test "creations returns ok", %{realm_name: realm_name} do
-      assert :ok = Queries.create_realm(realm_name, "test1publickey", 1, 1, 1, [])
+      assert :ok =
+               Queries.create_realm(realm_name, "test1publickey", {:simple_strategy, 1}, 1, 1, [])
     end
 
     test "creations returns ok with nil replication factor", %{realm_name: realm_name} do
@@ -228,23 +133,30 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
     end
 
     test "creations returns ok with 0 max retentions factor", %{realm_name: realm_name} do
-      assert :ok = Queries.create_realm(realm_name, "test1publickey", 1, 1, 0, [])
+      assert :ok =
+               Queries.create_realm(realm_name, "test1publickey", nil, 1, 0, [])
     end
 
     test "creations returns error with bigger than nodes replication factor", %{
       realm_name: realm_name
     } do
-      assert {:error,
-              {:invalid_replication,
-               "replication_factor 10 is >= 1 nodes in datacenter datacenter1"}} =
-               Queries.create_realm(realm_name, "test1publickey", 10, 1, 1, [])
+      replication_factor = 10
+      replication = {:simple_strategy, replication_factor}
+
+      expected_error =
+        {:error,
+         {:invalid_replication,
+          "replication_factor #{replication_factor} is >= 1 nodes in datacenter datacenter1"}}
+
+      assert Queries.create_realm(realm_name, "test1publickey", replication, 1, 1, []) ==
+               expected_error
     end
 
     test "creations returns an error", %{realm_name: realm_name} do
       Mimic.stub(Repo, :query, fn _, _, _ -> {:error, "generic error"} end)
 
       assert {:error, "generic error"} =
-               Queries.create_realm(realm_name, "test1publickey", 1, 1, 1, [])
+               Queries.create_realm(realm_name, "test1publickey", nil, 1, 1, [])
     end
   end
 
@@ -266,7 +178,7 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
     end
 
     test "list respects new realm creations" do
-      assert :ok = Queries.create_realm("anotherrealm", "test2publickey", 1, 1, 1, [])
+      assert :ok = Queries.create_realm("anotherrealm", "test2publickey", nil, 1, 1, [])
 
       assert {:ok, realms} = Queries.list_realms()
       assert %HKRealm{realm_name: "testrealm"} in realms
@@ -274,7 +186,7 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
     end
 
     test "get returns the realm data just inserted" do
-      assert :ok = Queries.create_realm("anotherrealm", "test2publickey", 1, 1, 1, [])
+      assert :ok = Queries.create_realm("anotherrealm", "test2publickey", nil, 1, 1, [])
 
       assert {:ok,
               %{
@@ -288,7 +200,7 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
     end
 
     test "get returns error due to get_public_key error" do
-      assert :ok = Queries.create_realm("anotherrealm", "test2publickey", 1, 1, 1, [])
+      assert :ok = Queries.create_realm("anotherrealm", "test2publickey", nil, 1, 1, [])
       Mimic.stub(Xandra, :execute, fn _, _, _, _ -> {:error, %Xandra.ConnectionError{}} end)
 
       assert {:error, :database_connection_error} =
@@ -300,7 +212,7 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
                Queries.create_realm(
                  "anotherrealm",
                  "test2publickey",
-                 %{"datacenter1" => 1},
+                 {:network_topology_strategy, %{"datacenter1" => 1}},
                  1,
                  1,
                  []
@@ -710,74 +622,6 @@ defmodule Astarte.Housekeeping.Realms.QueriesTest do
                  replication_class: "NetworkTopologyStrategy",
                  datacenter_replication_factors: [{"imaginarydatacenter", 3}]
                })
-    end
-  end
-
-  describe "get_keyspace_replication/2" do
-    test "returns simple strategy replication factor" do
-      keyspace = "test_simple_ks"
-
-      mock_replication = %{
-        "class" => "org.apache.cassandra.locator.SimpleStrategy",
-        "replication_factor" => "3"
-      }
-
-      expect(Repo, :safe_fetch_one, fn _query, _opts ->
-        {:ok, mock_replication}
-      end)
-
-      assert {:ok, %{strategy: :simple, factor: 3}} =
-               Queries.get_keyspace_replication(keyspace)
-    end
-
-    test "returns network topology strategy factors" do
-      keyspace = "test_network_ks"
-
-      mock_replication = %{
-        "class" => "org.apache.cassandra.locator.NetworkTopologyStrategy",
-        "dc1" => "3",
-        "dc2" => "2"
-      }
-
-      expect(Repo, :safe_fetch_one, fn _query, _opts ->
-        {:ok, mock_replication}
-      end)
-
-      assert {:ok, %{strategy: :network_topology, dc_factors: factors}} =
-               Queries.get_keyspace_replication(keyspace)
-
-      assert factors == %{"dc1" => 3, "dc2" => 2}
-    end
-
-    test "returns error for non-existent keyspace" do
-      expect(Repo, :safe_fetch_one, fn _query, _opts ->
-        {:error, :not_found}
-      end)
-
-      assert {:error, :keyspace_not_found} =
-               Queries.get_keyspace_replication("missing_ks")
-    end
-
-    test "returns error for unknown replication strategy" do
-      mock_replication = %{
-        "class" => "org.apache.cassandra.locator.LocalStrategy"
-      }
-
-      expect(Repo, :safe_fetch_one, fn _query, _opts ->
-        {:ok, mock_replication}
-      end)
-
-      assert {:error, {:unknown_strategy, "org.apache.cassandra.locator.LocalStrategy"}} =
-               Queries.get_keyspace_replication("local_ks")
-    end
-
-    test "handles database error gracefully" do
-      expect(Repo, :safe_fetch_one, fn _query, _opts ->
-        {:error, :timeout}
-      end)
-
-      assert {:error, :timeout} =
-               Queries.get_keyspace_replication("any_ks")
     end
   end
 

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/release_tasks_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/release_tasks_test.exs
@@ -23,9 +23,14 @@ defmodule Astarte.Housekeeping.ReleaseTasksTest do
   alias Astarte.DataAccess.Consistency
   alias Astarte.DataAccess.KvStore
   alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.DataAccess.Repo
+  alias Astarte.Housekeeping.Config
   alias Astarte.Housekeeping.Helpers.Database
   alias Astarte.Housekeeping.Migrator
+  alias Astarte.Housekeeping.Realms.Queries
   alias Astarte.Housekeeping.ReleaseTasks
+
+  import Ecto.Query
 
   use Mimic
 
@@ -60,6 +65,32 @@ defmodule Astarte.Housekeeping.ReleaseTasksTest do
 
       assert :ok = ReleaseTasks.ensure_migrated!()
     end
+
+    test "creates the astarte keyspace with network topology strategy by default" do
+      :ok = ReleaseTasks.ensure_migrated!()
+      assert astarte_replication_class() == :network_topology_strategy
+    end
+
+    test "creates the astarte keyspace with simple strategy if so configured" do
+      Config
+      |> expect(:astarte_keyspace_replication_strategy!, fn -> :simple_strategy end)
+      |> expect(:astarte_keyspace_replication_factor!, fn -> 1 end)
+      |> reject(:astarte_keyspace_network_replication_map!, 0)
+
+      :ok = ReleaseTasks.ensure_migrated!()
+      assert astarte_replication_class() == :simple_strategy
+    end
+
+    test "the astarte keyspace replication is independent from realm default replication" do
+      Config
+      |> expect(:astarte_keyspace_replication_strategy!, fn -> :simple_strategy end)
+      |> expect(:astarte_keyspace_replication_factor!, fn -> 1 end)
+      |> reject(:astarte_keyspace_network_replication_map!, 0)
+
+      :ok = ReleaseTasks.ensure_migrated!()
+      assert astarte_replication_class() == :simple_strategy
+      assert realm_default_replication_strategy() == :network_topology
+    end
   end
 
   defp assert_initialized do
@@ -82,5 +113,23 @@ defmodule Astarte.Housekeeping.ReleaseTasksTest do
       {:error, :not_found} -> {:ok, 0}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  defp astarte_replication_class do
+    astarte_keyspace = Realm.astarte_keyspace_name()
+
+    replication =
+      from(k in "system_schema.keyspaces", select: k.replication)
+      |> Repo.get_by!(keyspace_name: astarte_keyspace)
+
+    case replication["class"] do
+      "org.apache.cassandra.locator.SimpleStrategy" -> :simple_strategy
+      "org.apache.cassandra.locator.NetworkTopologyStrategy" -> :network_topology_strategy
+    end
+  end
+
+  defp realm_default_replication_strategy do
+    {:ok, %{strategy: strategy}} = Queries.fetch_keyspace_replication()
+    strategy
   end
 end


### PR DESCRIPTION
Treat the astarte keyspace replication environment values for the
astarte keyspace alone, and always set the network topology as the
default value for realms