### PR TITLE
refactor(dup): preserve handshake key type in state during init exchange

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -166,7 +166,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     case InitExchange.decode(payload) do
       # TODO: call send_exchange_resp/3 here and use the returned key pair
       #       for the ECDH + HKDF shared-secret derivation step.
-      {:ok, _init_exchange} ->
+      {:ok, init_exchange} ->
         :telemetry.execute(
           [:astarte, :data_updater_plant, :control_handler, :key_agreement_init],
           %{payload_size: byte_size(payload)},
@@ -176,7 +176,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
         final_state = %{
           new_state
           | total_received_msgs: new_state.total_received_msgs + 1,
-            total_received_bytes: new_state.total_received_bytes + byte_size(payload)
+            total_received_bytes: new_state.total_received_bytes + byte_size(payload),
+            active_key_type: init_exchange.key_type
         }
 
         {:ack, :ok, final_state}
@@ -208,52 +209,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   end
 
   def handle_control(state, "/keyAgreement/1", payload, timestamp) do
-    new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
-
-    expected_key_type =
-      Map.get(new_state, :pending_key_type, :ecdh_x25519_hkdf_sha256_aes_256_gcm)
-
-    case ExchangeResp.cbor_decode(payload, expected_key_type) do
-      # TODO: use exchange_resp for ECDH + HKDF shared-secret derivation
-      {:ok, _exchange_resp} ->
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :control_handler, :key_agreement_resp],
-          %{payload_size: byte_size(payload)},
-          %{realm: new_state.realm}
-        )
-
-        final_state = %{
-          new_state
-          | total_received_msgs: new_state.total_received_msgs + 1,
-            total_received_bytes: new_state.total_received_bytes + byte_size(payload)
-        }
-
-        {:ack, :ok, final_state}
-
-      {:error, reason} ->
-        Logger.warning(
-          "[keyAgreement/1] payload validation failed: #{inspect(reason)}",
-          tag: "key_agreement_resp_invalid_payload"
-        )
-
-        context = %{
-          state: new_state,
-          payload: payload,
-          path: "/keyAgreement/1",
-          timestamp: timestamp
-        }
-
-        error = %{
-          message:
-            "Invalid keyAgreement/1 payload (#{inspect(reason)}): " <>
-              inspect(Base.encode64(payload)),
-          logger_metadata: [tag: "key_agreement_resp_error"],
-          error_name: "key_agreement_resp_error",
-          error: :key_agreement_resp_error
-        }
-
-        Core.Error.handle_error(context, error)
-    end
+    state
+    |> TimeBasedActions.execute_time_based_actions(timestamp)
+    |> process_key_agreement(payload, timestamp)
   end
 
   def handle_control(state, path, payload, timestamp) do
@@ -278,21 +236,80 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     Core.Error.handle_error(context, error)
   end
 
+  defp process_key_agreement(%{handshake_key_type: nil} = state, _payload, _timestamp) do
+    Logger.warning(
+      "[keyAgreement/1] Received ExchangeResp but no pending key exchange was found in state.",
+      tag: "key_agreement_resp_unexpected"
+    )
+    #TODO: implement ExchangeFailed message to signal to the other party that for whatever reason the key exchange has failed
+    {:ack, :ok, state}
+  end
+
+  defp process_key_agreement(%{handshake_key_type: expected_key_type} = state, payload, timestamp) do
+    case ExchangeResp.cbor_decode(payload, expected_key_type) do
+      {:ok, _exchange_resp} ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_resp],
+          %{payload_size: byte_size(payload)},
+          %{realm: state.realm}
+        )
+
+        final_state = %{
+          state
+          | total_received_msgs: state.total_received_msgs + 1,
+            total_received_bytes: state.total_received_bytes + byte_size(payload),
+            handshake_key_type: nil,
+            active_key_type: expected_key_type
+        }
+
+        {:ack, :ok, final_state}
+
+      {:error, reason} ->
+        Logger.warning(
+          "[keyAgreement/1] payload validation failed: #{inspect(reason)}",
+          tag: "key_agreement_resp_invalid_payload"
+        )
+
+        context = %{
+          state: state,
+          payload: payload,
+          path: "/keyAgreement/1",
+          timestamp: timestamp
+        }
+
+        error = %{
+          message:
+            "Invalid keyAgreement/1 payload (#{inspect(reason)}): " <>
+              inspect(Base.encode64(payload)),
+          logger_metadata: [tag: "key_agreement_resp_error"],
+          error_name: "key_agreement_resp_error",
+          error: :key_agreement_resp_error
+        }
+
+        Core.Error.handle_error(context, error)
+    end
+  end
+
   @doc """
   Sends an `InitExchange` message from Astarte to a device to trigger
   a new key-agreement handshake
 
   Generates a fresh ephemeral X25519 key pair, a random HKDF
   salt, and a random AES-256-GCM nonce, CBOR-encodes the `InitExchange`
-  struct, and publishes it on: `<realm>/<device_id>/control/keyAgreement`
+  struct, updates the state with the new handshake key type, and publishes
+  it on: `<realm>/<device_id>/control/keyAgreement`
   """
-  @spec send_init_exchange(String.t(), binary()) ::
-          {:ok, InitExchange.t()} | {:error, term()}
-  def send_init_exchange(realm, device_id) do
+  @spec send_init_exchange(State.t()) :: {:ok, State.t()} | {:error, term()}
+  def send_init_exchange(state) do
     init_exchange = InitExchange.new()
 
