### PR TITLE
chore(dup): add HashOk logic for Astarte-Device handshake

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -26,6 +26,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.ExchangeResp
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOk
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SecretHash
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SharedSecret
@@ -46,6 +47,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   * `/keyAgreement` - Handles the InitExchange protocol (Device to Astarte direction).
   * `/keyAgreement/1` - Receives an ExchangeResp sent by the device when Astarte previously initiated a key-agreement handshake.
   * `/keyAgreement/2` - Receives a SecretHash from the device to verify keys.
+  * `/keyAgreement/3` - Receives a HashOk from the device confirming the key verification.
   """
   def handle_control(state, path, payload, timestamp)
 
@@ -193,7 +195,22 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
 
           {:error, reason} ->
             Logger.error("[keyAgreement] State machine transition failed: #{inspect(reason)}")
-            {:ack, :ok, new_state}
+
+            context = %{
+              state: new_state,
+              payload: payload,
+              path: "/keyAgreement",
+              timestamp: timestamp
+            }
+
+            error = %{
+              message: "keyAgreement state machine transition failed: #{inspect(reason)}",
+              logger_metadata: [tag: "key_agreement_transition_error"],
+              error_name: "key_agreement_transition_error",
+              error: :key_agreement_transition_error
+            }
+
+            Core.Error.handle_error(context, error)
         end
 
       {:error, reason} ->
@@ -265,6 +282,73 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     end
   end
 
+  def handle_control(state, "/keyAgreement/3", payload, timestamp) do
+    new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
+
+    case HashOk.cbor_decode(payload) do
+      {:ok, %HashOk{}} ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_hash_ok],
+          %{payload_size: byte_size(payload)},
+          %{realm: new_state.realm}
+        )
+
+        # Execute the state transition
+        case HandshakeState.transition(new_state.encrypted_endpoints_key, :secret_reconfirmed) do
+          {:ok, new_key_state} ->
+            final_state = %{
+              new_state
+              | encrypted_endpoints_key: new_key_state,
+                total_received_msgs: new_state.total_received_msgs + 1,
+                total_received_bytes: new_state.total_received_bytes + byte_size(payload)
+            }
+
+            {:ack, :ok, final_state}
+
+          {:error, reason} ->
+            Logger.error("[keyAgreement/3] State transition failed: #{inspect(reason)}")
+
+            context = %{
+              state: new_state,
+              payload: payload,
+              path: "/keyAgreement/3",
+              timestamp: timestamp
+            }
+
+            error = %{
+              message: "keyAgreement/3 state machine transition failed: #{inspect(reason)}",
+              logger_metadata: [tag: "key_agreement_transition_error"],
+              error_name: "key_agreement_transition_error",
+              error: :key_agreement_transition_error
+            }
+
+            Core.Error.handle_error(context, error)
+        end
+
+      {:error, reason} ->
+        Logger.warning(
+          "[keyAgreement/3] payload validation failed: #{inspect(reason)}",
+          tag: "hash_ok_invalid_payload"
+        )
+
+        context = %{
+          state: new_state,
+          payload: payload,
+          path: "/keyAgreement/3",
+          timestamp: timestamp
+        }
+
+        error = %{
+          message: "Invalid HashOk payload: #{inspect(Base.encode64(payload))}",
+          logger_metadata: [tag: "hash_ok_error"],
+          error_name: "hash_ok_error",
+          error: :hash_ok_error
+        }
+
+        Core.Error.handle_error(context, error)
+    end
+  end
+
   def handle_control(state, path, payload, timestamp) do
     # Track unexpected control messages
     :telemetry.execute(
@@ -287,36 +371,53 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     Core.Error.handle_error(context, error)
   end
 
-  defp process_secret_hash(state, _seq_num, secret_hash_msg, payload, _timestamp) do
-    case state.encrypted_endpoints_key do
-      {:established, %{shared_secret: shared_secret, alg: _alg}} ->
-        # Ask the module to verify itself
-        case SecretHash.verify(secret_hash_msg, shared_secret) do
-          :ok ->
-            # TODO: Implement HashOk (3) transmission here.
-            # For now, we acknowledge the valid hash and move on.
-            Logger.debug(
-              "[keyAgreement/2] SecretHash matches. Skipping HashOk transmission for now."
-            )
+  defp process_secret_hash(
+         %{encrypted_endpoints_key: {:established, %{shared_secret: shared_secret, alg: alg}}} =
+           state,
+         _seq_num,
+         secret_hash_msg,
+         payload,
+         _timestamp
+       ) do
+    state
+    |> confirm_secret_hash(secret_hash_msg, shared_secret, alg)
+    |> case do
+      {:ok, new_key_state} ->
+        final_state = %{
+          state
+          | encrypted_endpoints_key: new_key_state,
+            total_received_msgs: state.total_received_msgs + 1,
+            total_received_bytes: state.total_received_bytes + byte_size(payload)
+        }
 
-            final_state = %{
-              state
-              | total_received_msgs: state.total_received_msgs + 1,
-                total_received_bytes: state.total_received_bytes + byte_size(payload)
-            }
+        {:ack, :ok, final_state}
 
-            {:ack, :ok, final_state}
-
-          {:error, :hash_mismatch} ->
-            Logger.warning("[keyAgreement/2] SecretHash mismatch. Renegotiating.")
-            # TODO: implement ExchangeFailed message
-            renegotiate_handshake(state, payload)
-        end
-
-      _ ->
-        Logger.warning("[keyAgreement/2] No shared secret established. Renegotiating.")
+      {:error, :hash_mismatch} ->
+        Logger.warning("[keyAgreement/2] SecretHash mismatch. Renegotiating.")
         # TODO: implement ExchangeFailed message
         renegotiate_handshake(state, payload)
+
+      {:error, reason} ->
+        Logger.error("[keyAgreement/2] Failed to process SecretHash: #{inspect(reason)}")
+        # TODO: implement ExchangeFailed message
+        {:ack, :ok, state}
+    end
+  end
+
+  defp process_secret_hash(state, _seq_num, _secret_hash_msg, payload, _timestamp) do
+    Logger.warning("[keyAgreement/2] No shared secret established. Renegotiating.")
+    # TODO: implement ExchangeFailed message
+    renegotiate_handshake(state, payload)
+  end
+
+  defp confirm_secret_hash(state, secret_hash_msg, shared_secret, alg) do
+    with :ok <- SecretHash.verify(secret_hash_msg, shared_secret),
+         {:ok, new_key_state} <-
+           HandshakeState.transition(state.encrypted_endpoints_key, :secret_reconfirmed) do
+      case send_hash_ok(state.realm, state.device_id, alg) do
+        :ok -> {:ok, new_key_state}
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 
@@ -435,6 +536,53 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
              {:initiate_handshake, init_exchange}
            ) do
       {:ok, %{state | encrypted_endpoints_key: new_key_state}}
+    end
+  end
+
+  defp send_hash_ok(realm, device_id, alg) do
+    topic = "#{realm}/#{Device.encode_device_id(device_id)}/control/keyAgreement/3"
+
+    hash_ok = %HashOk{key_type: alg}
+    payload = HashOk.cbor_encode(hash_ok)
+
+    publish_start = System.monotonic_time()
+
+    case VMQPlugin.publish(topic, payload, 2) do
+      {:ok, %{local_matches: local, remote_matches: remote}} when local + remote >= 1 ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_hash_ok_send],
+          %{
+            duration: System.monotonic_time() - publish_start,
+            payload_size: byte_size(payload)
+          },
+          %{realm: realm, result: "success"}
+        )
+
+        :ok
+
+      {:ok, %{local_matches: 0, remote_matches: 0}} ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_hash_ok_send],
+          %{
+            duration: System.monotonic_time() - publish_start,
+            payload_size: byte_size(payload)
+          },
+          %{realm: realm, result: "no_matches"}
+        )
+
+        {:error, :session_not_found}
+
+      {:error, reason} ->
+        :telemetry.execute(
+          [:astarte, :data_updater_plant, :control_handler, :key_agreement_hash_ok_send],
+          %{
+            duration: System.monotonic_time() - publish_start,
+            payload_size: byte_size(payload)
+          },
+          %{realm: realm, result: "error"}
+        )
+
+        {:error, reason}
     end
   end
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/handshake_state.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/handshake_state.ex
@@ -24,30 +24,21 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState 
 
   ## States
 
-  * `:uninitialized` — no handshake has been attempted (initial state or post-reset).
-  * `{:handshake_started, data}` — one side sent/received `InitExchange`; waiting
-    for `ExchangeResp` and ECDH derivation.
-  * `{:established, data}` — shared secret successfully derived; encrypted traffic
-    may flow.
-  * `{:failed, reason}` — the handshake failed; caller must reset or re-initiate.
+  * `:uninitialized` — No handshake attempted (initial state or post-reset).
+  * `{:handshake_started, data}` — `InitExchange` exchanged; awaiting `ExchangeResp` and derivation.
+  * `{:established, data}` — Shared secret derived; ready for encrypted traffic.
+  * `{:failed, reason}` — Handshake failed; requires reset or re-initiation.
 
   ## Valid transitions
 
-  | Current state          | Event                             | Next state            |
-  |------------------------|-----------------------------------|-----------------------|
-  | any                    | `:reset`                          | `:uninitialized`      |
-  | any                    | `{:initiate_handshake, msg}`      | `:handshake_started`  |
-  | `:uninitialized`       | `{:receive_init, msg}`            | `:handshake_started`  |
-  | `{:handshake_started}` | `{:receive_init, msg}`            | `:handshake_started`  |
-  | `{:failed, _}`         | `{:receive_init, msg}`            | `:handshake_started`  |
-  | `{:handshake_started}` | `{:handshake_completed, secret}`  | `:established`        |
-  | any                    | `{:error, reason}`                | `{:failed, reason}`   |
-
-  Note that `{:receive_init, msg}` is intentionally **not** valid from
-  `:established`. When a device sends a fresh `InitExchange` while a secret
-  is already in place, the handler must decide whether to re-key; the state
-  machine must not advance until `send_exchange_resp/3` has actually been
-  called and the new exchange is committed.
+  | Current state                                     | Event                             | Next state           |
+  |---------------------------------------------------|-----------------------------------|----------------------|
+  | any                                               | `:reset`                          | `:uninitialized`     |
+  | any                                               | `{:initiate_handshake, msg}`      | `:handshake_started` |
+  | `:uninitialized`, `:handshake_started`, `:failed` | `{:receive_init, msg}`            | `:handshake_started` |
+  | `:handshake_started`                              | `{:handshake_completed, secret}`  | `:established`       |
+  | `:established`                                    | `:secret_reconfirmed`             | `:established`       |
+  | any                                               | `{:error, reason}`                | `{:failed, reason}`  |
   """
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
 
