### PR TITLE
feat(dup): persist shared secret

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
@@ -42,6 +42,7 @@ defmodule Astarte.AppEngine.API.Device.DeviceStatus do
     field :previous_interfaces, {:array, :map}
     field :groups, {:array, :string}
     field :deletion_in_progress, :boolean, default: false
+    field :shared_secret, :binary
   end
 
   @doc false

--- a/apps/astarte_appengine_api/test/support/helpers/database.ex
+++ b/apps/astarte_appengine_api/test/support/helpers/database.ex
@@ -136,6 +136,7 @@ defmodule Astarte.Helpers.Database do
         attributes map<varchar, varchar>,
         groups map<text, timeuuid>,
         capabilities capabilities,
+        shared_secret blob,
 
         PRIMARY KEY (device_id)
       );

--- a/apps/astarte_appengine_api/test/support/helpers/database_v2.ex
+++ b/apps/astarte_appengine_api/test/support/helpers/database_v2.ex
@@ -95,7 +95,7 @@ defmodule Astarte.Helpers.DatabaseV2 do
     last_seen_ip inet,
     attributes map<varchar, varchar>,
     capabilities capabilities,
-
+    shared_secret blob,
     groups map<text, timeuuid>,
 
     PRIMARY KEY (device_id)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/queries.ex
@@ -217,7 +217,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
         :total_received_bytes,
         :introspection,
         :exchanged_bytes_by_interface,
-        :exchanged_msgs_by_interface
+        :exchanged_msgs_by_interface,
+        :shared_secret
       ])
       |> put_query_prefix(keyspace_name)
       |> Repo.one(consistency: Consistency.device_info(:read))
@@ -233,7 +234,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
       total_received_msgs: stats.total_received_msgs,
       total_received_bytes: stats.total_received_bytes,
       initial_interface_exchanged_bytes: stats.exchanged_bytes_by_interface,
-      initial_interface_exchanged_msgs: stats.exchanged_msgs_by_interface
+      initial_interface_exchanged_msgs: stats.exchanged_msgs_by_interface,
+      shared_secret: stats.shared_secret
     }
   end
 
@@ -731,5 +733,17 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Queries do
       |> Map.take(nil_keys)
 
     Map.merge(capabilities, defaults)
+  end
+
+  def save_shared_secret(realm, device_id, shared_secret) do
+    keyspace_name = Realm.keyspace_name(realm)
+
+    device =
+      %Device{device_id: device_id}
+      |> Ecto.Changeset.change(%{shared_secret: shared_secret})
+
+    opts = [prefix: keyspace_name, consistency: Consistency.device_info(:write)]
+    Repo.update!(device, opts)
+    :ok
   end
 end

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
@@ -114,5 +114,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.State do
     field :last_datastream_maximum_retention_refresh, non_neg_integer(), default: 0
     field :capabilities, Capabilities.t(), default: %Capabilities{}
     field :encrypted_endpoints_key, HandshakeState.t(), default: :uninitialized
+    field :shared_secret, binary()
   end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
@@ -52,6 +52,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
   alias Astarte.DataAccess.Repo
   alias Astarte.DataUpdaterPlant.AMQPTestHelper
   alias Astarte.DataUpdaterPlant.DatabaseTestHelper
+  alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.Events.Triggers.Cache
 
   setup :verify_on_exit!
@@ -1620,6 +1621,33 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
 
     # The second disconnection trigger is not sent
     assert AMQPTestHelper.awaiting_messages_count(helper_name) == 0
+  end
+
+  test "the shared secret is loaded from the database when the data updater process comes up", %{
+    realm: realm,
+    helper_name: helper_name
+  } do
+    AMQPTestHelper.clean_queue(helper_name)
+    random_binary = :crypto.strong_rand_bytes(16)
+
+    encoded_device_id =
+      :crypto.strong_rand_bytes(16)
+      |> Base.url_encode64(padding: false)
+
+    {:ok, device_id} = Device.decode_device_id(encoded_device_id)
+
+    DatabaseTestHelper.insert_device(realm, device_id)
+
+    Queries.save_shared_secret(realm, device_id, random_binary)
+
+    handle_connection(
+      realm,
+      encoded_device_id,
+      "10.0.0.1",
+      make_timestamp("2017-12-09T14:00:32+00:00")
+    )
+
+    assert %{shared_secret: random_binary} = dump_state(realm, encoded_device_id)
   end
 
   defp generate_disconnection_trigger_data do

