### PR TITLE
chore(dup): re-encrypt with DEK and store data points arriving on encrypted endpoints

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -29,6 +29,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   alias Astarte.DataAccess.Data
   alias Astarte.DataAccess.Device, as: DeviceAccess
   alias Astarte.DataAccess.Device.InsertContext
+  alias Astarte.DataUpdaterPlant.DataEncryptionKeyCache, as: DEKCache
   alias Astarte.DataUpdaterPlant.DataUpdater.Cache
   alias Astarte.DataUpdaterPlant.DataUpdater.CachedPath
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
@@ -36,6 +37,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.DataUpdaterPlant.DataUpdater.State
   alias Astarte.DataUpdaterPlant.TriggersHandler
+  alias Astarte.Secrets
 
   require Logger
 
@@ -129,20 +131,46 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
       maybe_insert_path(context, interface_descriptor, mapping)
     end
 
-    insert_context = %InsertContext{
-      realm: realm,
-      device_id: device_id,
-      interface_descriptor: interface_descriptor,
-      mapping: mapping,
-      path: path,
-      value: value,
-      value_timestamp: maybe_explicit_value_timestamp,
-      reception_timestamp: timestamp,
-      opts: [ttl: db_max_ttl]
-    }
+    encrypted_endpoints =
+      state.mappings
+      |> Map.values()
+      |> Enum.filter(& &1.encrypted)
+      |> Enum.map(& &1.endpoint)
 
-    DeviceAccess.insert_value_into_db(insert_context)
-    |> handle_result(context, start)
+    case maybe_encrypt_value(
+           interface_descriptor.aggregation,
+           path,
+           value,
+           encrypted_endpoints,
+           realm
+         ) do
+      {:error, err_msg} = error ->
+        Logger.debug(
+          "Issue #{err_msg} encountered while attempting to encrypt data values with DEK. Data could not be saved to database",
+          tag: "data_encryption_error"
+        )
+
+        error
+
+      {value, encrypted_dek} ->
+        insert_context =
+          %InsertContext{
+            realm: realm,
+            device_id: device_id,
+            interface_descriptor: interface_descriptor,
+            mapping: mapping,
+            path: path,
+            value: value,
+            value_timestamp: maybe_explicit_value_timestamp,
+            reception_timestamp: timestamp,
+            encrypted_endpoints: encrypted_endpoints,
+            encrypted_dek: encrypted_dek,
+            opts: [ttl: db_max_ttl]
+          }
+
+        DeviceAccess.insert_value_into_db(insert_context)
+        |> handle_result(context, start)
+    end
   end
 
   defp get_previous_value(context, interface_descriptor, mapping)
@@ -156,6 +184,73 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   end
 
   defp get_previous_value(_, _, _), do: nil
