### PR TITLE
fix: ensure devices are eventually deleted

### DIFF
--- a/apps/astarte_realm_management/lib/astarte_realm_management/application.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/application.ex
@@ -48,10 +48,17 @@ defmodule Astarte.RealmManagement.Application do
     trigger_types = [:DEVICE_DELETION_STARTED, :DEVICE_DELETION_FINISHED]
 
     every_10_minutes = "*/10 * * * *"
+    every_30_minutes = "*/30 * * * *"
 
     unconfirmed_devices_scheduler = %{
       id: "unconfirmed_devices_scheduler",
       start: {SchedEx, :run_every, [Scheduler, :delete_unconfirmed_devices, [], every_10_minutes]}
+    }
+
+    pending_deletions_scheduler = %{
+      id: "pending_deletions_scheduler",
+      start:
+        {SchedEx, :run_every, [Scheduler, :reschedule_pending_deletions, [], every_30_minutes]}
     }
 
     children =
@@ -64,6 +71,7 @@ defmodule Astarte.RealmManagement.Application do
         {Horde.Registry, [keys: :unique, name: Registry.DataUpdaterRPC, members: :auto]},
         Scheduler,
         unconfirmed_devices_scheduler,
+        pending_deletions_scheduler,
         {Astarte.Events.AMQPEvents.Supervisor, []},
         {Astarte.Events.AMQPTriggers.Supervisor, []},
         {Astarte.Events.Triggers.Supervisor, []}

--- a/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/queries.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/queries.ex
@@ -227,6 +227,19 @@ defmodule Astarte.RealmManagement.DeviceRemoval.Queries do
     |> Enum.filter(&DeletionInProgress.all_ack?/1)
   end
 
+  def retrieve_devices_pending_deletion!(realm_name) do
+    keyspace = Realm.keyspace_name(realm_name)
+
+    opts = [
+      prefix: keyspace,
+      consistency: Consistency.device_info(:read)
+    ]
+
+    from(DeletionInProgress)
+    |> Repo.all(opts)
+    |> Enum.reject(&DeletionInProgress.all_ack?/1)
+  end
+
   @doc """
   Returns unconfirmed devices, with a grace period of 5 minutes
   """

--- a/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/scheduler.ex
+++ b/apps/astarte_realm_management/lib/astarte_realm_management/device_removal/scheduler.ex
@@ -27,8 +27,10 @@ defmodule Astarte.RealmManagement.DeviceRemoval.Scheduler do
 
   use GenServer
 
+  alias Astarte.Core.Device
   alias Astarte.RealmManagement.DeviceRemoval.DeviceRemover
   alias Astarte.RealmManagement.DeviceRemoval.Queries
+  alias Astarte.RealmManagement.RPC.DataUpdaterPlant.Client, as: DevicesRPC
 
   require Logger
 
@@ -73,6 +75,29 @@ defmodule Astarte.RealmManagement.DeviceRemoval.Scheduler do
     Enum.each(devices, &start_device_deletion/1)
   end
 
+  @doc """
+  Re-sends start_device_deletion RPC for all devices that are pending deletion
+  but have not yet received all three acks.
+  """
+  def reschedule_pending_deletions do
+    devices = retrieve_devices_pending_deletion!()
+
+    Enum.each(devices, fn %{device_id: device_id, realm_name: realm_name} ->
+      encoded_device_id = Device.encode_device_id(device_id)
+
+      _ =
+        Logger.debug(
+          "Re-sending start_device_deletion for pending device #{encoded_device_id}",
+          realm: realm_name
+        )
+
+      Task.Supervisor.start_child(
+        Astarte.RealmManagement.DeviceRemoverSupervisor,
+        fn -> DevicesRPC.start_device_deletion_rpc(realm_name, device_id) end
+      )
+    end)
+  end
+
   defp start_device_deletion! do
     device_to_delete_list = retrieve_devices_to_delete!()
 
