### PR TITLE
refactor(dup): simplify InitExchange struct creation

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -538,14 +538,14 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   Sends an `InitExchange` message from Astarte to a device to trigger
   a new key-agreement handshake
 
-  Generates a fresh ephemeral X25519 key pair, a random HKDF
-  salt, and a random AES-256-GCM nonce, CBOR-encodes the `InitExchange`
+  Generates a fresh ephemeral key pair, a random HKDF
+  salt, CBOR-encodes the `InitExchange`
   struct, updates the state with the new handshake key type, and publishes
   it on: `<realm>/<device_id>/control/keyAgreement`
   """
   @spec send_init_exchange(State.t()) :: {:ok, State.t()} | {:error, term()}
   def send_init_exchange(state) do
-    init_exchange = InitExchange.new()
+    init_exchange = InitExchange.new(0)
 
     with :ok <- publish_init_exchange(state.realm, state.device_id, init_exchange),
          {:ok, new_key_state} <-

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -44,7 +44,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   ### Supported Paths
   * `/producer/properties` - Handles properties pruning (plaintext or zlib compressed).
   * `/emptyCache` - Triggers a cache empty and interface properties resend.
-  * `/keyAgreement` - Handles the InitExchange protocol (Device to Astarte direction).
+  * `/keyAgreement/0` - Handles the InitExchange protocol (Device to Astarte direction).
   * `/keyAgreement/1` - Receives an ExchangeResp sent by the device when Astarte previously initiated a key-agreement handshake.
   * `/keyAgreement/2` - Receives a SecretHash from the device to verify keys.
   * `/keyAgreement/3` - Receives a HashOk from the device confirming the key verification.
@@ -166,7 +166,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     end
   end
 
-  def handle_control(state, "/keyAgreement", payload, timestamp) do
+  def handle_control(state, "/keyAgreement/0", payload, timestamp) do
     new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
 
     case InitExchange.decode(payload) do
@@ -182,17 +182,17 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
             {:ack, :ok, final_state}
 
           {:error, reason} ->
-            Logger.error("[keyAgreement] State machine transition failed: #{inspect(reason)}")
+            Logger.error("[keyAgreement/0] State machine transition failed: #{inspect(reason)}")
 
             context = %{
               state: new_state,
               payload: payload,
-              path: "/keyAgreement",
+              path: "/keyAgreement/0",
               timestamp: timestamp
             }
 
             error = %{
-              message: "keyAgreement state machine transition failed: #{inspect(reason)}",
+              message: "keyAgreement/0 state machine transition failed: #{inspect(reason)}",
               logger_metadata: [tag: "key_agreement_transition_error"],
               error_name: "key_agreement_transition_error",
               error: :key_agreement_transition_error
@@ -203,20 +203,20 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
 
       {:error, reason} ->
         Logger.warning(
-          "[keyAgreement] payload validation failed: #{inspect(reason)}",
+          "[keyAgreement/0] payload validation failed: #{inspect(reason)}",
           tag: "key_agreement_invalid_payload"
         )
 
         context = %{
           state: new_state,
           payload: payload,
-          path: "/keyAgreement",
+          path: "/keyAgreement/0",
           timestamp: timestamp
         }
 
         error = %{
           message:
-            "Invalid keyAgreement payload (#{inspect(reason)}): " <>
+            "Invalid keyAgreement/0 payload (#{inspect(reason)}): " <>
               inspect(Base.encode64(payload)),
           logger_metadata: [tag: "key_agreement_error"],
           error_name: "key_agreement_error",

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -411,9 +411,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
         {:ack, :ok, final_state}
 
       {:error, :hash_mismatch} ->
-        Logger.warning("[keyAgreement/2] SecretHash mismatch. Renegotiating.")
+        Logger.warning("[keyAgreement/2] SecretHash mismatch.")
         # TODO: implement ExchangeFailed message
-        renegotiate_handshake(state, payload)
+        {:ack, :ok, state}
 
       {:error, reason} ->
         Logger.error("[keyAgreement/2] Failed to process SecretHash: #{inspect(reason)}")
@@ -422,10 +422,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     end
   end
 
-  defp process_secret_hash(state, _seq_num, _secret_hash_msg, payload, _timestamp) do
-    Logger.warning("[keyAgreement/2] No shared secret established. Renegotiating.")
+  defp process_secret_hash(state, _seq_num, _secret_hash_msg, _payload, _timestamp) do
+    Logger.warning("[keyAgreement/2] No shared secret established.")
     # TODO: implement ExchangeFailed message
-    renegotiate_handshake(state, payload)
+    {:ack, :ok, state}
   end
 
   defp confirm_secret_hash(state, secret_hash_msg, shared_secret, alg) do
@@ -436,24 +436,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
         :ok -> {:ok, new_key_state}
         {:error, reason} -> {:error, reason}
       end
-    end
-  end
-
-  defp renegotiate_handshake(state, payload) do
-    case send_init_exchange(state) do
-      {:ok, state_after_init} ->
-        final_state = %{
-          state_after_init
-          | total_received_msgs: state.total_received_msgs + 1,
-            total_received_bytes: state.total_received_bytes + byte_size(payload)
-        }
-
-        {:ack, :ok, final_state}
-
-      {:error, reason} ->
-        Logger.error("[keyAgreement/2] Failed to renegotiate key: #{inspect(reason)}")
-        # TODO: implement ExchangeFailed message
-        {:discard, reason, state}
     end
   end
 
@@ -534,29 +516,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     end
   end
 
-  @doc """
-  Sends an `InitExchange` message from Astarte to a device to trigger
-  a new key-agreement handshake
-
-  Generates a fresh ephemeral key pair, a random HKDF
-  salt, CBOR-encodes the `InitExchange`
-  struct, updates the state with the new handshake key type, and publishes
-  it on: `<realm>/<device_id>/control/keyAgreement`
-  """
-  @spec send_init_exchange(State.t()) :: {:ok, State.t()} | {:error, term()}
-  def send_init_exchange(state) do
-    init_exchange = InitExchange.new(0)
-
-    with :ok <- publish_init_exchange(state.realm, state.device_id, init_exchange),
-         {:ok, new_key_state} <-
-           HandshakeState.transition(
-             state.encrypted_endpoints_key,
-             {:initiate_handshake, init_exchange}
-           ) do
-      {:ok, %{state | encrypted_endpoints_key: new_key_state}}
-    end
-  end
-
   defp send_hash_ok(realm, device_id, alg) do
     topic = "#{realm}/#{Device.encode_device_id(device_id)}/control/keyAgreement/3"
 
@@ -593,51 +552,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
       {:error, reason} ->
         :telemetry.execute(
           [:astarte, :data_updater_plant, :control_handler, :key_agreement_hash_ok_send],
-          %{
-            duration: System.monotonic_time() - publish_start,
-            payload_size: byte_size(payload)
-          },
-          %{realm: realm, result: "error"}
-        )
-
-        {:error, reason}
-    end
-  end
-
-  defp publish_init_exchange(realm, device_id, %InitExchange{} = init_exchange) do
-    topic = "#{realm}/#{Device.encode_device_id(device_id)}/control/keyAgreement"
-    payload = InitExchange.cbor_encode(init_exchange)
-
-    publish_start = System.monotonic_time()
-
-    case VMQPlugin.publish(topic, payload, 2) do
-      {:ok, %{local_matches: local, remote_matches: remote}} when local + remote >= 1 ->
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :control_handler, :key_agreement_send],
-          %{
-            duration: System.monotonic_time() - publish_start,
-            payload_size: byte_size(payload)
-          },
-          %{realm: realm, result: "success"}
-        )
-
-        :ok
-
-      {:ok, %{local_matches: 0, remote_matches: 0}} ->
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :control_handler, :key_agreement_send],
-          %{
-            duration: System.monotonic_time() - publish_start,
-            payload_size: byte_size(payload)
-          },
-          %{realm: realm, result: "no_matches"}
-        )
-
-        {:error, :session_not_found}
-
-      {:error, reason} ->
-        :telemetry.execute(
-          [:astarte, :data_updater_plant, :control_handler, :key_agreement_send],
           %{
             duration: System.monotonic_time() - publish_start,
             payload_size: byte_size(payload)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/init_exchange.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/init_exchange.ex
@@ -21,7 +21,7 @@
 defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
   @moduledoc """
   Represents the InitExchange key-agreement message exchanged over the
