### PR TITLE
chore(dup): init shared secret state machine

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -25,7 +25,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   alias Astarte.Core.Device
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.ExchangeResp
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SharedSecret
   alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.DataUpdaterPlant.DataUpdater.State
@@ -164,8 +166,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
 
     case InitExchange.decode(payload) do
-      # TODO: call send_exchange_resp/3 here and use the returned key pair
-      #       for the ECDH + HKDF shared-secret derivation step.
       {:ok, init_exchange} ->
         :telemetry.execute(
           [:astarte, :data_updater_plant, :control_handler, :key_agreement_init],
@@ -173,14 +173,26 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
           %{realm: new_state.realm}
         )
 
-        final_state = %{
-          new_state
-          | total_received_msgs: new_state.total_received_msgs + 1,
-            total_received_bytes: new_state.total_received_bytes + byte_size(payload),
-            active_key_type: init_exchange.key_type
-        }
+        # TODO: call send_exchange_resp/3 here and use the returned key pair
+        #       for the ECDH + HKDF shared-secret derivation step.
+        case HandshakeState.transition(
+               new_state.encrypted_endpoints_key,
+               {:receive_init, init_exchange}
+             ) do
+          {:ok, new_key_state} ->
+            final_state = %{
+              new_state
+              | total_received_msgs: new_state.total_received_msgs + 1,
+                total_received_bytes: new_state.total_received_bytes + byte_size(payload),
+                encrypted_endpoints_key: new_key_state
+            }
 
-        {:ack, :ok, final_state}
+            {:ack, :ok, final_state}
+
+          {:error, reason} ->
+            Logger.error("[keyAgreement] State machine transition failed: #{inspect(reason)}")
+            {:ack, :ok, new_state}
+        end
 
       {:error, reason} ->
         Logger.warning(
@@ -236,58 +248,80 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     Core.Error.handle_error(context, error)
   end
 
-  defp process_key_agreement(%{handshake_key_type: nil} = state, _payload, _timestamp) do
-    Logger.warning(
-      "[keyAgreement/1] Received ExchangeResp but no pending key exchange was found in state.",
-      tag: "key_agreement_resp_unexpected"
-    )
+  defp process_key_agreement(
+         %{encrypted_endpoints_key: {:handshake_started, data}} = state,
+         payload,
+         timestamp
+       ) do
+    with {:ok, exchange_resp} <- decode_exchange_resp(state, payload, timestamp, data.key_type),
+         {:ok, shared_secret} <- derive_shared_secret(state, data.init_exchange, exchange_resp),
+         {:ok, new_key_state} <- transition_key_agreement(state, shared_secret) do
+      :telemetry.execute(
+        [:astarte, :data_updater_plant, :control_handler, :key_agreement_resp],
+        %{payload_size: byte_size(payload)},
+        %{realm: state.realm}
+      )
 
-    # TODO: implement ExchangeFailed message
+      final_state = %{
+        state
+        | encrypted_endpoints_key: new_key_state,
+          total_received_msgs: state.total_received_msgs + 1,
+          total_received_bytes: state.total_received_bytes + byte_size(payload)
+      }
+
+      {:ack, :ok, final_state}
+    else
+      {:error, reason} ->
+        # TODO: Implement failedexchange message
+        Logger.warning("keyAgreement/1 failed, ignoring for now: #{inspect(reason)}")
+
+        # Fallback
+        {:ack, :ok, state}
+    end
+  end
+
+  defp process_key_agreement(state, _payload, _timestamp) do
+    Logger.warning("[keyAgreement/1] Unexpected response received.")
     {:ack, :ok, state}
   end
 
-  defp process_key_agreement(%{handshake_key_type: expected_key_type} = state, payload, timestamp) do
+  defp decode_exchange_resp(_state, payload, _timestamp, expected_key_type) do
     case ExchangeResp.cbor_decode(payload, expected_key_type) do
-      {:ok, _exchange_resp} ->
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :control_handler, :key_agreement_resp],
-          %{payload_size: byte_size(payload)},
-          %{realm: state.realm}
-        )
-
-        final_state = %{
-          state
-          | total_received_msgs: state.total_received_msgs + 1,
-            total_received_bytes: state.total_received_bytes + byte_size(payload),
-            handshake_key_type: nil,
-            active_key_type: expected_key_type
-        }
-
-        {:ack, :ok, final_state}
+      {:ok, exchange_resp} ->
+        {:ok, exchange_resp}
 
       {:error, reason} ->
-        Logger.warning(
-          "[keyAgreement/1] payload validation failed: #{inspect(reason)}",
-          tag: "key_agreement_resp_invalid_payload"
-        )
+        # TODO : implement ExchangeFailed message
+        {:error, reason}
+    end
+  end
 