@@ -109,6 +100,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState 
       )
       when is_binary(shared_secret) do
     {:ok, {:established, %{shared_secret: shared_secret, alg: alg}}}
+  end
+
+  # SecretHash successfully verified while already established
+  def transition({:established, data}, :secret_reconfirmed) do
+    {:ok, {:established, data}}
   end
 
   # Error transition

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok.ex
@@ -1,0 +1,75 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOk do
+  @moduledoc """
+  Represents the HashOk (type 3) key-agreement message published on the
+  `<realm>/<device>/control/keyAgreement/3` MQTT control topic.
+
+  It carries the internal key-suite atom which is cast to and from an integer
+  for CBOR encoding using `InitExchange.supported_key_suites()`.
+  """
+
+  use TypedStruct
+
+  alias __MODULE__, as: HashOk
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
+
+  typedstruct enforce: true do
+    @typedoc "HashOk acknowledgement message containing the key-suite algorithm atom."
+    field :key_type, InitExchange.key_suite()
+  end
+
+  @doc """
+  Returns the list representation of a `%HashOk{}` ready for CBOR encoding.
+  """
+  @spec encode(t()) :: list()
+  def encode(%HashOk{} = msg) do
+    {:ok, key_type_id} = Ecto.Type.dump(InitExchange.supported_key_suites(), msg.key_type)
+    [key_type_id]
+  end
+
+  @doc """
+  CBOR-encodes a `%HashOk{}` for transmission.
+  """
+  @spec cbor_encode(t()) :: binary()
+  def cbor_encode(%HashOk{} = msg), do: msg |> encode() |> CBOR.encode()
+
+  @doc """
+  Decodes and validates a raw CBOR payload received on the
+  `control/keyAgreement/3` topic.
+  """
+  @spec cbor_decode(binary()) :: {:ok, t()} | {:error, :invalid_payload}
+  def cbor_decode(payload) when is_binary(payload) do
+    case CBOR.decode(payload) do
+      {:ok, raw, _rest} -> decode(raw)
+      {:error, _reason} -> {:error, :invalid_payload}
+    end
+  end
+
+  defp decode([key_type]) when is_integer(key_type) and key_type >= 0 do
+    case Ecto.Type.cast(InitExchange.supported_key_suites(), key_type) do
+      {:ok, suite} -> {:ok, %HashOk{key_type: suite}}
+      _ -> {:error, :invalid_payload}
+    end
+  end
+
+  defp decode(_), do: {:error, :invalid_payload}
+end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -31,6 +31,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
   alias Astarte.DataUpdaterPlant.DataUpdater.Core
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.ExchangeResp
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOk
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.SecretHash
   alias Astarte.DataUpdaterPlant.DataUpdater.Impl