+
+  # if value == nil we are trying to unset a property, be it encrypted or not: return nil as it is
+  defp maybe_encrypt_value(_, _, nil, _, _) do
+    {nil, nil}
+  end
+
+  # no encrypted endpoints for this interface: return plaintext original value and no DEK
+  defp maybe_encrypt_value(_, _, value, [], _) do
+    {value, nil}
+  end
+
+  # check if encryption is required for the endpoint, and if so: retrieve the current realm DEK,
+  # encrypt the (individual) value with it, and return a tuple {encrypted_value, encrypted_dek}
+  # ready to be stored in db.
+  defp maybe_encrypt_value(:individual, path, value, encrypted_endpoints, realm) do
+    case path in encrypted_endpoints do
+      true ->
+        with {:ok, %{plaintext: plaintext_dek, ciphertext: ciphertext_dek}} <-
+               DEKCache.fetch_data_encryption_key(realm) do
+          encrypted_value =
+            do_encrypt_individual_value(value, plaintext_dek)
+
+          {encrypted_value, ciphertext_dek}
+        end
+
+      _ ->
+        {value, nil}
+    end
+  end
+
+  # for each of the mappings of the object check if the related encrypted option is set,
+  # and based on this condition treat each of the endpoints values as a separate one when
+  # applying encryption logic (encryption choice is done at endpoint level, not at object level)
+  defp maybe_encrypt_value(:object, _, obj_value, encrypted_endpoints, realm) do
+    case encrypted_endpoints != [] do
+      true ->
+        with {:ok, %{plaintext: plaintext_dek, ciphertext: ciphertext_dek}} <-
+               DEKCache.fetch_data_encryption_key(realm) do
+          obj_value_with_encryption =
+            do_encrypt_object_mappings(encrypted_endpoints, obj_value, plaintext_dek)
+
+          {obj_value_with_encryption, ciphertext_dek}
+        end
+
+      _ ->
+        {obj_value, nil}
+    end
+  end
+
+  defp do_encrypt_individual_value(value, dek) do
+    value_binary = :erlang.term_to_binary(value)
+    {:ok, encrypted_value} = Secrets.encrypt_with_dek(value_binary, dek)
+    encrypted_value
+  end
+
+  # leave untouched object values that do not need encryption, encrypt all others in-place
+  defp do_encrypt_object_mappings(encrypted_endpoints, obj_value, dek) do
+    Enum.reduce(encrypted_endpoints, obj_value, fn endpoint, acc_obj ->
+      endpoint = Path.basename(endpoint)
+
+      Map.put(
+        acc_obj,
+        endpoint,
+        do_encrypt_individual_value(Map.get(acc_obj, endpoint), dek)
+      )
+    end)
+  end
 
   defp handle_result({:error, :unset_not_allowed}, context, _start) do
     error = %{
@@ -234,7 +329,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   defp validate_value(context, interface_descriptor, mapping, value) do
     %{state: state} = context
 
-    mappings = Core.Interface.extract_mappings(interface_descriptor, mapping, state.mappings)
+    mappings =
+      Core.Interface.extract_mappings(interface_descriptor, mapping, state.mappings)
 
     with :ok <- validate_value_type(context, mappings, value) do
       validate_required_mappings(context, interface_descriptor, mappings, value)

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_test.exs
@@ -1,0 +1,322 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerTest do
+  use Astarte.Cases.Data, async: true
+  use Astarte.Cases.Device
+  use Astarte.Cases.DataUpdater
+
+  alias Astarte.Core.CQLUtils
+  alias Astarte.DataAccess.Realms.Realm
+  alias Astarte.DataUpdaterPlant.DataEncryptionKeyCache, as: DEKCache
+  alias Astarte.DataUpdaterPlant.DataQueryHelper
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler
+  alias Astarte.Secrets
+
+  setup_all context do
+    keyspace = Realm.keyspace_name(context.realm)
+
+    # generate a new DEK to be used in DataHandler internal encryptions during this test suite
+    DEKCache.reset_realm_dek(context.realm)
+    {:ok, current_dek_entry} = DEKCache.fetch_data_encryption_key(context.realm)
+
+    %{keyspace: keyspace, current_dek: current_dek_entry}
+  end
+
+  setup context do
+    timestamp = System.system_time(:microsecond) * 10
+    start = System.monotonic_time()
+
+    # create dummy payload to be sent by device, specific per interface type
+    payload_value =
+      case Map.get(context, :interface_aggregation) do
+        :individual ->
+          "encryptmeplease"
+
+        # only first 2 endpoints are encrypted (look at interfaces setup in Cases.Device)
+        :object ->
+          %{
+            "endpoint0" => "encryptme",
+            "endpoint1" => "encryptmetoo",
+            "endpoint2" => "plaintextforme"
+          }
+
+        _ ->
+          nil
+      end
+
+    {:ok, payload_encoded} = %{"v" => payload_value} |> Cyanide.encode()
+
+    %{
+      payload: payload_encoded,
+      payload_value: payload_value,
+      timestamp: timestamp,
+      start: start
+    }
+  end
+
+  describe "encryption with realm DEK of incoming data on encrypted endpoints" do
+    @tag interface_aggregation: :individual
+    test "is applied for interfaces of type 'properties'", context do
+      %{
+        state: state,
+        keyspace: keyspace,
+        device_id: device_id,
+        interfaces: interfaces,
+        payload: payload,
+        payload_value: payload_value,
+        timestamp: timestamp,
+        start: start,
+        current_dek: current_dek
+      } = context
+
+      test_interface_name = "test.EncryptedPropertiesInterface"
+      interface = Enum.find(interfaces, &(&1.name == test_interface_name))
+
+      encrypted_mapping = Enum.find(interface.mappings, & &1.encrypted)
+
+      endpoint_path = encrypted_mapping.endpoint
+
+      # message is received by DUP and handled correctly
+      assert {:ack, :ok, _, _} =
+               DataHandler.handle_data(
+                 state,
+                 test_interface_name,
+                 endpoint_path,
+                 payload,
+                 timestamp,
+                 start
+               )
+
+      # querying the data saved in db for this endpoint: assert encrypted property and
+      # related DEK got stored, and value when decrypted corresponds to plaintext payload value
+      [db_data_entry] =
+        DataQueryHelper.query_endpoint_data(
+          interface,
+          endpoint_path,
+          device_id,
+          keyspace,
+          :property
+        )
+
+      assert %{encryptedblob_value: encrypted_val, encrypted_dek: encrypted_dek} = db_data_entry
+      assert is_binary(encrypted_dek)
+      # the current DEK is stored in db in its ciphertext version
+      assert encrypted_dek == current_dek.ciphertext
+
+      # value can be decrypted with the current DEK
+      {:ok, decrypted_val} = Secrets.decrypt_with_dek(encrypted_val, current_dek.plaintext)
+      assert decrypted_val |> :erlang.binary_to_term() == payload_value
+    end
+
+    @tag interface_aggregation: :individual
+    test "is applied for interfaces of type 'individual datastream'", context do
+      %{
+        state: state,
+        keyspace: keyspace,
+        device_id: device_id,
+        interfaces: interfaces,
+        payload: payload,
+        payload_value: payload_value,
+        timestamp: timestamp,
+        start: start,
+        current_dek: current_dek
+      } = context
+
+      test_interface_name = "test.EncryptedIndividualDatastreamInterface"
+      interface = Enum.find(interfaces, &(&1.name == test_interface_name))
+
+      encrypted_mapping = Enum.find(interface.mappings, & &1.encrypted)
+
+      endpoint_path = encrypted_mapping.endpoint
+
+      assert {:ack, :ok, _, _} =
+               DataHandler.handle_data(
+                 state,
+                 test_interface_name,
+                 endpoint_path,
+                 payload,
+                 timestamp,
+                 start
+               )
+
+      # querying the data saved in db for this endpoint: assert encrypted individual value and
+      # related DEK got stored, and value when decrypted corresponds to plaintext payload value
+      [db_data_entry] =
+        DataQueryHelper.query_endpoint_data(
+          interface,
+          endpoint_path,
+          device_id,
+          keyspace,
+          :individual_datastream
+        )
+
+      assert %{encryptedblob_value: encrypted_val, encrypted_dek: encrypted_dek} = db_data_entry
+      assert is_binary(encrypted_dek)
+      assert encrypted_dek == current_dek.ciphertext
+
+      {:ok, decrypted_val} = Secrets.decrypt_with_dek(encrypted_val, current_dek.plaintext)
+      assert decrypted_val |> :erlang.binary_to_term() == payload_value
+    end
+
+    @tag interface_aggregation: :object
+    test "is applied for interfaces of type 'object datastream'", context do
+      %{
+        state: state,
+        keyspace: keyspace,
+        device_id: device_id,
+        interfaces: interfaces,
+        payload: payload,
+        payload_value: payload_value,
+        timestamp: timestamp,
+        start: start,
+        current_dek: current_dek
+      } = context
+
+      test_interface_name = "test.EncryptedObjectDatastreamInterface"
+      interface = Enum.find(interfaces, &(&1.name == test_interface_name))
+
+      common_endpoint_path =
+        interface.mappings |> Enum.at(0) |> Map.get(:endpoint) |> Path.dirname()
+
+      leaf_endpoints = get_interface_endpoints(interface)
+
+      assert {:ack, :ok, _, _} =
+               DataHandler.handle_data(
+                 state,
+                 test_interface_name,
+                 common_endpoint_path,
+                 payload,
+                 timestamp,
+                 start
+               )
+
+      # querying the data saved in db for this endpoint: assert encrypted object values and
+      # related DEK got stored, and values when decrypted correspond to plaintext payload values.
+      # Assert only encrypted endpoints got their value actually encrypted in db
+      endpoints_db_columns = Enum.map(leaf_endpoints, fn {_, db_column, _} -> db_column end)
+
+      [db_data_entry] =
+        DataQueryHelper.query_endpoint_data(
+          interface,
+          common_endpoint_path,
+          endpoints_db_columns,
+          device_id,
+          keyspace,
+          true,
+          :object_datastream
+        )
+
+      assert %{encrypted_dek: encrypted_dek} = db_data_entry
+      assert is_binary(encrypted_dek)
+      assert encrypted_dek == current_dek.ciphertext
+
+      decrypted_object = decrypt_object_value(db_data_entry, leaf_endpoints, current_dek)
+      assert decrypted_object == payload_value
+    end
+
+    test "is not applied when a nil value is sent on property endpoints with allow_unset option",
+         context do
+      %{
+        state: state,
+        keyspace: keyspace,
+        device_id: device_id,
+        interfaces: interfaces,
+        payload: payload,
+        timestamp: timestamp,
+        start: start
+      } = context
+
+      test_interface_name = "test.EncryptedPropertiesInterface"
+      interface = Enum.find(interfaces, &(&1.name == test_interface_name))
+
+      encrypted_mapping = Enum.find(interface.mappings, & &1.encrypted)
+
+      endpoint_path = encrypted_mapping.endpoint
+
+      # message is received by DUP and handled correctly
+      assert {:ack, :ok, _, _} =
+               DataHandler.handle_data(
+                 state,
+                 test_interface_name,
+                 endpoint_path,
+                 payload,
+                 timestamp,
+                 start
+               )
+
+      # querying the data saved in db for this endpoint: assert property row is missing
+      # (no encryption and storing was attempted)
+      assert [] =
+               DataQueryHelper.query_endpoint_data(
+                 interface,
+                 endpoint_path,
+                 device_id,
+                 keyspace,
+                 :property
+               )
+    end
+  end
+
+  # build a list of tuples {endpoint_x_in_string_format, endpoint_x_in_db_column_format, encrypted?}
+  # containing all the leaf endpoints of the mappings for the interface
+  defp get_interface_endpoints(interface) do
+    Enum.map(
+      interface.mappings,
+      fn mapping ->
+        endpoint_string =
+          mapping.endpoint
+          |> Path.basename()
+
+        endpoint_db_format =
+          endpoint_string
+          |> CQLUtils.endpoint_to_db_column_name()
+          |> String.to_atom()
+
+        {endpoint_string, endpoint_db_format, Map.get(mapping, :encrypted)}
+      end
+    )
+  end
+
+  # create a plaintext object by reversing DEK encryption (only) on encrypted endpoints
+  defp decrypt_object_value(data_entry, endpoints, current_dek) do
+    Enum.reduce(endpoints, Map.new(), fn {endpoint_to_string, endpoint_to_db_column, encrypted},
+                                         obj_map ->
+      decrypted_val =
+        case encrypted do
+          true ->
+            {:ok, decrypted_val} =
+              Map.get(data_entry, endpoint_to_db_column)
+              |> Secrets.decrypt_with_dek(current_dek.plaintext)
+
+            decrypted_val |> :erlang.binary_to_term()
+
+          _ ->
+            Map.get(data_entry, endpoint_to_db_column)
+        end
+
+      Map.put(
+        obj_map,
+        endpoint_to_string,
+        decrypted_val
+      )
+    end)
+  end
+end

--- a/apps/astarte_data_updater_plant/test/support/cases/device.ex
+++ b/apps/astarte_data_updater_plant/test/support/cases/device.ex
@@ -67,7 +67,8 @@ defmodule Astarte.Cases.Device do
 
     endpoints_to_update =
       for interface <- interfaces_with_encrypted_endpoints,
-          mapping <- interface.mappings do
+          mapping <- interface.mappings,
+          Map.get(mapping, :encrypted) do
         {interface.interface_id, mapping.endpoint_id}
       end
 
@@ -263,7 +264,7 @@ defmodule Astarte.Cases.Device do
         end
       },
       {
-        :encrypted_endpoints_oject_datastream_interfaces,
+        :encrypted_endpoints_object_datastream_interfaces,
         fn acc -> new_interfaces(encrypted_endpoint_mapping(:datastream, :object), acc, :list) end
       },
       {:other_interfaces,
@@ -320,7 +321,14 @@ defmodule Astarte.Cases.Device do
     )
     |> map(fn interface ->
       mapping = Enum.at(interface.mappings, 0)
-      mapping = %{mapping | endpoint: "/encryptedProperty", value_type: :string, encrypted: true}
+
+      mapping = %{
+        mapping
+        | endpoint: "/encryptedProperty",
+          value_type: :string,
+          encrypted: true,
+          allow_unset: true
+      }
 
       %{interface | mappings: [mapping]}
     end)
