### PR TITLE
fix(dup): remove nonce from InitExchange struct

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -520,8 +520,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   Sends an `InitExchange` message from Astarte to a device to trigger
   a new key-agreement handshake
 
-  Generates a fresh ephemeral X25519 key pair, a random HKDF
-  salt, and a random AES-256-GCM nonce, CBOR-encodes the `InitExchange`
+  Generates a fresh ephemeral key pair, a random HKDF
+  salt, CBOR-encodes the `InitExchange`
   struct, updates the state with the new handshake key type, and publishes
   it on: `<realm>/<device_id>/control/keyAgreement`
   """

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/init_exchange.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/init_exchange.ex
@@ -29,10 +29,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
         seq_num     :: uint,        # sequence number
         key_type    :: uint,        # suite identifier integer
         cose_key    :: #bstr,       # CBOR-encoded COSE_Key map
-        hkdf_salt   :: #bstr,       # HKDF salt (32 B)
-        nonce       :: #bstr        # AES-256-GCM nonce (12 B)
+        hkdf_salt   :: #bstr        # HKDF salt (32 B)
       ]
-
   """
 
   use TypedStruct
@@ -50,8 +48,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
                   ecdh_p256_hkdf_sha256_aes_256_gcm: 1
                 ]
               )
-  # AES-256-GCM nonce size (bytes)
-  @nonce_size 12
   # HKDF salt size (bytes)
   @hkdf_salt_size 32
 
@@ -64,56 +60,29 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
 
   typedstruct enforce: true do
     @typedoc "InitExchange key-agreement message."
-
     field :seq_num, non_neg_integer()
     field :key_type, key_suite()
     field :public_key, Key.t()
     field :hkdf_salt, binary()
-    field :nonce, binary()
   end
 
   @doc """
-  Builds a new `%InitExchange{}` with a freshly generated ephemeral X25519
-  key pair, a random HKDF salt, a random AES-GCM nonce, and a random sequence
-  number.
-
-  Returns a `%InitExchange{}` with the full key struct stored in `public_key`
-  (including the private `d` field for later ECDH derivation), a random HKDF
-  salt, a random AES-GCM nonce, and a random `seq_num` suitable for
-  correlation with the corresponding `ExchangeResp`.
+  Builds a new `%InitExchange{}` with a freshly generated ephemeral key pair,
+  a random HKDF salt, and the provided sequence number.
   """
-  @spec new(key_suite()) :: t()
-  def new(key_type \\ :ecdh_x25519_hkdf_sha256_aes_256_gcm)
-
-  def new(:ecdh_x25519_hkdf_sha256_aes_256_gcm) do
-    key = OKP.generate(:enc)
-    hkdf_salt = :crypto.strong_rand_bytes(@hkdf_salt_size)
-    nonce = :crypto.strong_rand_bytes(@nonce_size)
-    <<seq_num::unsigned-16>> = :crypto.strong_rand_bytes(2)
-
+  @spec new(non_neg_integer(), key_suite()) :: t()
+  def new(seq_num, key_type \\ :ecdh_x25519_hkdf_sha256_aes_256_gcm)
+      when is_integer(seq_num) and seq_num >= 0 do
     %__MODULE__{
       seq_num: seq_num,
-      key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm,
-      public_key: key,
-      hkdf_salt: hkdf_salt,
-      nonce: nonce
+      key_type: key_type,
+      public_key: generate_key(key_type),
+      hkdf_salt: :crypto.strong_rand_bytes(@hkdf_salt_size)
     }
   end
 
-  def new(:ecdh_p256_hkdf_sha256_aes_256_gcm) do
-    key = ECC.generate(:es256)
-    hkdf_salt = :crypto.strong_rand_bytes(@hkdf_salt_size)
-    nonce = :crypto.strong_rand_bytes(@nonce_size)
-    <<seq_num::unsigned-16>> = :crypto.strong_rand_bytes(2)
-
-    %__MODULE__{
-      seq_num: seq_num,
-      key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm,
-      public_key: key,
-      hkdf_salt: hkdf_salt,
-      nonce: nonce
-    }
-  end
+  defp generate_key(:ecdh_x25519_hkdf_sha256_aes_256_gcm), do: OKP.generate(:enc)
+  defp generate_key(:ecdh_p256_hkdf_sha256_aes_256_gcm), do: ECC.generate(:es256)
 
   @doc """
   Returns the list representation of an `%InitExchange{}` ready for CBOR encoding.
@@ -127,22 +96,19 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
       msg.seq_num,
       key_type_id,
       %CBOR.Tag{tag: :bytes, value: cose_key_bytes},
-      %CBOR.Tag{tag: :bytes, value: msg.hkdf_salt},
-      %CBOR.Tag{tag: :bytes, value: msg.nonce}
+      %CBOR.Tag{tag: :bytes, value: msg.hkdf_salt}
     ]
   end
 
   @doc """
   CBOR-encodes an `%InitExchange{}` for transmission to the device.