@@ -627,24 +628,38 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     end
   end
 
-  describe "/keyAgreement/2 (SecretHash)" do
-    test "acks a valid SecretHash payload when hashes match", context do
+  describe "/keyAgreement/2" do
+    setup context do
+      established_key_state =
+        {:established,
+         %{
+           shared_secret: context.shared_secret,
+           alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm
+         }}
+
+      established_state = %{context.state | encrypted_endpoints_key: established_key_state}
+
+      %{established_state: established_state}
+    end
+
+    test "acks a valid SecretHash payload and sends HashOk when hashes match", context do
       %{
-        state: state,
-        valid_secret_hash_payload: payload,
-        shared_secret: shared_secret
+        established_state: state,
+        valid_secret_hash_payload: payload
       } = context
 
-      # Inject the expected established key state
-      state = %{
-        state
-        | encrypted_endpoints_key:
-            {:established,
-             %{
-               shared_secret: shared_secret,
-               alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm
-             }}
-      }
+      # Expect exactly 1 publish for the HashOk message
+      expect(VMQPlugin, :publish, 1, fn topic, payload_bytes, qos ->
+        encoded_device_id = Astarte.Core.Device.encode_device_id(state.device_id)
+
+        assert topic == "#{state.realm}/#{encoded_device_id}/control/keyAgreement/3"
+        assert qos == 2
+
+        # Assert the HashOk payload correctly encoded the algorithm to 0
+        assert {:ok, [0], ""} = CBOR.decode(payload_bytes)
+
+        {:ok, %{local_matches: 1, remote_matches: 0}}
+      end)
 
       assert {:ack, :ok, new_state} =
                ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