@@ -354,13 +362,32 @@ defmodule Astarte.Cases.Device do
 
     mapping_gen = MappingGenerator.mapping(common_mapping_params)
 
-    # generate two encrypted mappings
+    # generate two encrypted mappings and a non-encrypted one
     mappings =
-      StreamData.fixed_list([mapping_gen, mapping_gen])
-      |> map(fn [mapping_0, mapping_1] ->
-        mapping_0 = %{mapping_0 | endpoint: "/encryptedPath/endpoint0", encrypted: true}
-        mapping_1 = %{mapping_1 | endpoint: "/encryptedPath/endpoint1", encrypted: true}
-        [mapping_0, mapping_1]
+      StreamData.fixed_list([mapping_gen, mapping_gen, mapping_gen])
+      |> map(fn [mapping_0, mapping_1, mapping_2] ->
+        mapping_0 = %{
+          mapping_0
+          | endpoint: "/partiallyEncryptedPath/endpoint0",
+            value_type: :string,
+            encrypted: true
+        }
+
+        mapping_1 = %{
+          mapping_1
+          | endpoint: "/partiallyEncryptedPath/endpoint1",
+            value_type: :string,
+            encrypted: true
+        }
+
+        mapping_2 = %{
+          mapping_2
+          | endpoint: "/partiallyEncryptedPath/endpoint2",
+            value_type: :string,
+            encrypted: false
+        }
+
+        [mapping_0, mapping_1, mapping_2]
       end)
 
     InterfaceGenerator.interface(

--- a/apps/astarte_data_updater_plant/test/support/data_query_helper.ex
+++ b/apps/astarte_data_updater_plant/test/support/data_query_helper.ex
@@ -1,0 +1,134 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defmodule Astarte.DataUpdaterPlant.DataQueryHelper do
+  @moduledoc """
+  This module provides helper functions to query for values stored in db data tables
+  for the three interface types [properties, individual datastream, object datastream]
+  during DUP tests. Only retrieval of last data point is supported.
+  TODO consider to integrate this into DataAccess module.
+  """
+
+  alias Astarte.Core.CQLUtils
+  alias Astarte.Core.Interface
+  alias Astarte.DataAccess.Realms.IndividualDatastream
+  alias Astarte.DataAccess.Realms.IndividualProperty
+  alias Astarte.DataAccess.Repo
+
+  import Ecto.Query
+
+  @spec query_endpoint_data(
+          Interface.t(),
+          String.t(),
+          binary(),
+          String.t(),
+          :individual_datastream | :property
+        ) :: list(map())
+  def query_endpoint_data(interface, endpoint_path, device_id, keyspace, :property) do
+    interface_id = CQLUtils.interface_id(interface.name, interface.major_version)
+    endpoint_id = CQLUtils.endpoint_id(interface.name, interface.major_version, endpoint_path)
+
+    do_query_property(device_id, interface_id, endpoint_id, endpoint_path, keyspace)
+  end
+
+  def query_endpoint_data(interface, endpoint_path, device_id, keyspace, :individual_datastream) do
+    interface_id = CQLUtils.interface_id(interface.name, interface.major_version)
+    endpoint_id = CQLUtils.endpoint_id(interface.name, interface.major_version, endpoint_path)
+
+    do_query_individual_datastream(device_id, interface_id, endpoint_id, endpoint_path, keyspace)
+  end
+
+  @spec query_endpoint_data(
+          Interface.t(),
+          String.t(),
+          list(atom()),
+          binary(),
+          String.t(),
+          boolean(),
+          :object_datastream
+        ) :: list(map())
+  def query_endpoint_data(
+        interface,
+        common_endpoint_path,
+        endpoints,
+        device_id,
+        keyspace,
+        encrypted,
+        :object_datastream
+      ) do
+    interface_storage_id =
+      CQLUtils.interface_name_to_table_name(interface.name, interface.major_version)
+
+    columns_to_select = endpoints |> maybe_add_dek_column(encrypted)
+
+    do_query_object_datastream(
+      interface_storage_id,
+      device_id,
+      common_endpoint_path,
+      columns_to_select,
+      keyspace
+    )
+  end
+
+  defp do_query_property(device_id, interface_id, endpoint_id, path, keyspace) do
+    value_query_params =
+      from(i in IndividualProperty,
+        where:
+          i.device_id == ^device_id and
+            i.interface_id == ^interface_id and
+            i.endpoint_id == ^endpoint_id and
+            i.path == ^path
+      )
+
+    Repo.all(value_query_params, prefix: keyspace)
+  end
+
+  defp do_query_individual_datastream(device_id, interface_id, endpoint_id, path, keyspace) do
+    value_query_params =
+      from(i in IndividualDatastream,
+        where:
+          i.device_id == ^device_id and
+            i.interface_id == ^interface_id and
+            i.endpoint_id == ^endpoint_id and
+            i.path == ^path
+      )
+
+    Repo.all(value_query_params, prefix: keyspace)
+  end
+
+  defp do_query_object_datastream(interface_storage_id, device_id, path, columns, keyspace) do
+    value_query_params =
+      from(i in interface_storage_id,
+        where:
+          i.device_id == ^device_id and
+            i.path == ^path,
+        select: ^columns
+      )
+
+    Repo.all(value_query_params, prefix: keyspace)
+  end
+
+  defp maybe_add_dek_column(columns, encrypted) do
+    case encrypted do
+      true ->
+        columns ++ [:encrypted_dek]
+
+      _ ->
+        columns
+    end
+  end
+end

--- a/apps/astarte_data_updater_plant/test/support/database_test_helper.ex
+++ b/apps/astarte_data_updater_plant/test/support/database_test_helper.ex
@@ -227,6 +227,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
       stringarray_value list<varchar>,
       binaryblobarray_value list<blob>,
       datetimearray_value list<timestamp>,
+      encrypted_blob blob,
+      encrypted_dek blob,
 
       PRIMARY KEY((device_id, interface_id), endpoint_id, path)
     );
@@ -249,6 +251,8 @@ defmodule Astarte.DataUpdaterPlant.DatabaseTestHelper do
       datetimearray_value list<timestamp>,
       double_value double,
       doublearray_value list<double>,
+      encrypted_blob blob,
+      encrypted_dek blob,
       integer_value int,
       integerarray_value list<int>,
       longinteger_value bigint,

--- a/libs/astarte_data_access/lib/astarte_data_access/device.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/device.ex
@@ -396,6 +396,7 @@ defmodule Astarte.DataAccess.Device do
       value: value,
       value_timestamp: value_timestamp,
       reception_timestamp: reception_timestamp,
+      encrypted_endpoints: encrypted_endpoints,
       encrypted_dek: encrypted_dek,
       opts: opts
     } = context