-        context = %{
-          state: state,
-          payload: payload,
-          path: "/keyAgreement/1",
-          timestamp: timestamp
-        }
+  defp derive_shared_secret(_state, init_exchange, exchange_resp) do
+    case SharedSecret.derive(
+           init_exchange.public_key,
+           exchange_resp.public_key,
+           init_exchange.hkdf_salt
+         ) do
+      {:ok, shared_secret} ->
+        {:ok, shared_secret}
 
-        error = %{
-          message:
-            "Invalid keyAgreement/1 payload (#{inspect(reason)}): " <>
-              inspect(Base.encode64(payload)),
-          logger_metadata: [tag: "key_agreement_resp_error"],
-          error_name: "key_agreement_resp_error",
-          error: :key_agreement_resp_error
-        }
+      {:error, reason} ->
+        Logger.error("[keyAgreement/1] Derivation failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
 
-        Core.Error.handle_error(context, error)
+  defp transition_key_agreement(state, shared_secret) do
+    case HandshakeState.transition(
+           state.encrypted_endpoints_key,
+           {:handshake_completed, shared_secret}
+         ) do
+      {:ok, new_key_state} ->
+        {:ok, new_key_state}
+
+      {:error, reason} ->
+        Logger.error("[keyAgreement/1] State machine transition failed: #{inspect(reason)}")
+        {:error, reason}
     end
   end
 
@@ -304,13 +338,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   def send_init_exchange(state) do
     init_exchange = InitExchange.new()
 
-    with :ok <- publish_init_exchange(state.realm, state.device_id, init_exchange) do
-      updated_state = %{
-        state
-        | handshake_key_type: init_exchange.key_type
-      }
-
-      {:ok, updated_state}
+    with :ok <- publish_init_exchange(state.realm, state.device_id, init_exchange),
+         {:ok, new_key_state} <-
+           HandshakeState.transition(
+             state.encrypted_endpoints_key,
+             {:initiate_handshake, init_exchange}
+           ) do
+      {:ok, %{state | encrypted_endpoints_key: new_key_state}}
     end
   end
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/handshake_state.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/handshake_state.ex
@@ -1,0 +1,63 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState do
+  @moduledoc """
+  Pure state machine for Encrypted Endpoints Key Agreement protocol.
+  """
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
+
+  @type key_suite :: InitExchange.key_suite()
+
+  @type t ::
+          :uninitialized
+          | {:handshake_started, %{key_type: key_suite(), init_exchange: InitExchange.t()}}
+          | {:established, %{shared_secret: binary(), alg: key_suite()}}
+          | {:failed, reason :: term()}
+
+  @doc """
+  Pure transition function. Cryptographic derivation must be performed
+  externally by the caller.
+  """
+  @spec transition(t(), term()) :: {:ok, t()} | {:error, term()}
+
+  # Initiating a handshake (Astarte to Device)
+  def transition(:uninitialized, {:initiate_handshake, %InitExchange{} = msg}) do
+    {:ok, {:handshake_started, %{key_type: msg.key_type, init_exchange: msg}}}
+  end
+
+  # Receiving a handshake initiation (Device to Astarte)
+  def transition(:uninitialized, {:receive_init, %InitExchange{} = msg}) do
+    {:ok, {:handshake_started, %{key_type: msg.key_type, init_exchange: msg}}}
+  end
+
+  # Successful handshake completion (Result of SharedSecret.derive/3)
+  def transition({:handshake_started, %{key_type: alg}}, {:handshake_completed, shared_secret}) do
+    {:ok, {:established, %{shared_secret: shared_secret, alg: alg}}}
+  end
+
+  # Error transition
+  def transition(_current_state, {:error, reason}) do
+    {:ok, {:failed, reason}}
+  end
+
+  # Fallback for invalid protocol steps
+  def transition(_current_state, _event), do: {:error, :invalid_transition}
+end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2017 - 2025 SECO Mind Srl
+# Copyright 2017 - 2026 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.State do
   alias Astarte.Core.Triggers.SimpleTriggersProtobuf.AMQPTriggerTarget
   alias Astarte.DataUpdaterPlant.DataUpdater.Cache
   alias Astarte.DataUpdaterPlant.DataUpdater.CachedPath
-  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState
 
   @type interface_name :: String.t()
   @type policy_name :: String.t()
@@ -113,7 +113,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.State do
     field :last_deletion_in_progress_refresh, non_neg_integer(), default: 0
     field :last_datastream_maximum_retention_refresh, non_neg_integer(), default: 0
     field :capabilities, Capabilities.t(), default: %Capabilities{}
-    field :handshake_key_type, InitExchange.key_suite() | nil
-    field :active_key_type, InitExchange.key_suite() | nil
+    field :encrypted_endpoints_key, HandshakeState.t(), default: :uninitialized
   end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -322,7 +322,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
-      assert new_state.active_key_type == :ecdh_x25519_hkdf_sha256_aes_256_gcm
+
+      assert {:handshake_started, %{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
+               new_state.encrypted_endpoints_key
     end
 
     test "acks a valid CBOR InitExchange payload with a P-256 key", context do
@@ -333,7 +335,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
-      assert new_state.active_key_type == :ecdh_p256_hkdf_sha256_aes_256_gcm
+
+      assert {:handshake_started, %{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}} =
+               new_state.encrypted_endpoints_key
     end
 
     test "discards the message if discard_messages is set", context do
@@ -343,6 +347,30 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert {:discard, _result, ^state} =
                ControlHandler.handle_control(state, "/keyAgreement", <<1>>, 0)
+    end
+
+    test "logs an error and leaves the key-agreement state untouched if the state machine rejects the transition",
+         context do
+      %{state: state, init_exchange_payload: payload} = context
+
+      # Simulate a handshake that has already completed, so a fresh
+      # InitExchange from the device is no longer a valid transition
+      state = %{
+        state
+        | encrypted_endpoints_key:
+            {:established,
+             %{
+               shared_secret: :crypto.strong_rand_bytes(32),
+               alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm
+             }}
+      }
+
+      assert {{:ack, :ok, new_state}, log} =
+               with_log(fn ->
+                 ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+               end)
+
+      assert new_state.encrypted_endpoints_key == state.encrypted_endpoints_key
     end
   end
 
@@ -439,7 +467,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert {:ok, new_state} = ControlHandler.send_init_exchange(state)
 
-      assert new_state.handshake_key_type == :ecdh_x25519_hkdf_sha256_aes_256_gcm
+      assert {:handshake_started, %{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
+               new_state.encrypted_endpoints_key
     end
 
     test "returns {:error, :session_not_found} when the device has no active session",
@@ -467,54 +496,52 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
   describe "/keyAgreement/1" do
     test "acks a valid CBOR ExchangeResp payload and increments message counters",
          context do
-      %{state: state, exchange_resp_payload: payload} = context
+      %{state: state, exchange_resp_payload: payload, init_exchange: init_exchange} = context
 
-      # Inject the expected key_type into the state for validation
-      state = %{state | handshake_key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
+      # Inject the expected key agreement state for validation
+      state = %{
+        state
+        | encrypted_endpoints_key:
+            {:handshake_started,
+             %{
+               init_exchange: init_exchange,
+               key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm
+             }}
+      }
 
       assert {:ack, :ok, new_state} =
                ControlHandler.handle_control(state, "/keyAgreement/1", payload, 0)
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
-      assert new_state.handshake_key_type == nil
-      assert new_state.active_key_type == :ecdh_x25519_hkdf_sha256_aes_256_gcm
+
+      assert {:established, %{alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
+               new_state.encrypted_endpoints_key
     end
 
     test "acks a valid CBOR ExchangeResp payload with a P-256 key", context do
-      %{state: state, p256_exchange_resp_payload: payload} = context
+      %{state: state, p256_exchange_resp_payload: payload, p256_init_exchange: p256_init_exchange} =
+        context
 
-      # Inject the expected key_type into the state for validation
-      state = %{state | handshake_key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}
+      # Inject the expected key agreement state for validation
+      state = %{
+        state
+        | encrypted_endpoints_key:
+            {:handshake_started,
+             %{
+               init_exchange: p256_init_exchange,
+               key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm
+             }}
+      }
 
       assert {:ack, :ok, new_state} =
                ControlHandler.handle_control(state, "/keyAgreement/1", payload, 0)
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
-      assert new_state.handshake_key_type == nil
-      assert new_state.active_key_type == :ecdh_p256_hkdf_sha256_aes_256_gcm
-    end
 
-    test "discards an invalid ExchangeResp payload", context do
-      %{state: state, invalid_exchange_resp_payload: payload} = context
-
-      # Inject default expected key type so validation proceeds to the actual error
-      state = %{state | handshake_key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
-
-      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
-
-      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
-                                                              "key_agreement_resp_error",
-                                                              _meta,
-                                                              _ts ->
-        :ok
-      end)
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement/1", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+      assert {:established, %{alg: :ecdh_p256_hkdf_sha256_aes_256_gcm}} =
+               new_state.encrypted_endpoints_key
     end
 
     test "discards the message if discard_messages is set", context do


### PR DESCRIPTION
This PR aim to add the logic to calculate and preserve the shared secret in dup state for the cmmunication handshake between Astarte and a Device for the encrypted endpoints feature