-  `<realm>/<device>/control/keyAgreement` MQTT control topic.
+  `<realm>/<device>/control/keyAgreement/0` MQTT control topic.
 
   ## Message structure:
 
@@ -108,7 +108,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
   def cbor_encode(%__MODULE__{} = msg), do: encode(msg) |> CBOR.encode()
 
   @doc """
-  Decodes and validates a raw CBOR payload received on the `control/keyAgreement` topic.
+  Decodes and validates a raw CBOR payload received on the `control/keyAgreement/0` topic.
   """
   @spec decode(binary()) :: {:ok, t()} | {:error, atom()}
   def decode(payload) when is_binary(payload) do

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/init_exchange.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/init_exchange.ex
@@ -29,10 +29,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
         seq_num     :: uint,        # sequence number
         key_type    :: uint,        # suite identifier integer
         cose_key    :: #bstr,       # CBOR-encoded COSE_Key map
-        hkdf_salt   :: #bstr,       # HKDF salt (32 B)
-        nonce       :: #bstr        # AES-256-GCM nonce (12 B)
+        hkdf_salt   :: #bstr        # HKDF salt (32 B)
       ]
-
   """
 
   use TypedStruct
@@ -46,12 +44,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
   # dump(type, atom) to {:ok, integer} (decoded to encoded)
   @key_suites Ecto.ParameterizedType.init(Ecto.Enum,
                 values: [
-                  ecdh_x25519_hkdf_sha256_aes_256_gcm: 0,
-                  ecdh_p256_hkdf_sha256_aes_256_gcm: 1
+                  ecdh_p256_hkdf_sha256_aes_256_gcm: 0,
+                  ecdh_x25519_hkdf_sha256_aes_256_gcm: 1
                 ]
               )
-  # AES-256-GCM nonce size (bytes)
-  @nonce_size 12
   # HKDF salt size (bytes)
   @hkdf_salt_size 32
 
@@ -64,56 +60,29 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
 
   typedstruct enforce: true do
     @typedoc "InitExchange key-agreement message."
-
     field :seq_num, non_neg_integer()
     field :key_type, key_suite()
     field :public_key, Key.t()
     field :hkdf_salt, binary()
-    field :nonce, binary()
   end
 
   @doc """