-
   Returns the raw binary ready to be published on the MQTT control topic.
   """
   @spec cbor_encode(t()) :: binary()
   def cbor_encode(%__MODULE__{} = msg), do: encode(msg) |> CBOR.encode()
 
   @doc """
-  Decodes and validates a raw CBOR payload received on the
-  `control/keyAgreement` topic.
+  Decodes and validates a raw CBOR payload received on the `control/keyAgreement` topic.
   """
   @spec decode(binary()) :: {:ok, t()} | {:error, atom()}
   def decode(payload) when is_binary(payload) do
@@ -152,23 +118,20 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
     end
   end
 
-  defp parse([seq_num, key_type, public_key, hkdf_salt, nonce])
+  defp parse([seq_num, key_type, public_key, hkdf_salt])
        when is_integer(seq_num) and seq_num >= 0 do
     with {:ok, key_suite} <- parse_key_suite(key_type),
          {:ok, cose_key_bytes} <- unwrap_bytes(public_key),
          {:ok, cose_key_map} <- decode_cbor(cose_key_bytes),
          {:ok, raw_public_key} <- decode_cose_key(key_suite, cose_key_map),
          {:ok, hkdf_salt} <- unwrap_bytes(hkdf_salt),
-         :ok <- validate_hkdf_salt(hkdf_salt),
-         {:ok, nonce} <- unwrap_bytes(nonce),
-         :ok <- validate_nonce(nonce) do
+         :ok <- validate_hkdf_salt(hkdf_salt) do
       {:ok,
        %__MODULE__{
          seq_num: seq_num,
          key_type: key_suite,
          public_key: raw_public_key,
-         hkdf_salt: hkdf_salt,
-         nonce: nonce
+         hkdf_salt: hkdf_salt
        }}
     end
   end
@@ -212,13 +175,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange do
   defp validate_hkdf_salt(salt) when byte_size(salt) == @hkdf_salt_size, do: :ok
   defp validate_hkdf_salt(_), do: {:error, :invalid_hkdf_salt}
 
-  defp validate_nonce(nonce) when byte_size(nonce) == @nonce_size, do: :ok
-  defp validate_nonce(_), do: {:error, :invalid_nonce}
-
   @doc """
-  Returns the Ecto.Enum parameterized type for all supported key-agreement
-  suites. Use `Ecto.Type.cast/2` (integer to atom) and `Ecto.Type.dump/2`
-  (atom to integer) to convert between encoded and decoded representations.
+  Returns the Ecto.Enum parameterized type for all supported key-agreement suites.
   """
   @spec supported_key_suites() :: term()
   def supported_key_suites, do: @key_suites

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -69,14 +69,13 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
     p256_exchange_resp_payload =
       p256_init_exchange |> ExchangeResp.new() |> ExchangeResp.cbor_encode()
 
-    # InitExchange invalid payloads: [seq_num, key_type, cose_key, hkdf_salt, nonce]
+    # InitExchange invalid payloads: [seq_num, key_type, cose_key, hkdf_salt]
     invalid_key_type_payload =
       CBOR.encode([
         0,
         99,
         %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(12)}
+        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)}
       ])
 
     wrong_okp_key_payload =
@@ -88,8 +87,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
           tag: :bytes,
           value: CBOR.encode(%{1 => 1, -1 => 4, -2 => :crypto.strong_rand_bytes(16)})
         },
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(12)}
+        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)}
       ])
 
     wrong_hkdf_salt_payload =
@@ -102,22 +100,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
           value: CBOR.encode(%{1 => 1, -1 => 4, -2 => :crypto.strong_rand_bytes(32)})
         },
         # 16 bytes instead of the required 32
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(16)},
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(12)}
-      ])
-
-    wrong_nonce_payload =
-      CBOR.encode([
-        0,
-        0,
-        # valid 32-byte X25519 COSE_Key, so parsing proceeds to the nonce check
-        %CBOR.Tag{
-          tag: :bytes,
-          value: CBOR.encode(%{1 => 1, -1 => 4, -2 => :crypto.strong_rand_bytes(32)})
-        },
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(32)},
-        # 8 bytes instead of the required 12
-        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(8)}
+        %CBOR.Tag{tag: :bytes, value: :crypto.strong_rand_bytes(16)}
       ])
 
     # ExchangeResp invalid payload  [seq_num, cose_key] but seq_num is a string
@@ -407,16 +390,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
     end
 
-    test "discards a payload with a wrong-size nonce", context do
-      %{state: state, wrong_nonce_payload: payload} = context
-
-      assert {:discard, _result, new_state, {:continue, continue_arg}} =
-               ControlHandler.handle_control(state, "/keyAgreement", payload, 0)
-
-      assert {:ok, _} = Impl.handle_continue(continue_arg, new_state)
-    end
-
-    test "discards a valid CBOR payload that is not a 5-element list", context do
+    test "discards a valid CBOR payload that is not a 4-element list", context do
       %{state: state} = context
 
       # CBOR-valid but wrong structure, hits the parse(_) fallback


### PR DESCRIPTION
This PR aim to remove the nonce field from InitExchange strcut of the Astarte-Device handshake protocol as the nonce should be randomized for each encrypted message