@@ -441,13 +442,7 @@ defmodule Astarte.DataAccess.Device do
 
     object_value =
       compute_db_object_entries(column_info, value)
-
-    object_value =
-      if mapping |> Enum.any?(& &1.encrypted) do
-        add_encrypted_dek_to_object(object_value, encrypted_dek)
-      else
-        object_value
-      end
+      |> maybe_add_dek_to_object(encrypted_endpoints, encrypted_dek)
 
     insert_value = Map.merge(insert_params, object_value)
 
@@ -492,7 +487,12 @@ defmodule Astarte.DataAccess.Device do
     _ = Repo.delete_all(query, opts)
   end
 
-  defp add_encrypted_dek_to_object(object, dek) do
+  # add a column to contain the DEK if at least one endpoint of the object is encrypted
+  defp maybe_add_dek_to_object(object, [], _) do
+    object
+  end
+
+  defp maybe_add_dek_to_object(object, _endpoints, dek) do
     Map.put(object, "encrypted_dek", dek)
   end
 

--- a/libs/astarte_data_access/lib/astarte_data_access/device/insert_context.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/device/insert_context.ex
@@ -36,6 +36,7 @@ defmodule Astarte.DataAccess.Device.InsertContext do
     field :value, term()
     field :value_timestamp, non_neg_integer()
     field :reception_timestamp, non_neg_integer()
+    field :encrypted_endpoints, list(String.t()), default: []
     field :encrypted_dek, binary(), default: nil
     field :opts, keyword(), default: []
   end


### PR DESCRIPTION

Handle data payloads arriving on interfaces of all types re-encrypting them with a DEK and storing them in db along with the DEK that has been used (encrypted with realm KEK)

#### What this PR does / why we need it:

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Astarte development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.astarte-platform.org/astarte/snapshot/001-dev_guide.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