-  Builds a new `%InitExchange{}` with a freshly generated ephemeral X25519
-  key pair, a random HKDF salt, a random AES-GCM nonce, and a random sequence
-  number.
-
-  Returns a `%InitExchange{}` with the full key struct stored in `public_key`
-  (including the private `d` field for later ECDH derivation), a random HKDF
-  salt, a random AES-GCM nonce, and a random `seq_num` suitable for
-  correlation with the corresponding `ExchangeResp`.
+  Builds a new `%InitExchange{}` with a freshly generated ephemeral key pair,
+  a random HKDF salt, and the provided sequence number.
   """
-  @spec new(key_suite()) :: t()
-  def new(key_type \\ :ecdh_x25519_hkdf_sha256_aes_256_gcm)
-
-  def new(:ecdh_x25519_hkdf_sha256_aes_256_gcm) do
-    key = OKP.generate(:enc)
-    hkdf_salt = :crypto.strong_rand_bytes(@hkdf_salt_size)
-    nonce = :crypto.strong_rand_bytes(@nonce_size)
-    <<seq_num::unsigned-16>> = :crypto.strong_rand_bytes(2)
-
+  @spec new(non_neg_integer(), key_suite()) :: t()
+  def new(seq_num, key_type \\ :ecdh_x25519_hkdf_sha256_aes_256_gcm)
+      when is_integer(seq_num) and seq_num >= 0 do
     %__MODULE__{
       seq_num: seq_num,
-      key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm,
-      public_key: key,
-      hkdf_salt: hkdf_salt,
-      nonce: nonce
+      key_type: key_type,
+      public_key: generate_key(key_type),
+      hkdf_salt: :crypto.strong_rand_bytes(@hkdf_salt_size)
     }
   end
 
-  def new(:ecdh_p256_hkdf_sha256_aes_256_gcm) do
-    key = ECC.generate(:es256)
-    hkdf_salt = :crypto.strong_rand_bytes(@hkdf_salt_size)
-    nonce = :crypto.strong_rand_bytes(@nonce_size)
-    <<seq_num::unsigned-16>> = :crypto.strong_rand_bytes(2)
-
-    %__MODULE__{
-      seq_num: seq_num,
-      key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm,
-      public_key: key,
-      hkdf_salt: hkdf_salt,
-      nonce: nonce
-    }
-  end
+  defp generate_key(:ecdh_x25519_hkdf_sha256_aes_256_gcm), do: OKP.generate(:enc)
+  defp generate_key(:ecdh_p256_hkdf_sha256_aes_256_gcm), do: ECC.generate(:es256)
 
   @doc """
   Returns the list representation of an `%InitExchange{}` ready for CBOR encoding.