@@ -658,20 +673,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
     test "renegotiates if hashes mismatch", context do
       %{
-        state: state,
-        invalid_secret_hash_payload: payload,
-        shared_secret: shared_secret
+        established_state: state,
+        invalid_secret_hash_payload: payload
       } = context
-
-      state = %{
-        state
-        | encrypted_endpoints_key:
-            {:established,
-             %{
-               shared_secret: shared_secret,
-               alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm
-             }}
-      }
 
       # Expect 1 publish (the InitExchange renegotiation fallback)
       expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
@@ -721,6 +725,139 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
       assert {:discard, _result, new_state, {:continue, continue_arg}} =
                ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+
+      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
+    end
+
+    test "logs error and acks message if sending HashOk fails", context do
+      %{
+        established_state: state,
+        valid_secret_hash_payload: payload
+      } = context
+
+      # Mock publish failure
+      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
+        {:error, :transport_failure}
+      end)
+
+      assert {{:ack, :ok, ^state}, log} =
+               with_log(fn ->
+                 ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+               end)
+
+      assert log =~ "Failed to process SecretHash: :transport_failure"
+    end
+
+    test "logs error and acks message if sending HashOk fails due to missing session", context do
+      %{
+        established_state: state,
+        valid_secret_hash_payload: payload
+      } = context
+
+      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
+        {:ok, %{local_matches: 0, remote_matches: 0}}
+      end)
+
+      assert {{:ack, :ok, ^state}, log} =
+               with_log(fn ->
+                 ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+               end)
+
+      assert log =~ "Failed to process SecretHash: :session_not_found"
+    end
+
+    test "discards message and logs error if renegotiation fails", context do
+      %{state: state, valid_secret_hash_payload: payload} = context
+
+      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
+        {:error, :transport_failure}
+      end)
+
+      assert {{:discard, :transport_failure, ^state}, log} =
+               with_log(fn ->
+                 ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+               end)
+
+      assert log =~ "Failed to renegotiate key: :transport_failure"
+    end
+
+    test "discards message and logs error if renegotiation fails due to missing session",
+         context do
+      %{state: state, valid_secret_hash_payload: payload} = context
+
+      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
+        {:ok, %{local_matches: 0, remote_matches: 0}}
+      end)
+
+      assert {{:discard, :session_not_found, ^state}, log} =
+               with_log(fn ->
+                 ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
+               end)
+
+      assert log =~ "Failed to renegotiate key: :session_not_found"
+    end
+  end
+
+  describe "/keyAgreement/3" do
+    setup do
+      valid_hash_ok = %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
+      valid_hash_ok_payload = HashOk.cbor_encode(valid_hash_ok)
+      invalid_hash_ok_payload = CBOR.encode([99])
+
+      %{
+        valid_hash_ok_payload: valid_hash_ok_payload,
+        invalid_hash_ok_payload: invalid_hash_ok_payload
+      }
+    end
+
+    test "acks a valid HashOk payload, updates state, and increments message counters", context do
+      %{state: state, valid_hash_ok_payload: payload} = context
+
+      # Inject the expected established key state before receiving HashOk
+      established_state = %{
+        state
+        | encrypted_endpoints_key:
+            {:established,
+             %{
+               shared_secret: :crypto.strong_rand_bytes(32),
+               alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm
+             }}
+      }
+
+      assert {:ack, :ok, new_state} =
+               ControlHandler.handle_control(established_state, "/keyAgreement/3", payload, 0)
+
+      # Ensure it correctly transitioned/stayed in the established state
+      assert {:established, _} = new_state.encrypted_endpoints_key
+      assert new_state.total_received_msgs == established_state.total_received_msgs + 1
+
+      assert new_state.total_received_bytes ==
+               established_state.total_received_bytes + byte_size(payload)
+    end
+
+    test "discards the message if discard_messages is set", context do
+      %{state: state, valid_hash_ok_payload: payload} = context
+
+      state = %{state | discard_messages: true}
+
+      assert {:discard, :discard_messages, ^state} =
+               ControlHandler.handle_control(state, "/keyAgreement/3", payload, 0)
+    end
+
+    test "discards payload and logs an error if the CBOR structure is invalid", context do
+      %{state: state, invalid_hash_ok_payload: payload} = context
+
+      expect(Core.Device, :ask_clean_session, fn _state, _ts -> {:ok, state} end)
+
+      expect(Core.Trigger, :execute_device_error_triggers, fn _state,
+                                                              "hash_ok_error",
+                                                              _meta,
+                                                              _ts ->
+        :ok
+      end)
+
+      assert {:discard, _result, new_state, {:continue, continue_arg}} =
+               ControlHandler.handle_control(state, "/keyAgreement/3", payload, 0)
 
       assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok_test.exs
