### PR TITLE
fix(housekeeping): Allow resuming partially completed realm deletions

### DIFF
--- a/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
+++ b/apps/astarte_housekeeping/lib/astarte_housekeeping/realms/queries.ex
@@ -1096,7 +1096,7 @@ defmodule Astarte.Housekeeping.Realms.Queries do
   end
 
   defp execute_realm_deletion(realm_name, keyspace_name) do
-    with :ok <- delete_realm_keyspace(keyspace_name),
+    with :ok <- ensure_realm_keyspace_deletion(keyspace_name),
          :ok <- remove_realm(realm_name) do
       :ok
     else
@@ -1120,8 +1120,11 @@ defmodule Astarte.Housekeeping.Realms.Queries do
 
     consistency = Consistency.device_info(:read)
 
-    case Repo.fetch_one(query, consistency: consistency) do
+    case Repo.safe_fetch_one(query, consistency: consistency) do
       {:error, :not_found} ->
+        :ok
+
+      {:error, :realm_not_found} ->
         :ok
 
       _ ->
@@ -1133,12 +1136,12 @@ defmodule Astarte.Housekeeping.Realms.Queries do
     end
   end
 
-  defp delete_realm_keyspace(keyspace_name) do
+  defp ensure_realm_keyspace_deletion(keyspace_name) do
     query = """
-    DROP KEYSPACE #{keyspace_name}
+    DROP KEYSPACE IF EXISTS #{keyspace_name}
     """
 
-    with {:ok, %{rows: nil, num_rows: 1}} <- CSystem.execute_schema_change(query) do
+    with {:ok, _} <- CSystem.execute_schema_change(query) do
       :ok
     end
   end

--- a/apps/astarte_housekeeping/test/astarte_housekeeping/realms/realms_test.exs
+++ b/apps/astarte_housekeeping/test/astarte_housekeeping/realms/realms_test.exs
@@ -25,6 +25,7 @@ defmodule Astarte.Housekeeping.RealmsTest do
 
   alias Astarte.Core.Generators.Realm, as: RealmGenerators
 
+  alias Astarte.DataAccess.Realms.Realm, as: DataAccessRealm
   alias Astarte.DataAccess.Repo
   alias Astarte.Events.AMQP
   alias Astarte.Events.AMQP.Vhost
@@ -342,6 +343,13 @@ defmodule Astarte.Housekeeping.RealmsTest do
       assert :ok = Realms.delete_realm(realm_name, async: true)
     end
 
+    test "succeeds when the keyspace was already deleted from a previous run", context do
+      %{realm_name: realm_name} = context
+      drop_realm_keyspace(realm_name)
+
+      assert :ok = Realms.delete_realm(realm_name, [])
+    end
+
     test "returns error when trying to delete a realm while deletion is disabled", %{
       realm_name: realm_name
     } do
@@ -360,5 +368,11 @@ defmodule Astarte.Housekeeping.RealmsTest do
       Mimic.stub(Repo, :query, fn _, _, _ -> {:error, "generic error"} end)
       assert {:error, "generic error"} = Realms.delete_realm(realm_name)
     end
+  end
+
+  defp drop_realm_keyspace(realm_name) do
+    keyspace = DataAccessRealm.keyspace_name(realm_name)
+    Repo.query!("DROP KEYSPACE #{keyspace}")
+    :ok
   end
 end


### PR DESCRIPTION
Previously we would error when the keyspace was already deleted but the
`realm` entry was not removed.

Make the delete operation idempotent instead.