@@ -98,6 +123,15 @@ defmodule Astarte.RealmManagement.DeviceRemoval.Scheduler do
 
     Enum.flat_map(realms, fn %{realm_name: realm_name} ->
       devices = Queries.retrieve_devices_to_delete!(realm_name)
+      Enum.map(devices, &Map.put(&1, :realm_name, realm_name))
+    end)
+  end
+
+  defp retrieve_devices_pending_deletion! do
+    realms = Queries.retrieve_realms!()
+
+    Enum.flat_map(realms, fn %{realm_name: realm_name} ->
+      devices = Queries.retrieve_devices_pending_deletion!(realm_name)
       Enum.map(devices, &Map.put(&1, :realm_name, realm_name))
     end)
   end

--- a/apps/astarte_realm_management/test/astarte_realm_management/device_removal/scheduler_sync_test.exs
+++ b/apps/astarte_realm_management/test/astarte_realm_management/device_removal/scheduler_sync_test.exs
@@ -35,6 +35,8 @@ defmodule Astarte.RealmManagement.DeviceRemoval.SchedulerSyncTest do
   alias Astarte.DataAccess.Repo
 
   alias Astarte.RealmManagement.DeviceRemoval.Scheduler
+  alias Astarte.RealmManagement.Generators.DeletionInProgress, as: DeletionGenerator
+  alias Astarte.RealmManagement.RPC.DataUpdaterPlant.Client, as: DevicesRPC
 
   import Astarte.Helpers.Device
 
@@ -54,6 +56,44 @@ defmodule Astarte.RealmManagement.DeviceRemoval.SchedulerSyncTest do
     test "does nothing for unconfirmed devices", context do
       %{realm: realm_name, device_id: device_id} = context
       assert Scheduler.delete_device(realm_name, device_id) == {:error, :device_not_ready}
+    end
+  end
+
+  describe "reschedule_pending_deletions/0" do
+    property "re-sends the RPC only for devices missing at least one ack", %{realm: realm} do
+      check all ackd_devices <- DeviceGenerator.id() |> list_of(length: 1..5),
+                non_ackd_devices <-
+                  DeviceGenerator.id()
+                  |> filter(&(&1 not in ackd_devices))
+                  |> bind(&DeletionGenerator.deletion_in_progress(device_id: &1))
+                  |> filter(&(not DeletionInProgress.all_ack?(&1)))
+                  |> list_of(length: 1..5),
+                max_runs: 10 do
+        ackd_deletions = seed_ackd_deletions(ackd_devices, realm)
+        non_ackd_deletions = seed_non_ackd_deletions(non_ackd_devices, realm)
+        non_ackd_device_ids = Enum.map(non_ackd_devices, & &1.device_id)
+
+        test_process = self()
+
+        DevicesRPC
+        |> expect(:start_device_deletion_rpc, length(non_ackd_device_ids), fn ^realm, device_id ->
+          send(test_process, {:rpc_called, device_id})
+          :ok
+        end)
+
+        assert Scheduler.reschedule_pending_deletions() == :ok
+
+        for device_id <- non_ackd_device_ids do
+          assert_receive {:rpc_called, ^device_id}
+        end
+
+        for device_id <- ackd_devices do
+          refute_receive {:rpc_called, ^device_id}
+        end
+
+        (ackd_deletions ++ non_ackd_deletions)
+        |> Enum.each(&Repo.delete!(&1, prefix: Realm.keyspace_name(realm)))
+      end
     end
   end
 
@@ -90,5 +130,25 @@ defmodule Astarte.RealmManagement.DeviceRemoval.SchedulerSyncTest do
       vmq_ack: true
     }
     |> Repo.insert!(prefix: Realm.keyspace_name(realm_name))
+  end
+
+  defp seed_ackd_deletions(devices, realm) do
+    keyspace = Realm.keyspace_name(realm)
+
+    devices
+    |> Enum.map(fn device_id ->
+      %DeletionInProgress{
+        device_id: device_id,
+        dup_end_ack: true,
+        dup_start_ack: true,
+        vmq_ack: true
+      }
+      |> Repo.insert!(prefix: keyspace)
+    end)
+  end
+
+  defp seed_non_ackd_deletions(deletions, realm) do
+    keyspace = Realm.keyspace_name(realm)
+    Enum.map(deletions, &Repo.insert!(&1, prefix: keyspace))
   end
 end


### PR DESCRIPTION
This PR aim to fix a bug where devices are stuck in deletion state, by adding a deletion scheduler procedure that runs every 30 minutes for devices that don't have all three deletion acks checked