### PR TITLE
fix(housekeeping): gate readiness probe on keyspace initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [astarte_housekeeping] Added HOUSEKEEPING_DEFAULT_DATASTREAM_MAXIMUM_STORAGE_RETENTION to set default, instance wise, realm default realm data retention, expressed in seconds
 
+### Fixed
+
+- [astarte_housekeeping] The `/health` readiness probe now reports ready only once the `astarte` keyspace replication has been initialized, so realm creation no longer fails intermittently right after a pod reports ready.
+
 ## [1.3.0] - 2026-05-06
 
 ### Changed

--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/health.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/health.ex
@@ -23,6 +23,7 @@ defmodule Astarte.Housekeeping.Health do
 
   alias Astarte.DataAccess.Health, as: DatabaseHealth
   alias Astarte.Housekeeping.Health
+  alias Astarte.Housekeeping.Realms.Queries
 
   @doc """
   Gets the backend health, and raises if it's not healthy.
@@ -39,6 +40,17 @@ defmodule Astarte.Housekeeping.Health do
   Gets the backend health.
   """
   def get_health do
-    DatabaseHealth.get_health()
+    db_health = DatabaseHealth.get_health()
+
+    case db_health do
+      status when status in [:ready, :degraded] ->
+        case Queries.fetch_keyspace_replication() do
+          {:ok, _replication} -> status
+          {:error, _reason} -> :bad
+        end
+
+      status ->
+        status
+    end
   end
 end

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/health_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/health_test.exs
@@ -20,7 +20,61 @@ defmodule Astarte.Housekeeping.HealthTest do
   use ExUnit.Case, async: true
   use Mimic
 
+  alias Astarte.DataAccess.Health, as: DatabaseHealth
   alias Astarte.Housekeeping.Health
+  alias Astarte.Housekeeping.Realms.Queries
+
+  describe "get_health/0" do
+    test "returns ready when database is ready and keyspace replication is initialized" do
+      DatabaseHealth
+      |> expect(:get_health, fn -> :ready end)
+
+      Queries
+      |> expect(:fetch_keyspace_replication, fn -> {:ok, {:simple_strategy, 1}} end)
+
+      assert Health.get_health() == :ready
+    end
+
+    test "returns bad when database is ready but keyspace replication is not initialized" do
+      DatabaseHealth
+      |> expect(:get_health, fn -> :ready end)
+
+      Queries
+      |> expect(:fetch_keyspace_replication, fn -> {:error, :replication_not_found} end)
+
+      assert Health.get_health() == :bad
+    end
+
+    test "returns degraded when database is degraded and keyspace replication is initialized" do
+      DatabaseHealth
+      |> expect(:get_health, fn -> :degraded end)
+
+      Queries
+      |> expect(:fetch_keyspace_replication, fn -> {:ok, {:simple_strategy, 1}} end)
+
+      assert Health.get_health() == :degraded
+    end
+
+    test "returns error unchanged when database health reports error" do
+      DatabaseHealth
+      |> expect(:get_health, fn -> :error end)
+
+      Queries
+      |> reject(:fetch_keyspace_replication, 0)
+
+      assert Health.get_health() == :error
+    end
+
+    test "returns bad unchanged when database health reports bad" do
+      DatabaseHealth
+      |> expect(:get_health, fn -> :bad end)
+
+      Queries
+      |> reject(:fetch_keyspace_replication, 0)
+
+      assert Health.get_health() == :bad
+    end
+  end
 
   describe "rpc_healthcheck/0" do
     test "returns ok when health is ready" do


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes #1963.

The Housekeeping `/health` endpoint backs the Kubernetes liveness/readiness probe, but it only checked the database via `Astarte.DataAccess.Health.get_health/0`. The database becomes reachable before the Housekeeping service can actually serve write operations: realm creation depends on the `astarte` keyspace being initialized and its default replication persisted, which is done asynchronously at startup by `Astarte.Housekeeping.ReleaseTasks` (`initialize_database/1` followed by `save_keyspace_replication/1`).

During that startup window the probe reported `ready` (200) while a realm-creation request would fail — `fetch_keyspace_replication/0` returns an error and the write path returns a non-JSON 500, which the client tries to JSON-decode, producing the reported `invalid character 'N' looking for beginning of value`. Reads (listing realms) succeed throughout, which is why the failure is intermittent and write-only.

This change gates the readiness signal on the write path being serviceable:

- `Astarte.Housekeeping.Health.get_health/0` now, when the database reports `:ready`/`:degraded`, additionally checks that `Astarte.Housekeeping.Realms.Queries.fetch_keyspace_replication/0` succeeds. If replication is not yet initialized it returns `:bad`, which `HealthPlug` maps to `503 Service Unavailable`, so Kubernetes holds traffic until writes can be served.
- Database `:bad`/`:error` results are returned unchanged, preserving the existing 503/500 mapping.

`HealthPlug` already maps every non-`:ready`/`:degraded` status to 503, so no plug change was required.

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

Added a `get_health/0` test group in `health_test.exs` (Mimic) covering: db ready + replication initialized → `:ready`; db ready + replication missing → `:bad`; db degraded + replication initialized → `:degraded`; db `:error`/`:bad` returned unchanged without consulting replication.
