### PR TITLE
chore(dup): add SecretHash logic for Astarte-Device handshake

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -27,6 +27,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.ExchangeResp
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SecretHash
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SharedSecret
   alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
@@ -44,6 +45,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   * `/emptyCache` - Triggers a cache empty and interface properties resend.
   * `/keyAgreement` - Handles the InitExchange protocol (Device to Astarte direction).
   * `/keyAgreement/1` - Receives an ExchangeResp sent by the device when Astarte previously initiated a key-agreement handshake.
+  * `/keyAgreement/2` - Receives a SecretHash from the device to verify keys.
   """
   def handle_control(state, path, payload, timestamp)
 
@@ -226,6 +228,43 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     |> process_key_agreement(payload, timestamp)
   end
 
+  def handle_control(state, "/keyAgreement/2", payload, timestamp) do
+    new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
+
+    case SecretHash.cbor_decode(payload) do
+      {:ok, %SecretHash{seq_num: seq_num} = secret_hash_msg} ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_secret_hash],
+          %{payload_size: byte_size(payload)},
+          %{realm: new_state.realm}
+        )
+
+        process_secret_hash(new_state, seq_num, secret_hash_msg, payload, timestamp)
+
+      {:error, reason} ->
+        Logger.warning(
+          "[keyAgreement/2] payload validation failed: #{inspect(reason)}",
+          tag: "secret_hash_invalid_payload"
+        )
+
+        context = %{
+          state: new_state,
+          payload: payload,
+          path: "/keyAgreement/2",
+          timestamp: timestamp
+        }
+
+        error = %{
+          message: "Invalid SecretHash payload: #{inspect(Base.encode64(payload))}",
+          logger_metadata: [tag: "secret_hash_error"],
+          error_name: "secret_hash_error",
+          error: :secret_hash_error
+        }
+
+        Core.Error.handle_error(context, error)
+    end
+  end
+
   def handle_control(state, path, payload, timestamp) do
     # Track unexpected control messages
     :telemetry.execute(
@@ -246,6 +285,57 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     }
 
     Core.Error.handle_error(context, error)
+  end
+
+  defp process_secret_hash(state, _seq_num, secret_hash_msg, payload, _timestamp) do
+    case state.encrypted_endpoints_key do
+      {:established, %{shared_secret: shared_secret, alg: _alg}} ->
+        # Ask the module to verify itself
+        case SecretHash.verify(secret_hash_msg, shared_secret) do
+          :ok ->
+            # TODO: Implement HashOk (3) transmission here.
+            # For now, we acknowledge the valid hash and move on.
+            Logger.debug(
+              "[keyAgreement/2] SecretHash matches. Skipping HashOk transmission for now."
+            )
+
+            final_state = %{
+              state
+              | total_received_msgs: state.total_received_msgs + 1,
+                total_received_bytes: state.total_received_bytes + byte_size(payload)
+            }
+
+            {:ack, :ok, final_state}
+
+          {:error, :hash_mismatch} ->
+            Logger.warning("[keyAgreement/2] SecretHash mismatch. Renegotiating.")
+            # TODO: implement ExchangeFailed message
+            renegotiate_handshake(state, payload)
+        end
+
+      _ ->
+        Logger.warning("[keyAgreement/2] No shared secret established. Renegotiating.")
+        # TODO: implement ExchangeFailed message
+        renegotiate_handshake(state, payload)
+    end
+  end
+
+  defp renegotiate_handshake(state, payload) do
+    case send_init_exchange(state) do
+      {:ok, state_after_init} ->
+        final_state = %{
+          state_after_init
+          | total_received_msgs: state.total_received_msgs + 1,
+            total_received_bytes: state.total_received_bytes + byte_size(payload)
+        }
+
+        {:ack, :ok, final_state}
+
+      {:error, reason} ->
+        Logger.error("[keyAgreement/2] Failed to renegotiate key: #{inspect(reason)}")
+        # TODO: implement ExchangeFailed message
+        {:discard, reason, state}
+    end
   end
 
   defp process_key_agreement(

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/secret_hash.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/secret_hash.ex
@@ -40,7 +40,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SecretHash do
 
   typedstruct enforce: true do
     @typedoc "SecretHash key-agreement verification message."
-
     field :seq_num, non_neg_integer()
     field :key_hash, binary()
   end
@@ -98,4 +97,19 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SecretHash do
   # SHA256 output is exactly 32 bytes
   defp validate_hash_length(hash) when byte_size(hash) == 32, do: :ok
   defp validate_hash_length(_), do: {:error, :invalid_hash_length}
+
+  @doc """
+  Verifies if the received SecretHash matches the expected derived shared secret
+  using a constant-time comparison to prevent timing attacks.
+  """
+  @spec verify(t(), binary()) :: :ok | {:error, :hash_mismatch}
+  def verify(%SecretHash{key_hash: received_hash}, shared_secret) do
+    expected_hash = :crypto.hash(:sha256, shared_secret)
+
+    if :crypto.hash_equals(expected_hash, received_hash) do
+      :ok
+    else
+      {:error, :hash_mismatch}
+    end
+  end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -32,6 +32,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.ExchangeResp
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SecretHash
   alias Astarte.DataUpdaterPlant.DataUpdater.Impl
   alias Astarte.DataUpdaterPlant.DataUpdater.PayloadsDecoder
   alias Astarte.DataUpdaterPlant.RPC.VMQPlugin
@@ -128,6 +129,15 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
         }
       ])
 
+    # SecretHash payloads
+    shared_secret = :crypto.strong_rand_bytes(32)
+    valid_secret_hash = SecretHash.new(1, shared_secret)
+    valid_secret_hash_payload = SecretHash.cbor_encode(valid_secret_hash)
+
+    # Hash derived from a different random secret to simulate a mismatch
+    invalid_secret_hash = %SecretHash{seq_num: 1, key_hash: :crypto.strong_rand_bytes(32)}
+    invalid_secret_hash_payload = SecretHash.cbor_encode(invalid_secret_hash)
+
     %{
       init_exchange: init_exchange,
       init_exchange_payload: init_exchange_payload,
@@ -139,7 +149,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       wrong_okp_key_payload: wrong_okp_key_payload,
       wrong_hkdf_salt_payload: wrong_hkdf_salt_payload,
       wrong_nonce_payload: wrong_nonce_payload,
-      invalid_exchange_resp_payload: invalid_exchange_resp_payload
+      invalid_exchange_resp_payload: invalid_exchange_resp_payload,
+      shared_secret: shared_secret,
+      valid_secret_hash_payload: valid_secret_hash_payload,
+      invalid_secret_hash_payload: invalid_secret_hash_payload
     }
   end
 
@@ -611,6 +624,105 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert {:error, :transport_failure} =
                ControlHandler.send_exchange_resp(realm, device_id, init_exchange)
+    end
+  end
+
+  describe "/keyAgreement/2 (SecretHash)" do
+    test "acks a valid SecretHash payload when hashes match", context do
+      %{
+        state: state,
+        valid_secret_hash_payload: payload,
+        shared_secret: shared_secret
+      } = context
+
+      # Inject the expected established key state
+      state = %{
+        state
+        | encrypted_endpoints_key:
+            {:established,
+             %{
+               shared_secret: shared_secret,
+               alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm
+             }}
+      }
+
+      assert {:ack, :ok, new_state} =
+               ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+
+      assert new_state.total_received_msgs == state.total_received_msgs + 1
+      assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
+
+      # The state should remain untouched
+      assert {:established, _} = new_state.encrypted_endpoints_key
+    end
+
+    test "renegotiates if hashes mismatch", context do
+      %{
+        state: state,
+        invalid_secret_hash_payload: payload,
+        shared_secret: shared_secret
+      } = context
+
+      state = %{
+        state
+        | encrypted_endpoints_key:
+            {:established,
+             %{
+               shared_secret: shared_secret,
+               alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm
+             }}
+      }
+
+      # Expect 1 publish (the InitExchange renegotiation fallback)
+      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
+        {:ok, %{local_matches: 1, remote_matches: 0}}
+      end)
+
+      assert {:ack, :ok, new_state} =
+               ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+
+      # Ensure it correctly fell back and overwrote the :established state with a new handshake
+      assert {:handshake_started, _} = new_state.encrypted_endpoints_key
+      assert new_state.total_received_msgs == state.total_received_msgs + 1
+    end
+
+    test "renegotiates if no shared secret is established", context do
+      %{state: state, valid_secret_hash_payload: payload} = context
+
+      # state.encrypted_endpoints_key is :uninitialized by default here
+
+      # Expect 1 publish (the InitExchange renegotiation fallback)
+      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
+        {:ok, %{local_matches: 1, remote_matches: 0}}
+      end)
+
+      assert {:ack, :ok, new_state} =
+               ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+
+      # Ensure it started a new handshake
+      assert {:handshake_started, _} = new_state.encrypted_endpoints_key
+      assert new_state.total_received_msgs == state.total_received_msgs + 1
+    end
+
+    test "discards payload and logs an error if the CBOR structure is invalid", context do
+      %{state: state} = context
+
+      # Corrupted/invalid payload
+      payload = <<0xFF, 0xFE, 0x00>>
+
+      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
+
+      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
+                                                              "secret_hash_error",
+                                                              _meta,
+                                                              _ts ->
+        :ok
+      end)
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end
   end
 end


### PR DESCRIPTION
This PR aim to add control handler logic for the SecretHash message of the Device-Astarte handshake for the Encrypted Endpoints feature