@@ -127,22 +96,19 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
       msg.seq_num,
       key_type_id,
       %CBOR.Tag{tag: :bytes, value: cose_key_bytes},
-      %CBOR.Tag{tag: :bytes, value: msg.hkdf_salt},
-      %CBOR.Tag{tag: :bytes, value: msg.nonce}
+      %CBOR.Tag{tag: :bytes, value: msg.hkdf_salt}
     ]
   end
 
   @doc """
   CBOR-encodes an `%InitExchange{}` for transmission to the device.
-
   Returns the raw binary ready to be published on the MQTT control topic.
   """
   @spec cbor_encode(t()) :: binary()
   def cbor_encode(%__MODULE__{} = msg), do: encode(msg) |> CBOR.encode()
 
   @doc """
-  Decodes and validates a raw CBOR payload received on the
-  `control/keyAgreement` topic.
+  Decodes and validates a raw CBOR payload received on the `control/keyAgreement` topic.
   """
   @spec decode(binary()) :: {:ok, t()} | {:error, atom()}
   def decode(payload) when is_binary(payload) do
@@ -152,23 +118,20 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
     end
   end
 
-  defp parse([seq_num, key_type, public_key, hkdf_salt, nonce])
+  defp parse([seq_num, key_type, public_key, hkdf_salt])
        when is_integer(seq_num) and seq_num >= 0 do
     with {:ok, key_suite} <- parse_key_suite(key_type),
          {:ok, cose_key_bytes} <- unwrap_bytes(public_key),
          {:ok, cose_key_map} <- decode_cbor(cose_key_bytes),
          {:ok, raw_public_key} <- decode_cose_key(key_suite, cose_key_map),
          {:ok, hkdf_salt} <- unwrap_bytes(hkdf_salt),
-         :ok <- validate_hkdf_salt(hkdf_salt),
-         {:ok, nonce} <- unwrap_bytes(nonce),
-         :ok <- validate_nonce(nonce) do
+         :ok <- validate_hkdf_salt(hkdf_salt) do
       {:ok,
        %__MODULE__{
          seq_num: seq_num,
          key_type: key_suite,
          public_key: raw_public_key,
-         hkdf_salt: hkdf_salt,
-         nonce: nonce
+         hkdf_salt: hkdf_salt
        }}
     end
   end
@@ -212,13 +175,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
   defp validate_hkdf_salt(salt) when byte_size(salt) == @hkdf_salt_size, do: :ok
   defp validate_hkdf_salt(_), do: {:error, :invalid_hkdf_salt}
 
-  defp validate_nonce(nonce) when byte_size(nonce) == @nonce_size, do: :ok
-  defp validate_nonce(_), do: {:error, :invalid_nonce}
-
   @doc """
-  Returns the Ecto.Enum parameterized type for all supported key-agreement
-  suites. Use `Ecto.Type.cast/2` (integer to atom) and `Ecto.Type.dump/2`
-  (atom to integer) to convert between encoded and decoded representations.
+  Returns the Ecto.Enum parameterized type for all supported key-agreement suites.
   """
   @spec supported_key_suites() :: term()
   def supported_key_suites, do: @key_suites

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -431,49 +431,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     end
   end
 