--- a/apps/astarte_pairing/test/support/helpers/database.ex
+++ b/apps/astarte_pairing/test/support/helpers/database.ex
@@ -151,6 +151,7 @@ defmodule Astarte.Helpers.Database do
     last_seen_ip inet,
     attributes map<varchar, varchar>,
     capabilities capabilities,
+    shared_secret blob,
 
     groups map<text, timeuuid>,
 

--- a/apps/astarte_realm_management/test/support/helpers/database.ex
+++ b/apps/astarte_realm_management/test/support/helpers/database.ex
@@ -95,6 +95,7 @@ defmodule Astarte.Helpers.Database do
     attributes map<varchar, varchar>,
     capabilities capabilities,
     groups map<text, timeuuid>,
+    shared_secret blob,
 
     PRIMARY KEY (device_id)
   )

--- a/apps/astarte_trigger_engine/test/support/helpers/database.ex
+++ b/apps/astarte_trigger_engine/test/support/helpers/database.ex
@@ -97,6 +97,7 @@ defmodule Astarte.Helpers.Database do
     attributes map<varchar, varchar>,
     capabilities capabilities,
     groups map<text, timeuuid>,
+    shared_secret blob,
 
     PRIMARY KEY (device_id)
   )

--- a/libs/astarte_data_access/lib/astarte_data_access/database/database.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/database/database.ex
@@ -63,7 +63,8 @@ defmodule Astarte.DataAccess.Database do
     {21, Migrations.Realm.CreateUnconfirmedDevices},
     {22, Migrations.Realm.AddEncryptedToIndividualProperties},
     {23, Migrations.Realm.AddEncryptedToIndividualDatastreams},
-    {24, Migrations.Realm.AddEncryptedToEndpoints}
+    {24, Migrations.Realm.AddEncryptedToEndpoints},
+    {25, Migrations.Realm.AddSharedSecretToDevice}
   ]
 
   @doc """

--- a/libs/astarte_data_access/lib/astarte_data_access/database/migrations/realm/0025_add_shared_secret_to_device.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/database/migrations/realm/0025_add_shared_secret_to_device.ex
@@ -1,0 +1,29 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.DataAccess.Database.Migrations.Realm.AddSharedSecretToDevice do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:devices) do
+      add :shared_secret, :binary
+    end
+  end
+end

--- a/libs/astarte_data_access/lib/astarte_data_access/devices/device.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/devices/device.ex
@@ -68,5 +68,6 @@ defmodule Astarte.DataAccess.Devices.Device do
     field :protocol_revision, :integer
     field :total_received_bytes, :integer
     field :total_received_msgs, :integer
+    field :shared_secret, :binary
   end
 end

--- a/libs/astarte_events/test/support/helpers/database_test_helper.ex
+++ b/libs/astarte_events/test/support/helpers/database_test_helper.ex
@@ -111,6 +111,7 @@ defmodule Astarte.Helpers.Database do
     capabilities capabilities,
 
     groups map<text, timeuuid>,
+    shared_secret blob,
 
     PRIMARY KEY (device_id)
   )

--- a/libs/astarte_fdo/test/support/helpers/database.ex
+++ b/libs/astarte_fdo/test/support/helpers/database.ex
@@ -156,6 +156,7 @@ defmodule Astarte.FDO.Helpers.Database do
     capabilities capabilities,
 
     groups map<text, timeuuid>,
+    shared_secret blob,
 
     PRIMARY KEY (device_id)
   )

--- a/libs/astarte_rpc/test/support/helpers/database.ex
+++ b/libs/astarte_rpc/test/support/helpers/database.ex
@@ -99,6 +99,7 @@ defmodule Astarte.RPC.Helpers.Database do
     capabilities capabilities,
 
     groups map<text, timeuuid>,
+    shared_secret blob,
 
     PRIMARY KEY (device_id)
   )

--- a/libs/astarte_test_suite/lib/astarte/test_suite/helpers/realm.ex
+++ b/libs/astarte_test_suite/lib/astarte/test_suite/helpers/realm.ex
@@ -177,6 +177,7 @@ defmodule Astarte.TestSuite.Helpers.Realm do
       last_seen_ip inet,
       attributes map<varchar, varchar>,
       groups map<text, timeuuid>,
+      shared_secret blob,
       PRIMARY KEY (device_id)
     );
     """


### PR DESCRIPTION
add functions and fields to persist shared secret in the db
