### PR TITLE
chore(dup): add ExchangeResp logic for Astarte-Device handshake

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -24,6 +24,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   """
   alias Astarte.Core.Device
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.ExchangeResp
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
   alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
@@ -32,6 +33,17 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   alias Astarte.DataUpdaterPlant.TimeBasedActions
 
   require Logger
+
+  @doc """
+  Handles control messages published by the device on various control topics.
+
+  ### Supported Paths
+  * `/producer/properties` - Handles properties pruning (plaintext or zlib compressed).
+  * `/emptyCache` - Triggers a cache empty and interface properties resend.
+  * `/keyAgreement` - Handles the InitExchange protocol (Device to Astarte direction).
+  * `/keyAgreement/1` - Receives an ExchangeResp sent by the device when Astarte previously initiated a key-agreement handshake.
+  """
+  def handle_control(state, path, payload, timestamp)
 
   def handle_control(%State{discard_messages: true} = state, _, _, _) do
     {:discard, :discard_messages, state}
@@ -148,16 +160,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     end
   end
 
-  @doc """
-  Handles the `/keyAgreement` control topic (Device to Astarte direction).
-
-  Performs full payload parsing and validation per the InitExchange protocol.
-  """
   def handle_control(state, "/keyAgreement", payload, timestamp) do
     new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
 
     case InitExchange.decode(payload) do
-      # TODO: use init_exchange for shared-secret derivation (ECDH + HKDF step)
+      # TODO: call send_exchange_resp/3 here and use the returned key pair
+      #       for the ECDH + HKDF shared-secret derivation step.
       {:ok, _init_exchange} ->
         :telemetry.execute(
           [:astarte, :data_updater_plant, :control_handler, :key_agreement_init],
@@ -193,6 +201,55 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
           logger_metadata: [tag: "key_agreement_error"],
           error_name: "key_agreement_error",
           error: :key_agreement_error
+        }
+
+        Core.Error.handle_error(context, error)
+    end
+  end
+
+  def handle_control(state, "/keyAgreement/1", payload, timestamp) do
+    new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
+
+    expected_key_type =
+      Map.get(new_state, :pending_key_type, :ecdh_x25519_hkdf_sha256_aes_256_gcm)
+
+    case ExchangeResp.cbor_decode(payload, expected_key_type) do
+      # TODO: use exchange_resp for ECDH + HKDF shared-secret derivation
+      {:ok, _exchange_resp} ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_resp],
+          %{payload_size: byte_size(payload)},
+          %{realm: new_state.realm}
+        )
+
+        final_state = %{
+          new_state
+          | total_received_msgs: new_state.total_received_msgs + 1,
+            total_received_bytes: new_state.total_received_bytes + byte_size(payload)
+        }
+
+        {:ack, :ok, final_state}
+
+      {:error, reason} ->
+        Logger.warning(
+          "[keyAgreement/1] payload validation failed: #{inspect(reason)}",
+          tag: "key_agreement_resp_invalid_payload"
+        )
+
+        context = %{
+          state: new_state,
+          payload: payload,
+          path: "/keyAgreement/1",
+          timestamp: timestamp
+        }
+
+        error = %{
+          message:
+            "Invalid keyAgreement/1 payload (#{inspect(reason)}): " <>
+              inspect(Base.encode64(payload)),
+          logger_metadata: [tag: "key_agreement_resp_error"],
+          error_name: "key_agreement_resp_error",
+          error: :key_agreement_resp_error
         }
 
         Core.Error.handle_error(context, error)
@@ -273,6 +330,66 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
       {:error, reason} ->
         :telemetry.execute(
           [:astarte, :data_updater_plant, :control_handler, :key_agreement_send],
+          %{
+            duration: System.monotonic_time() - publish_start,
+            payload_size: byte_size(payload)
+          },
+          %{realm: realm, result: "error"}
+        )
+
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Publishes an `ExchangeResp` message from Astarte to a device in response to a
+  received `InitExchange` on:
+  `<realm>/<device_id>/control/keyAgreement/1`
+  """
+  @spec send_exchange_resp(String.t(), binary(), InitExchange.t()) ::
+          {:ok, ExchangeResp.t()} | {:error, term()}
+  def send_exchange_resp(realm, device_id, %InitExchange{} = init_exchange) do
+    exchange_resp = ExchangeResp.new(init_exchange)
+
+    with :ok <- publish_exchange_resp(realm, device_id, exchange_resp) do
+      {:ok, exchange_resp}
+    end
+  end
+
+  defp publish_exchange_resp(realm, device_id, %ExchangeResp{} = exchange_resp) do
+    topic = "#{realm}/#{Device.encode_device_id(device_id)}/control/keyAgreement/1"
+    payload = ExchangeResp.cbor_encode(exchange_resp)
+
+    publish_start = System.monotonic_time()
+
+    case VMQPlugin.publish(topic, payload, 2) do
+      {:ok, %{local_matches: local, remote_matches: remote}} when local + remote >= 1 ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_resp_send],
+          %{
+            duration: System.monotonic_time() - publish_start,
+            payload_size: byte_size(payload)
+          },
+          %{realm: realm, result: "success"}
+        )
+
+        :ok
+
+      {:ok, %{local_matches: 0, remote_matches: 0}} ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_resp_send],
+          %{
+            duration: System.monotonic_time() - publish_start,
+            payload_size: byte_size(payload)
+          },
+          %{realm: realm, result: "no_matches"}
+        )
+
+        {:error, :session_not_found}
+
+      {:error, reason} ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_resp_send],
           %{
             duration: System.monotonic_time() - publish_start,
             payload_size: byte_size(payload)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/exchange_resp.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/exchange_resp.ex
@@ -1,0 +1,147 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.ExchangeResp do
+  @moduledoc """
+  Represents the ExchangeResp (type 1) key-agreement message published by
+  Astarte on the `<realm>/<device>/control/keyAgreement/1` MQTT control topic.
+
+  Sent in response to an `InitExchange` message, it carries the sender's
+  (Astarte's) ephemeral public key so both sides can independently derive the
+  shared secret via ECDH + HKDF.
+
+  ## Message structure:
+
+      [
+        seq_num  :: uint,   # sequence number from the corresponding InitExchange
+        cose_key :: #bstr   # CBOR-encoded COSE_Key (sender's EC public key)
+      ]
+
+  """
+
+  use TypedStruct
+
+  alias __MODULE__, as: ExchangeResp
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
+  alias COSE.Keys.ECC
+  alias COSE.Keys.Key
+  alias COSE.Keys.OKP
+
+  typedstruct enforce: true do
+    @typedoc "ExchangeResp key-agreement message."
+
+    field :seq_num, non_neg_integer()
+    field :public_key, Key.t()
+  end
+
+  @doc """
+  Builds a new `%ExchangeResp{}` from a received `%InitExchange{}`.
+
+  Generates a fresh ephemeral key pair using the same suite (`key_type`) that the remote side
+  declared.  The private component of the generated key is retained in
+  `public_key` for the subsequent ECDH derivation step.
+  """
+  @spec new(InitExchange.t()) :: t()
+  def new(init_exchange) do
+    %InitExchange{seq_num: seq_num, key_type: key_type} = init_exchange
+    key = generate_key(key_type)
+
+    %ExchangeResp{seq_num: seq_num, public_key: key}
+  end
+
+  defp generate_key(:ecdh_x25519_hkdf_sha256_aes_256_gcm), do: OKP.generate(:enc)
+  defp generate_key(:ecdh_p256_hkdf_sha256_aes_256_gcm), do: ECC.generate(:es256)
+
+  @doc """
+  Returns the list representation of an `%ExchangeResp{}` ready for CBOR
+  encoding.
+  """
+  @spec encode(t()) :: list()
+  def encode(%ExchangeResp{} = msg) do
+    cose_key_bytes = COSE.Keys.encode_cbor(msg.public_key)
+
+    [
+      msg.seq_num,
+      %CBOR.Tag{tag: :bytes, value: cose_key_bytes}
+    ]
+  end
+
+  @doc """
+  CBOR-encodes an `%ExchangeResp{}` for transmission to the device.
+
+  Returns the raw binary ready to be published on the
+  `control/keyAgreement/1` MQTT control topic.
+  """
+  @spec cbor_encode(t()) :: binary()
+  def cbor_encode(%ExchangeResp{} = msg), do: encode(msg) |> CBOR.encode()
+
+  @doc """
+  Decodes and validates a raw CBOR payload received on the
+  `control/keyAgreement/1` topic.
+  Requires the expected key_type from the corresponding InitExchange to validate compatibility.
+  """
+  @spec cbor_decode(binary(), atom()) :: {:ok, t()} | {:error, atom()}
+  def cbor_decode(payload, expected_key_type) when is_binary(payload) do
+    case CBOR.decode(payload) do
+      {:ok, raw, _rest} -> decode(raw, expected_key_type)
+      {:error, _reason} -> {:error, :invalid_payload}
+    end
+  end
+
+  defp decode([seq_num, public_key], expected_key_type)
+       when is_integer(seq_num) and seq_num >= 0 do
+    with {:ok, cose_key_bytes} <- unwrap_bytes(public_key),
+         {:ok, cose_key_map} <- decode_cbor(cose_key_bytes),
+         {:ok, cose_key} <- decode_cose_key(cose_key_map, expected_key_type) do
+      {:ok, %ExchangeResp{seq_num: seq_num, public_key: cose_key}}
+    end
+  end
+
+  defp decode(_, _expected_key_type), do: {:error, :invalid_payload}
+
+  # Validate the key against the algorithm specified in InitExchange
+  defp decode_cose_key(cose_key_map, expected_key_type) do
+    case COSE.Keys.decode(cose_key_map) do
+      {:ok, %OKP{crv: :x25519} = key}
+      when expected_key_type == :ecdh_x25519_hkdf_sha256_aes_256_gcm ->
+        {:ok, key}
+
+      {:ok, %ECC{crv: :p256} = key}
+      when expected_key_type == :ecdh_p256_hkdf_sha256_aes_256_gcm ->
+        {:ok, key}
+
+      {:ok, _} ->
+        {:error, :key_type_mismatch}
+
+      {:error, _} ->
+        {:error, :invalid_cose_key}
+    end
+  end
+
+  defp unwrap_bytes(%CBOR.Tag{tag: :bytes, value: value}), do: {:ok, value}
+  defp unwrap_bytes(_), do: {:error, :invalid_payload}
+
+  defp decode_cbor(bytes) do
+    case CBOR.decode(bytes) do
+      {:ok, decoded, _rest} -> {:ok, decoded}
+      {:error, _reason} -> {:error, :invalid_payload}
+    end
+  end
+end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/init_exchange.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/init_exchange.ex
@@ -26,6 +26,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
   ## Message structure:
 
       [
+        seq_num     :: uint,        # sequence number
         key_type    :: uint,        # suite identifier integer
         cose_key    :: #bstr,       # CBOR-encoded COSE_Key map
         hkdf_salt   :: #bstr,       # HKDF salt (32 B)
@@ -64,6 +65,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
   typedstruct enforce: true do
     @typedoc "InitExchange key-agreement message."
 
+    field :seq_num, non_neg_integer()
     field :key_type, key_suite()
     field :public_key, Key.t()
     field :hkdf_salt, binary()
@@ -72,11 +74,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
 
   @doc """
   Builds a new `%InitExchange{}` with a freshly generated ephemeral X25519
-  key pair, a random HKDF salt, and a random AES-GCM nonce.
+  key pair, a random HKDF salt, a random AES-GCM nonce, and a random sequence
+  number.
 
   Returns a `%InitExchange{}` with the full key struct stored in `public_key`
   (including the private `d` field for later ECDH derivation), a random HKDF
-  salt, and a random AES-GCM nonce.
+  salt, a random AES-GCM nonce, and a random `seq_num` suitable for
+  correlation with the corresponding `ExchangeResp`.
   """
   @spec new(key_suite()) :: t()
   def new(key_type \\ :ecdh_x25519_hkdf_sha256_aes_256_gcm)
@@ -85,8 +89,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
     key = OKP.generate(:enc)
     hkdf_salt = :crypto.strong_rand_bytes(@hkdf_salt_size)
     nonce = :crypto.strong_rand_bytes(@nonce_size)
+    <<seq_num::unsigned-16>> = :crypto.strong_rand_bytes(2)
 
     %__MODULE__{
+      seq_num: seq_num,
       key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm,
       public_key: key,
       hkdf_salt: hkdf_salt,
@@ -98,8 +104,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
     key = ECC.generate(:es256)
     hkdf_salt = :crypto.strong_rand_bytes(@hkdf_salt_size)
     nonce = :crypto.strong_rand_bytes(@nonce_size)
+    <<seq_num::unsigned-16>> = :crypto.strong_rand_bytes(2)
 
     %__MODULE__{
+      seq_num: seq_num,
       key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm,
       public_key: key,
       hkdf_salt: hkdf_salt,
@@ -116,6 +124,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
     cose_key_bytes = COSE.Keys.encode_cbor(msg.public_key)
 
     [
+      msg.seq_num,
       key_type_id,
       %CBOR.Tag{tag: :bytes, value: cose_key_bytes},
       %CBOR.Tag{tag: :bytes, value: msg.hkdf_salt},
@@ -143,7 +152,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
     end
   end
 
-  defp parse([key_type, public_key, hkdf_salt, nonce]) do
+  defp parse([seq_num, key_type, public_key, hkdf_salt, nonce])
+       when is_integer(seq_num) and seq_num >= 0 do
     with {:ok, key_suite} <- parse_key_suite(key_type),
          {:ok, cose_key_bytes} <- unwrap_bytes(public_key),
          {:ok, cose_key_map} <- decode_cbor(cose_key_bytes),
@@ -154,6 +164,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
          :ok <- validate_nonce(nonce) do
       {:ok,
        %__MODULE__{
+         seq_num: seq_num,
          key_type: key_suite,
          public_key: raw_public_key,
          hkdf_salt: hkdf_salt,

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -30,6 +30,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.ExchangeResp
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
   alias Astarte.DataUpdaterPlant.DataUpdater.Impl
   alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
@@ -61,8 +62,15 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     p256_init_exchange = InitExchange.new(:ecdh_p256_hkdf_sha256_aes_256_gcm)
     p256_init_exchange_payload = InitExchange.cbor_encode(p256_init_exchange)
 
+    exchange_resp_payload = init_exchange |> ExchangeResp.new() |> ExchangeResp.cbor_encode()
+
+    p256_exchange_resp_payload =
+      p256_init_exchange |> ExchangeResp.new() |> ExchangeResp.cbor_encode()
+
+    # InitExchange invalid payloads: [seq_num, key_type, cose_key, hkdf_salt, nonce]
     invalid_key_type_payload =
       CBOR.encode([
+        0,
         99,
         %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
         %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
@@ -71,6 +79,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
     wrong_okp_key_payload =
       CBOR.encode([
+        0,
         0,
         # COSE_Key map with a 16-byte x coordinate instead of the required 32
         %CBOR.Tag{
@@ -83,6 +92,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
     wrong_hkdf_salt_payload =
       CBOR.encode([
+        0,
         0,
         # valid 32-byte X25519 COSE_Key, so parsing proceeds to the salt check
         %CBOR.Tag{
@@ -97,6 +107,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     wrong_nonce_payload =
       CBOR.encode([
         0,
+        0,
         # valid 32-byte X25519 COSE_Key, so parsing proceeds to the nonce check
         %CBOR.Tag{
           tag: :bytes,
@@ -107,15 +118,28 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
         %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(8)}
       ])
 
+    # ExchangeResp invalid payload  [seq_num, cose_key] but seq_num is a string
+    invalid_exchange_resp_payload =
+      CBOR.encode([
+        "not_an_integer",
+        %CBOR.Tag{
+          tag: :bytes,
+          value: CBOR.encode(%{1 => 1, -1 => 4, -2 => :crypto.strong_rand_bytes(32)})
+        }
+      ])
+
     %{
       init_exchange: init_exchange,
       init_exchange_payload: init_exchange_payload,
       p256_init_exchange: p256_init_exchange,
       p256_init_exchange_payload: p256_init_exchange_payload,
+      exchange_resp_payload: exchange_resp_payload,
+      p256_exchange_resp_payload: p256_exchange_resp_payload,
       invalid_key_type_payload: invalid_key_type_payload,
       wrong_okp_key_payload: wrong_okp_key_payload,
       wrong_hkdf_salt_payload: wrong_hkdf_salt_payload,
-      wrong_nonce_payload: wrong_nonce_payload
+      wrong_nonce_payload: wrong_nonce_payload,
+      invalid_exchange_resp_payload: invalid_exchange_resp_payload
     }
   end
 
@@ -300,8 +324,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
     end
 
-    test "acks a valid CBOR InitExchange payload with a P-256 key",
-         context do
+    test "acks a valid CBOR InitExchange payload with a P-256 key", context do
       %{state: state, p256_init_exchange_payload: payload} = context
 
       assert {:ack, :ok, new_state} =
@@ -309,120 +332,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
-    end
-
-    test "discards a payload whose key_type integer is not a supported suite",
-         context do
-      %{state: state, invalid_key_type_payload: payload} = context
-
-      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
-
-      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
-                                                              "key_agreement_error",
-                                                              _meta,
-                                                              _ts ->
-        :ok
-      end)
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
-    end
-
-    test "discards a payload with a wrong-size OKP public key", context do
-      %{state: state, wrong_okp_key_payload: payload} = context
-
-      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
-
-      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
-                                                              "key_agreement_error",
-                                                              _meta,
-                                                              _ts ->
-        :ok
-      end)
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
-    end
-
-    test "discards a payload with a wrong-size HKDF salt", context do
-      %{state: state, wrong_hkdf_salt_payload: payload} = context
-
-      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
-
-      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
-                                                              "key_agreement_error",
-                                                              _meta,
-                                                              _ts ->
-        :ok
-      end)
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
-    end
-
-    test "discards a payload with a wrong-size nonce", context do
-      %{state: state, wrong_nonce_payload: payload} = context
-
-      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
-
-      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
-                                                              "key_agreement_error",
-                                                              _meta,
-                                                              _ts ->
-        :ok
-      end)
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
-    end
-
-    test "discards a valid CBOR payload that is not a 4-element list", context do
-      %{state: state} = context
-
-      # CBOR-valid but wrong structure, hits the parse(_) fallback
-      payload = CBOR.encode(%{"key_type" => 0})
-
-      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
-
-      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
-                                                              "key_agreement_error",
-                                                              _meta,
-                                                              _ts ->
-        :ok
-      end)
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
-    end
-
-    test "discards a non-CBOR binary payload", context do
-      %{state: state} = context
-
-      payload = <<0xFF, 0xFE, 0x00, 0x01>>
-
-      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
-
-      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
-                                                              "key_agreement_error",
-                                                              _meta,
-                                                              _ts ->
-        :ok
-      end)
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end
 
     test "discards the message if discard_messages is set", context do
@@ -435,13 +344,91 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     end
   end
 
-  describe "send_init_exchange/2" do
-    test "publishes a well-formed CBOR InitExchange to the device and returns the message",
-         context do
+  describe "/keyAgreement - invalid payloads" do
+    setup context do
       %{state: state} = context
 
-      realm = state.realm
-      device_id = state.device_id
+      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
+
+      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
+                                                              "key_agreement_error",
+                                                              _meta,
+                                                              _ts ->
+        :ok
+      end)
+
+      :ok
+    end
+
+    test "discards a payload whose key_type integer is not a supported suite", context do
+      %{state: state, invalid_key_type_payload: payload} = context
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+    end
+
+    test "discards a payload with a wrong-size OKP public key", context do
+      %{state: state, wrong_okp_key_payload: payload} = context
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+    end
+
+    test "discards a payload with a wrong-size HKDF salt", context do
+      %{state: state, wrong_hkdf_salt_payload: payload} = context
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+    end
+
+    test "discards a payload with a wrong-size nonce", context do
+      %{state: state, wrong_nonce_payload: payload} = context
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+    end
+
+    test "discards a valid CBOR payload that is not a 5-element list", context do
+      %{state: state} = context
+
+      # CBOR-valid but wrong structure, hits the parse(_) fallback
+      payload = CBOR.encode(%{"key_type" => 0})
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+    end
+
+    test "discards a non-CBOR binary payload", context do
+      %{state: state} = context
+
+      payload = <<0xFF, 0xFE, 0x00, 0x01>>
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+    end
+  end
+
+  describe "send_init_exchange/2" do
+    setup context do
+      %{state: state} = context
+      {:ok, realm: state.realm, device_id: state.device_id}
+    end
+
+    test "publishes a well-formed CBOR InitExchange to the device and returns the message",
+         context do
+      %{realm: realm, device_id: device_id} = context
 
       expect(VMQPlugin, :publish, fn topic, payload_bytes, qos ->
         encoded_device_id = Astarte.Core.Device.encode_device_id(device_id)
@@ -464,23 +451,166 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
     test "returns {:error, :session_not_found} when the device has no active session",
          context do
-      %{state: state} = context
+      %{realm: realm, device_id: device_id} = context
 
       expect(VMQPlugin, :publish, fn _topic, _payload, _qos ->
         {:ok, %{local_matches: 0, remote_matches: 0}}
       end)
 
       assert {:error, :session_not_found} =
-               ControlHandler.send_init_exchange(state.realm, state.device_id)
+               ControlHandler.send_init_exchange(realm, device_id)
     end
 
     test "returns {:error, reason} on VMQ publish failure", context do
-      %{state: state} = context
+      %{realm: realm, device_id: device_id} = context
 
       expect(VMQPlugin, :publish, fn _topic, _payload, _qos -> {:error, :transport_failure} end)
 
       assert {:error, :transport_failure} =
-               ControlHandler.send_init_exchange(state.realm, state.device_id)
+               ControlHandler.send_init_exchange(realm, device_id)
+    end
+  end
+
+  describe "/keyAgreement/1" do
+    test "acks a valid CBOR ExchangeResp payload and increments message counters",
+         context do
+      %{state: state, exchange_resp_payload: payload} = context
+
+      # Inject the expected key_type into the state for validation
+      state = Map.put(state, :pending_key_type, :ecdh_x25519_hkdf_sha256_aes_256_gcm)
+
+      assert {:ack, :ok, new_state} =
+               ControlHandler.handle_control(state, "/keyAgreement/1", payload, 0)
+
+      assert new_state.total_received_msgs == state.total_received_msgs + 1
+      assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
+    end
+
+    test "acks a valid CBOR ExchangeResp payload with a P-256 key", context do
+      %{state: state, p256_exchange_resp_payload: payload} = context
+
+      # Inject the expected key_type into the state for validation
+      state = Map.put(state, :pending_key_type, :ecdh_p256_hkdf_sha256_aes_256_gcm)
+
+      assert {:ack, :ok, new_state} =
+               ControlHandler.handle_control(state, "/keyAgreement/1", payload, 0)
+
+      assert new_state.total_received_msgs == state.total_received_msgs + 1
+      assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
+    end
+
+    test "discards an invalid ExchangeResp payload", context do
+      %{state: state, invalid_exchange_resp_payload: payload} = context
+
+      # Inject default expected key type so validation proceeds to the actual error
+      state = Map.put(state, :pending_key_type, :ecdh_x25519_hkdf_sha256_aes_256_gcm)
+
+      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
+
+      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
+                                                              "key_agreement_resp_error",
+                                                              _meta,
+                                                              _ts ->
+        :ok
+      end)
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement/1", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+    end
+
+    test "discards the message if discard_messages is set", context do
+      %{state: state} = context
+
+      state = %{state | discard_messages: true}
+
+      assert {:discard, _result, ^state} =
+               ControlHandler.handle_control(state, "/keyAgreement/1", <<1>>, 0)
+    end
+  end
+
+  describe "send_exchange_resp/3" do
+    setup context do
+      %{state: state} = context
+      {:ok, realm: state.realm, device_id: state.device_id}
+    end
+
+    test "publishes a well-formed CBOR ExchangeResp (X25519) and returns the message",
+         context do
+      %{realm: realm, device_id: device_id, init_exchange: init_exchange} = context
+
+      expect(VMQPlugin, :publish, fn topic, payload_bytes, qos ->
+        encoded_device_id = Astarte.Core.Device.encode_device_id(device_id)
+
+        assert topic == "#{realm}/#{encoded_device_id}/control/keyAgreement/1"
+        assert qos == 2
+
+        assert {:ok, decoded} =
+                 ExchangeResp.cbor_decode(
+                   payload_bytes,
+                   :ecdh_x25519_hkdf_sha256_aes_256_gcm
+                 )
+
+        assert decoded.seq_num == init_exchange.seq_num
+
+        {:ok, %{local_matches: 1, remote_matches: 0}}
+      end)
+
+      assert {:ok, %ExchangeResp{} = msg} =
+               ControlHandler.send_exchange_resp(realm, device_id, init_exchange)
+
+      assert msg.seq_num == init_exchange.seq_num
+      assert %COSE.Keys.OKP{} = msg.public_key
+    end
+
+    test "publishes a well-formed CBOR ExchangeResp (P-256) and returns the message",
+         context do
+      %{realm: realm, device_id: device_id, p256_init_exchange: init_exchange} = context
+
+      expect(VMQPlugin, :publish, fn topic, payload_bytes, qos ->
+        encoded_device_id = Astarte.Core.Device.encode_device_id(device_id)
+
+        assert topic == "#{realm}/#{encoded_device_id}/control/keyAgreement/1"
+        assert qos == 2
+
+        assert {:ok, decoded} =
+                 ExchangeResp.cbor_decode(
+                   payload_bytes,
+                   :ecdh_p256_hkdf_sha256_aes_256_gcm
+                 )
+
+        assert decoded.seq_num == init_exchange.seq_num
+
+        {:ok, %{local_matches: 1, remote_matches: 0}}
+      end)
+
+      assert {:ok, %ExchangeResp{} = msg} =
+               ControlHandler.send_exchange_resp(realm, device_id, init_exchange)
+
+      assert msg.seq_num == init_exchange.seq_num
+      assert %COSE.Keys.ECC{} = msg.public_key
+    end
+
+    test "returns {:error, :session_not_found} when the device has no active session",
+         context do
+      %{realm: realm, device_id: device_id, init_exchange: init_exchange} = context
+
+      expect(VMQPlugin, :publish, fn _topic, _payload, _qos ->
+        {:ok, %{local_matches: 0, remote_matches: 0}}
+      end)
+
+      assert {:error, :session_not_found} =
+               ControlHandler.send_exchange_resp(realm, device_id, init_exchange)
+    end
+
+    test "returns {:error, reason} on VMQ publish failure", context do
+      %{realm: realm, device_id: device_id, init_exchange: init_exchange} = context
+
+      expect(VMQPlugin, :publish, fn _topic, _payload, _qos -> {:error, :transport_failure} end)
+
+      assert {:error, :transport_failure} =
+               ControlHandler.send_exchange_resp(realm, device_id, init_exchange)
     end
   end
 end


### PR DESCRIPTION
This PR aims to add the logic for implementing the logic for the ExchangeResp message regarding the handshake between Astarte and a Device (or viceversa) for the Encrypted Endpoints feature