-  describe "send_init_exchange/1" do
-    test "publishes a well-formed CBOR InitExchange to the device and returns the updated state",
-         context do
-      %{state: state} = context
-
-      expect(VMQPlugin, :publish, fn topic, payload_bytes, qos ->
-        encoded_device_id = Astarte.Core.Device.encode_device_id(state.device_id)
-
-        assert topic == "#{state.realm}/#{encoded_device_id}/control/keyAgreement"
-        assert qos == 2
-        assert {:ok, _} = InitExchange.decode(payload_bytes)
-
-        {:ok, %{local_matches: 1, remote_matches: 0}}
-      end)
-
-      assert {:ok, new_state} = ControlHandler.send_init_exchange(state)
-
-      assert {:handshake_started, %{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
-               new_state.encrypted_endpoints_key
-    end
-
-    test "returns {:error, :session_not_found} when the device has no active session",
-         context do
-      %{state: state} = context
-
-      expect(VMQPlugin, :publish, fn _topic, _payload, _qos ->
-        {:ok, %{local_matches: 0, remote_matches: 0}}
-      end)
-
-      assert {:error, :session_not_found} =
-               ControlHandler.send_init_exchange(state)
-    end
-
-    test "returns {:error, reason} on VMQ publish failure", context do
-      %{state: state} = context
-
-      expect(VMQPlugin, :publish, fn _topic, _payload, _qos -> {:error, :transport_failure} end)
-
-      assert {:error, :transport_failure} =
-               ControlHandler.send_init_exchange(state)
-    end
-  end
-
   describe "/keyAgreement/1" do
     test "acks a valid CBOR ExchangeResp payload and increments message counters",
          context do
@@ -662,43 +619,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       assert {:established, _} = new_state.encrypted_endpoints_key
     end
 
-    test "renegotiates if hashes mismatch", context do
-      %{
-        established_state: state,
-        invalid_secret_hash_payload: payload
-      } = context
-
-      # Expect 1 publish (the InitExchange renegotiation fallback)
-      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
-        {:ok, %{local_matches: 1, remote_matches: 0}}
-      end)
-
-      assert {:ack, :ok, new_state} =
-               ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
-
-      # Ensure it correctly fell back and overwrote the :established state with a new handshake
-      assert {:handshake_started, _} = new_state.encrypted_endpoints_key
-      assert new_state.total_received_msgs == state.total_received_msgs + 1
-    end
-
-    test "renegotiates if no shared secret is established", context do
-      %{state: state, valid_secret_hash_payload: payload} = context
-
-      # state.encrypted_endpoints_key is :uninitialized by default here
-
-      # Expect 1 publish (the InitExchange renegotiation fallback)
-      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
-        {:ok, %{local_matches: 1, remote_matches: 0}}
-      end)
-
-      assert {:ack, :ok, new_state} =
-               ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
-
-      # Ensure it started a new handshake
-      assert {:handshake_started, _} = new_state.encrypted_endpoints_key
-      assert new_state.total_received_msgs == state.total_received_msgs + 1
-    end
-
     test "discards payload and logs an error if the CBOR structure is invalid", context do
       %{state: state} = context
 
@@ -755,37 +675,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
                end)
 
       assert log =~ "Failed to process SecretHash: :session_not_found"
-    end
-
-    test "discards message and logs error if renegotiation fails", context do
-      %{state: state, valid_secret_hash_payload: payload} = context
-
-      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
-        {:error, :transport_failure}
-      end)
-
-      assert {{:discard, :transport_failure, ^state}, log} =
-               with_log(fn ->
-                 ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
-               end)
-
-      assert log =~ "Failed to renegotiate key: :transport_failure"
-    end
-
-    test "discards message and logs error if renegotiation fails due to missing session",
-         context do
-      %{state: state, valid_secret_hash_payload: payload} = context
-
-      expect(VMQPlugin, :publish, 1, fn _topic, _payload_bytes, _qos ->
-        {:ok, %{local_matches: 0, remote_matches: 0}}
-      end)
-
-      assert {{:discard, :session_not_found, ^state}, log} =
-               with_log(fn ->
-                 ControlHandler.handle_control(state, "/keyAgreement/2", payload, 0)
-               end)
-
-      assert log =~ "Failed to renegotiate key: :session_not_found"
     end
   end
 

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -308,7 +308,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     assert new_state.total_received_msgs > state.total_received_msgs
   end
 
