### PR TITLE
chore(dup): add send exchange response and shared secret derivation calls flow

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -177,20 +177,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
           %{realm: new_state.realm}
         )
 
-        # TODO: call send_exchange_resp/3 here and use the returned key pair
-        #       for the ECDH + HKDF shared-secret derivation step.
-        case HandshakeState.transition(
-               new_state.encrypted_endpoints_key,
-               {:receive_init, init_exchange}
-             ) do
-          {:ok, new_key_state} ->
-            final_state = %{
-              new_state
-              | total_received_msgs: new_state.total_received_msgs + 1,
-                total_received_bytes: new_state.total_received_bytes + byte_size(payload),
-                encrypted_endpoints_key: new_key_state
-            }
-
+        case perform_key_agreement(new_state, init_exchange, payload) do
+          {:ok, final_state} ->
             {:ack, :ok, final_state}
 
           {:error, reason} ->
@@ -369,6 +357,36 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     }
 
     Core.Error.handle_error(context, error)
+  end
+
+  defp perform_key_agreement(new_state, init_exchange, payload) do
+    with {:ok, state_after_receive} <-
+           HandshakeState.transition(
+             new_state.encrypted_endpoints_key,
+             {:receive_init, init_exchange}
+           ),
+         {:ok, exchange_resp} <-
+           send_exchange_resp(new_state.realm, new_state.device_id, init_exchange),
+         {:ok, shared_secret} <-
+           SharedSecret.derive(
+             exchange_resp.public_key,
+             init_exchange.public_key,
+             init_exchange.hkdf_salt
+           ),
+         {:ok, established_key_state} <-
+           HandshakeState.transition(
+             state_after_receive,
+             {:handshake_completed, shared_secret}
+           ) do
+      final_state = %{
+        new_state
+        | total_received_msgs: new_state.total_received_msgs + 1,
+          total_received_bytes: new_state.total_received_bytes + byte_size(payload),
+          encrypted_endpoints_key: established_key_state
+      }
+
+      {:ok, final_state}
+    end
   end
 
   defp process_secret_hash(

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/handshake_state.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/handshake_state.ex
@@ -42,6 +42,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState 
   """
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
 
+  require Logger
+
   @type key_suite :: InitExchange.key_suite()
 
   @type handshake_data :: %{
@@ -113,5 +115,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState 
   end
 
   # Fallback for invalid protocol steps
-  def transition(_current_state, _event), do: {:error, :invalid_transition}
+  def transition(current_state, event) do
+    Logger.warning(
+      "Handshake: tried to transition with event #{inspect(event)} from state #{inspect(current_state)}"
+    )
+
+    {:error, :invalid_transition}
+  end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -331,26 +331,44 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
          context do
       %{state: state, init_exchange_payload: payload} = context
 
+      expect(VMQPlugin, :publish, 1, fn topic, _payload_bytes, qos ->
+        encoded_device_id = Astarte.Core.Device.encode_device_id(state.device_id)
+
+        assert topic == "#{state.realm}/#{encoded_device_id}/control/keyAgreement/1"
+        assert qos == 2
+
+        {:ok, %{local_matches: 1, remote_matches: 0}}
+      end)
+
       assert {:ack, :ok, new_state} =
                ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
 
-      assert {:handshake_started, %{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
+      assert {:established, %{alg: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
                new_state.encrypted_endpoints_key
     end
 
     test "acks a valid CBOR InitExchange payload with a P-256 key", context do
       %{state: state, p256_init_exchange_payload: payload} = context
 
+      expect(VMQPlugin, :publish, 1, fn topic, _payload_bytes, qos ->
+        encoded_device_id = Astarte.Core.Device.encode_device_id(state.device_id)
+
+        assert topic == "#{state.realm}/#{encoded_device_id}/control/keyAgreement/1"
+        assert qos == 2
+
+        {:ok, %{local_matches: 1, remote_matches: 0}}
+      end)
+
       assert {:ack, :ok, new_state} =
                ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
 
-      assert {:handshake_started, %{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}} =
+      assert {:established, %{alg: :ecdh_p256_hkdf_sha256_aes_256_gcm}} =
                new_state.encrypted_endpoints_key
     end
 


### PR DESCRIPTION
This PR aim to add the send_exchange_resp call and use the returned key pair for the ECDH + HKDF shared-secret derivation step in dup control handler for the encrypted endpoints feature