-    with :ok <- publish_init_exchange(realm, device_id, init_exchange) do
-      {:ok, init_exchange}
+    with :ok <- publish_init_exchange(state.realm, state.device_id, init_exchange) do
+      updated_state = %{
+        state
+        | handshake_key_type: init_exchange.key_type
+      }
+
+      {:ok, updated_state}
     end
   end
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
@@ -29,6 +29,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.State do
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.AMQPTriggerTarget
   alias Astarte.DataUpdaterPlant.DataUpdater.Cache
   alias Astarte.DataUpdaterPlant.DataUpdater.CachedPath
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
 
   @type interface_name :: String.t()
   @type policy_name :: String.t()
@@ -112,5 +113,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.State do
     field :last_deletion_in_progress_refresh, non_neg_integer(), default: 0
     field :last_datastream_maximum_retention_refresh, non_neg_integer(), default: 0
     field :capabilities, Capabilities.t(), default: %Capabilities{}
+    field :handshake_key_type, InitExchange.key_suite() | nil
+    field :active_key_type, InitExchange.key_suite() | nil
   end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -322,6 +322,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
+      assert new_state.active_key_type == :ecdh_x25519_hkdf_sha256_aes_256_gcm
     end
 
     test "acks a valid CBOR InitExchange payload with a P-256 key", context do
@@ -332,6 +333,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
+      assert new_state.active_key_type == :ecdh_p256_hkdf_sha256_aes_256_gcm
     end
 
     test "discards the message if discard_messages is set", context do
@@ -420,54 +422,45 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     end
   end
 
-  describe "send_init_exchange/2" do
-    setup context do
-      %{state: state} = context
-      {:ok, realm: state.realm, device_id: state.device_id}
-    end
-
-    test "publishes a well-formed CBOR InitExchange to the device and returns the message",
+  describe "send_init_exchange/1" do
+    test "publishes a well-formed CBOR InitExchange to the device and returns the updated state",
          context do
-      %{realm: realm, device_id: device_id} = context
+      %{state: state} = context
 
       expect(VMQPlugin, :publish, fn topic, payload_bytes, qos ->
-        encoded_device_id = Astarte.Core.Device.encode_device_id(device_id)
+        encoded_device_id = Astarte.Core.Device.encode_device_id(state.device_id)
 
-        assert topic == "#{realm}/#{encoded_device_id}/control/keyAgreement"
+        assert topic == "#{state.realm}/#{encoded_device_id}/control/keyAgreement"
         assert qos == 2
         assert {:ok, _} = InitExchange.decode(payload_bytes)
 
         {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
 
-      assert {:ok, %InitExchange{} = msg} =
-               ControlHandler.send_init_exchange(realm, device_id)
+      assert {:ok, new_state} = ControlHandler.send_init_exchange(state)
 
-      assert msg.key_type == :ecdh_x25519_hkdf_sha256_aes_256_gcm
-      assert %COSE.Keys.OKP{} = msg.public_key
-      assert byte_size(msg.hkdf_salt) == 32
-      assert byte_size(msg.nonce) == 12
+      assert new_state.handshake_key_type == :ecdh_x25519_hkdf_sha256_aes_256_gcm
     end
 
     test "returns {:error, :session_not_found} when the device has no active session",
          context do
-      %{realm: realm, device_id: device_id} = context
+      %{state: state} = context
 
       expect(VMQPlugin, :publish, fn _topic, _payload, _qos ->
         {:ok, %{local_matches: 0, remote_matches: 0}}
       end)
 
       assert {:error, :session_not_found} =
-               ControlHandler.send_init_exchange(realm, device_id)
+               ControlHandler.send_init_exchange(state)
     end
 
     test "returns {:error, reason} on VMQ publish failure", context do
-      %{realm: realm, device_id: device_id} = context
+      %{state: state} = context
 
       expect(VMQPlugin, :publish, fn _topic, _payload, _qos -> {:error, :transport_failure} end)
 
       assert {:error, :transport_failure} =
-               ControlHandler.send_init_exchange(realm, device_id)
+               ControlHandler.send_init_exchange(state)
     end
   end
 
@@ -477,33 +470,37 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       %{state: state, exchange_resp_payload: payload} = context
 
       # Inject the expected key_type into the state for validation
-      state = Map.put(state, :pending_key_type, :ecdh_x25519_hkdf_sha256_aes_256_gcm)
+      state = %{state | handshake_key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
 
       assert {:ack, :ok, new_state} =
                ControlHandler.handle_control(state, "/keyAgreement/1", payload, 0)
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
+      assert new_state.handshake_key_type == nil
+      assert new_state.active_key_type == :ecdh_x25519_hkdf_sha256_aes_256_gcm
     end
 
     test "acks a valid CBOR ExchangeResp payload with a P-256 key", context do
       %{state: state, p256_exchange_resp_payload: payload} = context
 
       # Inject the expected key_type into the state for validation
-      state = Map.put(state, :pending_key_type, :ecdh_p256_hkdf_sha256_aes_256_gcm)
+      state = %{state | handshake_key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}
 
       assert {:ack, :ok, new_state} =
                ControlHandler.handle_control(state, "/keyAgreement/1", payload, 0)
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
+      assert new_state.handshake_key_type == nil
+      assert new_state.active_key_type == :ecdh_p256_hkdf_sha256_aes_256_gcm
     end
 
     test "discards an invalid ExchangeResp payload", context do
       %{state: state, invalid_exchange_resp_payload: payload} = context
 
       # Inject default expected key type so validation proceeds to the actual error
-      state = Map.put(state, :pending_key_type, :ecdh_x25519_hkdf_sha256_aes_256_gcm)
+      state = %{state | handshake_key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
 
       expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
 


### PR DESCRIPTION
This PR aims to add preservation of the handshake key type in data updater pant state during init exchange 