-  describe "/keyAgreement" do
+  describe "/keyAgreement/0" do
     test "acks a valid CBOR InitExchange payload and increments message counters",
          context do
       %{state: state, init_exchange_payload: payload} = context
@@ -323,7 +323,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       end)
 
       assert {:ack, :ok, new_state} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+               ControlHandler.handle_control(state, "/keyAgreement/0", payload, 0)
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
@@ -345,7 +345,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       end)
 
       assert {:ack, :ok, new_state} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+               ControlHandler.handle_control(state, "/keyAgreement/0", payload, 0)
 
       assert new_state.total_received_msgs == state.total_received_msgs + 1
       assert new_state.total_received_bytes == state.total_received_bytes + byte_size(payload)
@@ -360,11 +360,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       state = %{state | discard_messages: true}
 
       assert {:discard, _result, ^state} =
-               ControlHandler.handle_control(state, "/keyAgreement", <<1>>, 0)
+               ControlHandler.handle_control(state, "/keyAgreement/0", <<1>>, 0)
     end
   end
 
-  describe "/keyAgreement - invalid payloads" do
+  describe "/keyAgreement/0 - invalid payloads" do
     setup context do
       %{state: state} = context
 
@@ -384,7 +384,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       %{state: state, invalid_key_type_payload: payload} = context
 
       assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+               ControlHandler.handle_control(state, "/keyAgreement/0", payload, 0)
 
       assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end
@@ -393,7 +393,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       %{state: state, wrong_okp_key_payload: payload} = context
 
       assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+               ControlHandler.handle_control(state, "/keyAgreement/0", payload, 0)
 
       assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end
@@ -402,7 +402,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       %{state: state, wrong_hkdf_salt_payload: payload} = context
 
       assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+               ControlHandler.handle_control(state, "/keyAgreement/0", payload, 0)
 
       assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end
@@ -414,7 +414,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       payload = CBOR.encode(%{"key_type" => 0})
 
       assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+               ControlHandler.handle_control(state, "/keyAgreement/0", payload, 0)
 
       assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end
@@ -425,7 +425,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       payload = <<0xFF, 0xFE, 0x00, 0x01>>
 
       assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
+               ControlHandler.handle_control(state, "/keyAgreement/0", payload, 0)
 
       assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -58,10 +58,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
   end
 
   setup_all do
-    init_exchange = InitExchange.new()
+    init_exchange = InitExchange.new(0)
     init_exchange_payload = InitExchange.cbor_encode(init_exchange)
 
-    p256_init_exchange = InitExchange.new(:ecdh_p256_hkdf_sha256_aes_256_gcm)
+    p256_init_exchange = InitExchange.new(0, :ecdh_p256_hkdf_sha256_aes_256_gcm)
     p256_init_exchange_payload = InitExchange.cbor_encode(p256_init_exchange)
 
     exchange_resp_payload = init_exchange |> ExchangeResp.new() |> ExchangeResp.cbor_encode()
@@ -69,14 +69,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     p256_exchange_resp_payload =
       p256_init_exchange |> ExchangeResp.new() |> ExchangeResp.cbor_encode()
 
-    # InitExchange invalid payloads: [seq_num, key_type, cose_key, hkdf_salt, nonce]
+    # InitExchange invalid payloads: [seq_num, key_type, cose_key, hkdf_salt]
     invalid_key_type_payload =
       CBOR.encode([
         0,
         99,
         %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(12)}
+        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)}
       ])
 
     wrong_okp_key_payload =
@@ -88,8 +87,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
           tag: :bytes,
           value: CBOR.encode(%{1 => 1, -1 => 4, -2 => :crypto.strong_rand_bytes(16)})
         },
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(12)}
+        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)}
       ])
 
     wrong_hkdf_salt_payload =