@@ -1,0 +1,84 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOkTest do
+  use ExUnit.Case, async: true
+
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOk
+
+  describe "encode/1" do
+    test "returns a single-element list with the integer mapped from InitExchange" do
+      # According to InitExchange.supported_key_suites(), x25519 is 0, p256 is 1
+      msg_x25519 = %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
+      assert HashOk.encode(msg_x25519) == [0]
+
+      msg_p256 = %HashOk{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}
+      assert HashOk.encode(msg_p256) == [1]
+    end
+  end
+
+  describe "cbor_encode/1" do
+    test "encodes the struct into a valid CBOR binary" do
+      msg = %HashOk{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}
+      encoded = HashOk.cbor_encode(msg)
+
+      assert is_binary(encoded)
+      assert {:ok, [1], ""} = CBOR.decode(encoded)
+    end
+  end
+
+  describe "cbor_decode/1" do
+    test "successfully decodes a valid CBOR payload to the correct atom" do
+      payload_x25519 = CBOR.encode([0])
+
+      assert {:ok, %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
+               HashOk.cbor_decode(payload_x25519)
+
+      payload_p256 = CBOR.encode([1])
+
+      assert {:ok, %HashOk{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}} =
+               HashOk.cbor_decode(payload_p256)
+    end
+
+    test "returns error for valid CBOR with unknown algorithm code" do
+      unknown_alg_payload = CBOR.encode([99])
+      assert {:error, :invalid_payload} = HashOk.cbor_decode(unknown_alg_payload)
+    end
+
+    test "returns error for valid CBOR with invalid inner structure" do
+      invalid_payloads = [
+        CBOR.encode("not a list"),
+        CBOR.encode([]),
+        CBOR.encode([-1]),
+        CBOR.encode(["string"]),
+        CBOR.encode([1, 2])
+      ]
+
+      for payload <- invalid_payloads do
+        assert {:error, :invalid_payload} = HashOk.cbor_decode(payload)
+      end
+    end
+
+    test "returns error for invalid malformed CBOR binary" do
+      invalid_cbor = <<0xFF>>
+      assert {:error, :invalid_payload} = HashOk.cbor_decode(invalid_cbor)
+    end
+  end
+end


### PR DESCRIPTION
This PR aim to add the message structure and control handler logic for the HashOk message of the Device-Astarte handshake for the Encrypted Endpoints feature