@@ -102,22 +100,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
           value: CBOR.encode(%{1 => 1, -1 => 4, -2 => :crypto.strong_rand_bytes(32)})
         },
         # 16 bytes instead of the required 32
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(16)},
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(12)}
-      ])
-
-    wrong_nonce_payload =
-      CBOR.encode([
-        0,
-        0,
-        # valid 32-byte X25519 COSE_Key, so parsing proceeds to the nonce check
-        %CBOR.Tag{
-          tag: :bytes,
-          value: CBOR.encode(%{1 => 1, -1 => 4, -2 => :crypto.strong_rand_bytes(32)})
-        },
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
-        # 8 bytes instead of the required 12
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(8)}
+        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(16)}
       ])
 
     # ExchangeResp invalid payload  [seq_num, cose_key] but seq_num is a string
@@ -149,7 +132,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       invalid_key_type_payload: invalid_key_type_payload,
       wrong_okp_key_payload: wrong_okp_key_payload,
       wrong_hkdf_salt_payload: wrong_hkdf_salt_payload,
-      wrong_nonce_payload: wrong_nonce_payload,
       invalid_exchange_resp_payload: invalid_exchange_resp_payload,
       shared_secret: shared_secret,
       valid_secret_hash_payload: valid_secret_hash_payload,
@@ -425,16 +407,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end
 
-    test "discards a payload with a wrong-size nonce", context do
-      %{state: state, wrong_nonce_payload: payload} = context
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
-    end
-
-    test "discards a valid CBOR payload that is not a 5-element list", context do
+    test "discards a valid CBOR payload that is not a 4-element list", context do
       %{state: state} = context
 
       # CBOR-valid but wrong structure, hits the parse(_) fallback
@@ -673,8 +646,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
         assert topic == "#{state.realm}/#{encoded_device_id}/control/keyAgreement/3"
         assert qos == 2
 
-        # Assert the HashOk payload correctly encoded the algorithm to 0
-        assert {:ok, [0], ""} = CBOR.decode(payload_bytes)
+        # Assert the HashOk payload correctly encoded the algorithm to 1 (x25519)
+        assert {:ok, [1], ""} = CBOR.decode(payload_bytes)
 
         {:ok, %{local_matches: 1, remote_matches: 0}}
       end)

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok_test.exs
@@ -25,12 +25,12 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOkTest do
 
   describe "encode/1" do
     test "returns a single-element list with the integer mapped from InitExchange" do
-      # According to InitExchange.supported_key_suites(), x25519 is 0, p256 is 1
+      # According to InitExchange.supported_key_suites(), p256 is 0, x25519 is 1
       msg_x25519 = %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
-      assert HashOk.encode(msg_x25519) == [0]
+      assert HashOk.encode(msg_x25519) == [1]
 
       msg_p256 = %HashOk{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}
-      assert HashOk.encode(msg_p256) == [1]
+      assert HashOk.encode(msg_p256) == [0]
     end
   end
 
@@ -40,21 +40,21 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOkTest do
       encoded = HashOk.cbor_encode(msg)
 
       assert is_binary(encoded)
-      assert {:ok, [1], ""} = CBOR.decode(encoded)
+      assert {:ok, [0], ""} = CBOR.decode(encoded)
     end
   end
 
   describe "cbor_decode/1" do
     test "successfully decodes a valid CBOR payload to the correct atom" do
-      payload_x25519 = CBOR.encode([0])
-
-      assert {:ok, %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
-               HashOk.cbor_decode(payload_x25519)
-
-      payload_p256 = CBOR.encode([1])
+      payload_p256 = CBOR.encode([0])
 
       assert {:ok, %HashOk{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}} =
                HashOk.cbor_decode(payload_p256)
+
+      payload_x25519 = CBOR.encode([1])
+
+      assert {:ok, %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
+               HashOk.cbor_decode(payload_x25519)
     end
 
     test "returns error for valid CBOR with unknown algorithm code" do


### PR DESCRIPTION
This PR includes a change to remove the nonce field from the InitExchange struct, as it should be randomized for each encrypted message.
It also includes a change for which the /0 suffix is added to the InitExchange control route