### PR TITLE
feat(appengine): Encrypt value before publishing

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -208,7 +208,6 @@ defmodule Astarte.AppEngine.API.Device do
            ),
          {:ok, value} <- InterfaceValue.cast_value(mapping.value_type, raw_value),
          :ok <- validate_value_type(mapping.value_type, value),
-         wrapped_value = wrap_to_bson_struct(mapping.value_type, value),
          interface_type = interface_descriptor.type,
          reliability = mapping.reliability,
          publish_opts = build_publish_opts(interface_type, reliability),
@@ -217,8 +216,9 @@ defmodule Astarte.AppEngine.API.Device do
            maybe_apply_transport_encryption(
              realm_name,
              mapping,
-             wrapped_value,
-             device_id
+             value,
+             device_id,
+             mapping.value_type
            ),
          :ok <-
            ensure_publish(
@@ -264,18 +264,25 @@ defmodule Astarte.AppEngine.API.Device do
     end
   end
 
-  defp maybe_apply_transport_encryption(realm_name, %Mapping{} = mapping, value, device_id) do
+  defp maybe_apply_transport_encryption(
+         realm_name,
+         %Mapping{} = mapping,
+         value,
+         device_id,
+         expected_types
+       ) do
     encrypted_endpoints = extract_encrypted_endpoints([mapping])
 
     maybe_apply_transport_encryption_with_endpoints(
       realm_name,
       encrypted_endpoints,
       value,
-      device_id
+      device_id,
+      expected_types
     )
   end
 
-  defp maybe_apply_transport_encryption(realm_name, mappings, value, device_id)
+  defp maybe_apply_transport_encryption(realm_name, mappings, value, device_id, expected_types)
        when is_list(mappings) do
     encrypted_endpoints = extract_encrypted_endpoints(mappings)
 
@@ -283,7 +290,8 @@ defmodule Astarte.AppEngine.API.Device do
       realm_name,
       encrypted_endpoints,
       value,
-      device_id
+      device_id,
+      expected_types
     )
   end
 
@@ -291,34 +299,20 @@ defmodule Astarte.AppEngine.API.Device do
          realm_name,
          encrypted_endpoints,
          value,
-         device_id
+         device_id,
+         expected_types
        )
        when is_list(encrypted_endpoints) do
     should_encrypt_transport_payload? = encrypted_endpoints != []
 
     if should_encrypt_transport_payload? do
-      encoded_device_id = Device.encode_device_id(device_id)
-
-      with {:ok, device_status} <- get_device_status!(realm_name, encoded_device_id),
-           :ok <- check_shared_secret(device_status.shared_secret) do
-        encrypt_aes_gcm_binary(value, device_status.shared_secret)
+      with {:ok, shared_secret} <- Queries.retrieve_shared_secret(realm_name, device_id) do
+        bson_value = Cyanide.encode!(%{v: value})
+        EncryptedMessages.encrypt(bson_value, shared_secret.k, shared_secret.alg)
       end
     else
-      value
+      wrap_to_bson_struct(expected_types, value)
     end
-  end
-
-  defp check_shared_secret(nil), do: {:error, :device_not_ready_for_encryption}
-  defp check_shared_secret(_), do: :ok
-
-  defp encrypt_aes_gcm_binary(value, shared_secret) do
-    plaintext = normalize_transport_payload(value)
-    EncryptedMessages.encrypt(plaintext, shared_secret, :aes_256_gcm)
-  end
-
-  defp normalize_transport_payload(value) do
-    # Used for object aggregated interfaces
-    :erlang.term_to_binary(value)
   end
 
   # Helper to calculate TTL and build DB options
@@ -532,7 +526,6 @@ defmodule Astarte.AppEngine.API.Device do
            Map.new(mappings_by_key, fn {k, %Mapping{value_type: t}} -> {k, t} end),
          {:ok, value} <- InterfaceValue.cast_value(expected_types, raw_value),
          :ok <- validate_value(mappings_by_key, value),
-         wrapped_value = wrap_to_bson_struct(expected_types, value),
          reliability = extract_aggregate_reliability(mappings),
          interface_type = interface_descriptor.type,
          publish_opts = build_publish_opts(interface_type, reliability),
@@ -541,8 +534,9 @@ defmodule Astarte.AppEngine.API.Device do
            maybe_apply_transport_encryption(
              realm_name,
              mappings,
-             wrapped_value,
-             device_id
+             value,
+             device_id,
+             expected_types
            ),
          :ok <-
            ensure_publish(

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device.ex
@@ -42,6 +42,7 @@ defmodule Astarte.AppEngine.API.Device do
   alias Astarte.DataAccess.Mappings
   alias Astarte.Secrets
   alias Astarte.Secrets.Core
+  alias Astarte.Secrets.EncryptedMessages
   alias Ecto.Changeset
 
   require Logger
@@ -212,13 +213,20 @@ defmodule Astarte.AppEngine.API.Device do
          reliability = mapping.reliability,
          publish_opts = build_publish_opts(interface_type, reliability),
          interface_name = interface_descriptor.name,
+         publish_value =
+           maybe_apply_transport_encryption(
+             realm_name,
+             mapping,
+             wrapped_value,
+             device_id
+           ),
          :ok <-
            ensure_publish(
              realm_name,
              device_id,
              interface_name,
              path,
-             wrapped_value,
+             publish_value,
              publish_opts
            ) do
       opts = build_database_opts(realm_name, mapping)
@@ -256,6 +264,63 @@ defmodule Astarte.AppEngine.API.Device do
     end
   end
 
+  defp maybe_apply_transport_encryption(realm_name, %Mapping{} = mapping, value, device_id) do
+    encrypted_endpoints = extract_encrypted_endpoints([mapping])
+
+    maybe_apply_transport_encryption_with_endpoints(
+      realm_name,
+      encrypted_endpoints,
+      value,
+      device_id
+    )
+  end
+
+  defp maybe_apply_transport_encryption(realm_name, mappings, value, device_id)
+       when is_list(mappings) do
+    encrypted_endpoints = extract_encrypted_endpoints(mappings)
+
+    maybe_apply_transport_encryption_with_endpoints(
+      realm_name,
+      encrypted_endpoints,
+      value,
+      device_id
+    )
+  end
+
+  defp maybe_apply_transport_encryption_with_endpoints(
+         realm_name,
+         encrypted_endpoints,
+         value,
+         device_id
+       )
+       when is_list(encrypted_endpoints) do
+    should_encrypt_transport_payload? = encrypted_endpoints != []
+
+    if should_encrypt_transport_payload? do
+      encoded_device_id = Device.encode_device_id(device_id)
+
+      with {:ok, device_status} <- get_device_status!(realm_name, encoded_device_id),
+           :ok <- check_shared_secret(device_status.shared_secret) do
+        encrypt_aes_gcm_binary(value, device_status.shared_secret)
+      end
+    else
+      value
+    end
+  end
+
+  defp check_shared_secret(nil), do: {:error, :device_not_ready_for_encryption}
+  defp check_shared_secret(_), do: :ok
+
+  defp encrypt_aes_gcm_binary(value, shared_secret) do
+    plaintext = normalize_transport_payload(value)
+    EncryptedMessages.encrypt(plaintext, shared_secret, :aes_256_gcm)
+  end
+
+  defp normalize_transport_payload(value) do
+    # Used for object aggregated interfaces
+    :erlang.term_to_binary(value)
+  end
+
   # Helper to calculate TTL and build DB options
   defp build_database_opts(realm_name, mapping) do
     realm_max_ttl = Queries.fetch_datastream_maximum_storage_retention(realm_name)
@@ -282,14 +347,7 @@ defmodule Astarte.AppEngine.API.Device do
       |> DateTime.to_unix(:microsecond)
       |> Kernel.*(10)
 
-    encrypted_endpoints =
-      case Map.get(mapping, :encrypted) do
-        true ->
-          [Map.get(mapping, :endpoint)]
-
-        _ ->
-          []
-      end
+    encrypted_endpoints = extract_encrypted_endpoints([mapping])
 
     case maybe_encrypt_value(
            desc.aggregation,
@@ -479,13 +537,20 @@ defmodule Astarte.AppEngine.API.Device do
          interface_type = interface_descriptor.type,
          publish_opts = build_publish_opts(interface_type, reliability),
          interface_name = interface_descriptor.name,
+         publish_value =
+           maybe_apply_transport_encryption(
+             realm_name,
+             mappings,
+             wrapped_value,
+             device_id
+           ),
          :ok <-
            ensure_publish(
              realm_name,
              device_id,
              interface_name,
              path,
-             wrapped_value,
+             publish_value,
              publish_opts
            ) do
       handle_object_value_storage(%{

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/device_status.ex
@@ -42,7 +42,6 @@ defmodule Astarte.AppEngine.API.Device.DeviceStatus do
     field :previous_interfaces, {:array, :map}
     field :groups, {:array, :string}
     field :deletion_in_progress, :boolean, default: false
-    field :shared_secret, :binary
   end
 
   @doc false

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -243,7 +243,8 @@ defmodule Astarte.AppEngine.API.Device.Queries do
     :exchanged_bytes_by_interface,
     :groups,
     :old_introspection,
-    :inhibit_credentials_request
+    :inhibit_credentials_request,
+    :shared_secret
   ]
 
   defp truncate_datetime(nil), do: nil
@@ -854,7 +855,8 @@ defmodule Astarte.AppEngine.API.Device.Queries do
       exchanged_bytes_by_interface: exchanged_bytes_by_interface,
       groups: groups,
       old_introspection: old_introspection,
-      inhibit_credentials_request: credentials_inhibited
+      inhibit_credentials_request: credentials_inhibited,
+      shared_secret: shared_secret
     } = device
 
     introspection =
@@ -920,7 +922,21 @@ defmodule Astarte.AppEngine.API.Device.Queries do
       total_received_msgs: total_received_msgs,
       total_received_bytes: total_received_bytes,
       previous_interfaces: previous_interfaces,
-      groups: groups
+      groups: groups,
+      shared_secret: shared_secret
     }
+  end
+
+  # TODO This is copied from DUP
+  def save_shared_secret(realm, device_id, shared_secret) do
+    keyspace_name = Realm.keyspace_name(realm)
+
+    device =
+      %DatabaseDevice{device_id: device_id}
+      |> Ecto.Changeset.change(%{shared_secret: shared_secret})
+
+    opts = [prefix: keyspace_name, consistency: Consistency.device_info(:write)]
+    Repo.update!(device, opts)
+    :ok
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/device/queries.ex
@@ -243,8 +243,7 @@ defmodule Astarte.AppEngine.API.Device.Queries do
     :exchanged_bytes_by_interface,
     :groups,
     :old_introspection,
-    :inhibit_credentials_request,
-    :shared_secret
+    :inhibit_credentials_request
   ]
 
   defp truncate_datetime(nil), do: nil
@@ -855,8 +854,7 @@ defmodule Astarte.AppEngine.API.Device.Queries do
       exchanged_bytes_by_interface: exchanged_bytes_by_interface,
       groups: groups,
       old_introspection: old_introspection,
-      inhibit_credentials_request: credentials_inhibited,
-      shared_secret: shared_secret
+      inhibit_credentials_request: credentials_inhibited
     } = device
 
     introspection =
@@ -922,12 +920,29 @@ defmodule Astarte.AppEngine.API.Device.Queries do
       total_received_msgs: total_received_msgs,
       total_received_bytes: total_received_bytes,
       previous_interfaces: previous_interfaces,
-      groups: groups,
-      shared_secret: shared_secret
+      groups: groups
     }
   end
 
+  def retrieve_shared_secret(realm, device_id) do
+    keyspace_name = Realm.keyspace_name(realm)
+
+    query =
+      from d in DatabaseDevice,
+        prefix: ^keyspace_name,
+        select: d.shared_secret
+
+    opts = [consistency: Consistency.device_info(:read), error: :device_not_found]
+
+    case Repo.fetch(query, device_id, opts) do
+      {:ok, nil} -> {:error, :device_not_ready_for_encryption}
+      {:ok, shared_secret} -> {:ok, shared_secret}
+      error -> error
+    end
+  end
+
   # TODO This is copied from DUP
+  @doc false
   def save_shared_secret(realm, device_id, shared_secret) do
     keyspace_name = Realm.keyspace_name(realm)
 

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_reading_v2_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_reading_v2_test.exs
@@ -38,6 +38,8 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
 
   alias Astarte.Secrets.EncryptedMessages
 
+  alias COSE.Keys.Symmetric
+
   describe "get_interface_value" do
     setup context do
       %{astarte_instance_id: astarte_instance_id, realm_name: realm_name} = context
@@ -117,10 +119,10 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
         device: device
       } = context
 
-      random_binary = :crypto.strong_rand_bytes(32)
+      shared_secret = %Symmetric{k: :crypto.strong_rand_bytes(32), alg: :aes_256_gcm}
       {:ok, device_id} = CoreDevice.decode_device_id(device.encoded_id)
 
-      :ok = AppEngineDeviceQueries.save_shared_secret(realm_name, device_id, random_binary)
+      :ok = AppEngineDeviceQueries.save_shared_secret(realm_name, device_id, shared_secret)
 
       encrypted_server_interfaces =
         interfaces
@@ -164,7 +166,7 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
               device,
               interface_to_update,
               mapping_update,
-              random_binary
+              shared_secret
             )
 
           {:ok, %InterfaceValues{data: result}} =
@@ -356,11 +358,17 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
   defp decrypt_value(encrypted_value, shared_secret) do
     case EncryptedMessages.decrypt(
            encrypted_value,
-           shared_secret,
-           :aes_256_gcm
+           shared_secret.k,
+           shared_secret.alg
          ) do
       {:ok, decrypted_value} ->
-        :erlang.binary_to_term(decrypted_value)
+        case Cyanide.decode(decrypted_value) do
+          {:ok, %{"v" => value}} ->
+            value
+
+          _ ->
+            :erlang.binary_to_term(decrypted_value)
+        end
 
       {:error, reason} ->
         flunk("Unable to decrypt published value: #{inspect(reason)}")

--- a/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_reading_v2_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api/device/device_reading_v2_test.exs
@@ -24,6 +24,7 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
 
   alias Astarte.AppEngine.API.Device
   alias Astarte.AppEngine.API.Device.InterfaceValues
+  alias Astarte.AppEngine.API.Device.Queries, as: AppEngineDeviceQueries
 
   alias Astarte.Core.Device, as: CoreDevice
   alias Astarte.Core.InterfaceDescriptor
@@ -34,6 +35,8 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
   alias Astarte.DataAccess.Repo
 
   alias Astarte.Generators.InterfaceUpdate, as: InterfaceUpdateGenerator
+
+  alias Astarte.Secrets.EncryptedMessages
 
   describe "get_interface_value" do
     setup context do
@@ -114,6 +117,11 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
         device: device
       } = context
 
+      random_binary = :crypto.strong_rand_bytes(32)
+      {:ok, device_id} = CoreDevice.decode_device_id(device.encoded_id)
+
+      :ok = AppEngineDeviceQueries.save_shared_secret(realm_name, device_id, random_binary)
+
       encrypted_server_interfaces =
         interfaces
         |> Enum.filter(fn interface ->
@@ -150,7 +158,14 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
             interface_to_update: interface_to_update,
             expected_read_value: expected_read_value,
             mapping_update: mapping_update
-          } = populate_interface(realm_name, device, interface_to_update, mapping_update)
+          } =
+            populate_interface(
+              realm_name,
+              device,
+              interface_to_update,
+              mapping_update,
+              random_binary
+            )
 
           {:ok, %InterfaceValues{data: result}} =
             Device.get_interface_values!(
@@ -249,10 +264,17 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
     Repo.query!("TRUNCATE #{Realm.keyspace_name(realm_name)}.individual_datastreams")
   end
 
-  defp populate_interface(realm_name, device, interface_to_update, mapping_update) do
+  defp populate_interface(
+         realm_name,
+         device,
+         interface_to_update,
+         mapping_update,
+         shared_key \\ nil
+       ) do
     update_value = mapping_update.value
     path_tokens = String.split(mapping_update.path, "/")
     expected_token = [realm_name, device.encoded_id, interface_to_update.name | path_tokens]
+    encrypted_path? = encrypted_mapping_path?(interface_to_update, mapping_update.path)
 
     expected_published_value =
       expected_published_value!(mapping_update.value_type, update_value)
@@ -267,7 +289,14 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
       assert %{payload: payload, topic_tokens: topic_tokens, qos: qos} = args
       assert topic_tokens == expected_token
       assert qos == expected_qos
-      assert {:ok, %{"v" => ^expected_published_value}} = Cyanide.decode(payload)
+
+      assert {:ok, %{"v" => published_value}} = Cyanide.decode(payload)
+
+      if encrypted_path? do
+        assert decrypt_value(published_value, shared_key) == expected_published_value
+      else
+        assert published_value == expected_published_value
+      end
     end)
 
     with {:ok, device_id} <- CoreDevice.decode_device_id(device.encoded_id),
@@ -306,5 +335,35 @@ defmodule Astarte.AppEngine.API.Device.DeviceReadingV2Test do
       expected_read_value: expected_read_value,
       mapping_update: mapping_update
     }
+  end
+
+  defp encrypted_mapping_path?(interface_to_update, path) do
+    normalized_path = normalize_path(path)
+
+    Enum.any?(interface_to_update.mappings, fn mapping ->
+      normalized_endpoint = normalize_path(mapping.endpoint)
+
+      mapping.encrypted and
+        (normalized_endpoint == normalized_path or
+           String.starts_with?(normalized_endpoint, normalized_path <> "/"))
+    end)
+  end
+
+  defp normalize_path(path) do
+    "/" <> String.trim(path, "/")
+  end
+
+  defp decrypt_value(encrypted_value, shared_secret) do
+    case EncryptedMessages.decrypt(
+           encrypted_value,
+           shared_secret,
+           :aes_256_gcm
+         ) do
+      {:ok, decrypted_value} ->
+        :erlang.binary_to_term(decrypted_value)
+
+      {:error, reason} ->
+        flunk("Unable to decrypt published value: #{inspect(reason)}")
+    end
   end
 end

--- a/apps/astarte_appengine_api/test/support/cases/device.ex
+++ b/apps/astarte_appengine_api/test/support/cases/device.ex
@@ -93,7 +93,10 @@ defmodule Astarte.Cases.Device do
 
     random_interfaces =
       interfaces
-      |> Enum.reject(&(&1 in taken_interfaces))
+      # Do not populate interfaces with encrypted mappings
+      |> Enum.reject(fn interface ->
+        interface in taken_interfaces or Enum.any?(interface.mappings, & &1.encrypted)
+      end)
       |> Enum.group_by(fn interface ->
         {interface.type, interface.ownership, interface.aggregation}
       end)

--- a/apps/astarte_appengine_api/test/support/helpers/database.ex
+++ b/apps/astarte_appengine_api/test/support/helpers/database.ex
@@ -136,7 +136,7 @@ defmodule Astarte.Helpers.Database do
         attributes map<varchar, varchar>,
         groups map<text, timeuuid>,
         capabilities capabilities,
-        shared_secret blob,
+        shared_secret session_key,
 
         PRIMARY KEY (device_id)
       );
@@ -409,6 +409,13 @@ defmodule Astarte.Helpers.Database do
     """
   ]
 
+  @create_session_key_type """
+  CREATE TYPE #{Realm.keyspace_name(@test_realm)}.session_key (
+    alg int,
+    k blob
+  );
+  """
+
   def insert_empty_device(device_id) do
     keyspace_name = Realm.keyspace_name(@test_realm)
 
@@ -441,6 +448,8 @@ defmodule Astarte.Helpers.Database do
     case Repo.query(@create_autotestrealm) do
       {:ok, _} ->
         Repo.query!(@create_capabilities_type)
+
+        Repo.query!(@create_session_key_type)
 
         Repo.query!(@create_devices_table)
 

--- a/apps/astarte_appengine_api/test/support/helpers/database_v2.ex
+++ b/apps/astarte_appengine_api/test/support/helpers/database_v2.ex
@@ -95,7 +95,7 @@ defmodule Astarte.Helpers.DatabaseV2 do
     last_seen_ip inet,
     attributes map<varchar, varchar>,
     capabilities capabilities,
-    shared_secret blob,
+    shared_secret session_key,
     groups map<text, timeuuid>,
 
     PRIMARY KEY (device_id)
@@ -252,10 +252,18 @@ defmodule Astarte.Helpers.DatabaseV2 do
   -----END PUBLIC KEY-----
   """
 
+  @create_session_key_type """
+  CREATE TYPE :keyspace.session_key (
+    alg int,
+    k blob
+  );
+  """
+
   def setup!(realm_name) do
     realm_keyspace = Realm.keyspace_name(realm_name)
     execute!(realm_keyspace, @create_keyspace)
     execute!(realm_keyspace, @create_capabilities_type)
+    execute!(realm_keyspace, @create_session_key_type)
     execute!(realm_keyspace, @create_devices_table)
     execute!(realm_keyspace, @create_groups_table)
     execute!(realm_keyspace, @create_names_table)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/state.ex
@@ -30,6 +30,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.State do
   alias Astarte.DataUpdaterPlant.DataUpdater.Cache
   alias Astarte.DataUpdaterPlant.DataUpdater.CachedPath
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HandshakeState
+  alias COSE.Keys.Symmetric
 
   @type interface_name :: String.t()
   @type policy_name :: String.t()
@@ -114,6 +115,6 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.State do
     field :last_datastream_maximum_retention_refresh, non_neg_integer(), default: 0
     field :capabilities, Capabilities.t(), default: %Capabilities{}
     field :encrypted_endpoints_key, HandshakeState.t(), default: :uninitialized
-    field :shared_secret, binary()
+    field :shared_secret, Symmetric.t()
   end
 end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
@@ -54,6 +54,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
   alias Astarte.DataUpdaterPlant.DatabaseTestHelper
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.Events.Triggers.Cache
+  alias COSE.Keys.Symmetric
 
   setup :verify_on_exit!
 
@@ -1628,7 +1629,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
     helper_name: helper_name
   } do
     AMQPTestHelper.clean_queue(helper_name)
-    random_binary = :crypto.strong_rand_bytes(16)
+    shared_secret = %Symmetric{alg: :aes_256_gcm, k: :crypto.strong_rand_bytes(32)}
 
     encoded_device_id =
       :crypto.strong_rand_bytes(16)
@@ -1638,7 +1639,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
 
     DatabaseTestHelper.insert_device(realm, device_id)
 
-    Queries.save_shared_secret(realm, device_id, random_binary)
+    Queries.save_shared_secret(realm, device_id, shared_secret)
 
     handle_connection(
       realm,

--- a/apps/astarte_pairing/test/support/helpers/database.ex
+++ b/apps/astarte_pairing/test/support/helpers/database.ex
@@ -151,7 +151,7 @@ defmodule Astarte.Helpers.Database do
     last_seen_ip inet,
     attributes map<varchar, varchar>,
     capabilities capabilities,
-    shared_secret blob,
+    shared_secret session_key,
 
     groups map<text, timeuuid>,
 

--- a/apps/astarte_realm_management/test/support/helpers/database.ex
+++ b/apps/astarte_realm_management/test/support/helpers/database.ex
@@ -68,6 +68,13 @@ defmodule Astarte.Helpers.Database do
   );
   """
 
+  @create_session_key_type """
+  CREATE TYPE IF NOT EXISTS :keyspace.session_key (
+    alg int,
+    k blob
+  );
+  """
+
   @create_devices_table """
   CREATE TABLE IF NOT EXISTS :keyspace.devices (
     device_id uuid,
@@ -95,7 +102,7 @@ defmodule Astarte.Helpers.Database do
     attributes map<varchar, varchar>,
     capabilities capabilities,
     groups map<text, timeuuid>,
-    shared_secret blob,
+    shared_secret session_key,
 
     PRIMARY KEY (device_id)
   )
@@ -278,6 +285,7 @@ defmodule Astarte.Helpers.Database do
     realm_keyspace = Realm.keyspace_name(realm_name)
     execute!(realm_keyspace, @create_keyspace)
     execute!(realm_keyspace, @create_capabilities_type)
+    execute!(realm_keyspace, @create_session_key_type)
     execute!(realm_keyspace, @create_devices_table)
     execute!(realm_keyspace, @create_groups_table)
     execute!(realm_keyspace, @create_names_table)

--- a/apps/astarte_trigger_engine/test/support/helpers/database.ex
+++ b/apps/astarte_trigger_engine/test/support/helpers/database.ex
@@ -97,7 +97,7 @@ defmodule Astarte.Helpers.Database do
     attributes map<varchar, varchar>,
     capabilities capabilities,
     groups map<text, timeuuid>,
-    shared_secret blob,
+    shared_secret session_key,
 
     PRIMARY KEY (device_id)
   )
@@ -230,10 +230,18 @@ defmodule Astarte.Helpers.Database do
   )
   """
 
+  @create_session_key_type """
+  CREATE TYPE :keyspace.session_key (
+    alg int,
+    k blob
+  );
+  """
+
   def setup!(realm_name) do
     realm_keyspace = Realm.keyspace_name(realm_name)
     execute!(realm_keyspace, @create_keyspace)
     execute!(realm_keyspace, @create_capabilities_type)
+    execute!(realm_keyspace, @create_session_key_type)
     execute!(realm_keyspace, @create_devices_table)
     execute!(realm_keyspace, @create_groups_table)
     execute!(realm_keyspace, @create_names_table)

--- a/libs/astarte_data_access/lib/astarte_data_access/database/migrations/realm/0025_add_shared_secret_to_device.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/database/migrations/realm/0025_add_shared_secret_to_device.ex
@@ -23,7 +23,7 @@ defmodule Astarte.DataAccess.Database.Migrations.Realm.AddSharedSecretToDevice d
 
   def change do
     alter table(:devices) do
-      add :shared_secret, :binary
+      add :shared_secret, :session_key
     end
   end
 end

--- a/libs/astarte_data_access/lib/astarte_data_access/devices/device.ex
+++ b/libs/astarte_data_access/lib/astarte_data_access/devices/device.ex
@@ -25,6 +25,7 @@ defmodule Astarte.DataAccess.Devices.Device do
   alias Astarte.Core.Device.Capabilities
   alias Astarte.DataAccess.DateTime, as: DateTimeMs
   alias Astarte.DataAccess.UUID
+  alias COSE.Keys.Symmetric
 
   @primary_key {:device_id, UUID, autogenerate: false}
   typed_schema "devices" do
@@ -68,6 +69,6 @@ defmodule Astarte.DataAccess.Devices.Device do
     field :protocol_revision, :integer
     field :total_received_bytes, :integer
     field :total_received_msgs, :integer
-    field :shared_secret, :binary
+    field :shared_secret, Exandra.EmbeddedType, using: Symmetric
   end
 end

--- a/libs/astarte_events/test/support/helpers/database_test_helper.ex
+++ b/libs/astarte_events/test/support/helpers/database_test_helper.ex
@@ -83,6 +83,13 @@ defmodule Astarte.Helpers.Database do
   );
   """
 
+  @create_session_key_type """
+  CREATE TYPE IF NOT EXISTS :keyspace.session_key (
+    alg int,
+    k blob
+  );
+  """
+
   @create_devices_table """
   CREATE TABLE :keyspace.devices (
     device_id uuid,
@@ -111,7 +118,7 @@ defmodule Astarte.Helpers.Database do
     capabilities capabilities,
 
     groups map<text, timeuuid>,
-    shared_secret blob,
+    shared_secret session_key,
 
     PRIMARY KEY (device_id)
   )
@@ -285,6 +292,7 @@ defmodule Astarte.Helpers.Database do
     realm_keyspace = Realm.keyspace_name(realm_name)
     execute!(realm_keyspace, @create_keyspace)
     execute!(realm_keyspace, @create_capabilities_type)
+    execute!(realm_keyspace, @create_session_key_type)
     execute!(realm_keyspace, @create_devices_table)
     execute!(realm_keyspace, @create_groups_table)
     execute!(realm_keyspace, @create_names_table)

--- a/libs/astarte_fdo/test/support/helpers/database.ex
+++ b/libs/astarte_fdo/test/support/helpers/database.ex
@@ -156,7 +156,7 @@ defmodule Astarte.FDO.Helpers.Database do
     capabilities capabilities,
 
     groups map<text, timeuuid>,
-    shared_secret blob,
+    shared_secret session_key,
 
     PRIMARY KEY (device_id)
   )

--- a/libs/astarte_rpc/test/support/helpers/database.ex
+++ b/libs/astarte_rpc/test/support/helpers/database.ex
@@ -99,7 +99,7 @@ defmodule Astarte.RPC.Helpers.Database do
     capabilities capabilities,
 
     groups map<text, timeuuid>,
-    shared_secret blob,
+    shared_secret session_key,
 
     PRIMARY KEY (device_id)
   )
@@ -286,6 +286,13 @@ defmodule Astarte.RPC.Helpers.Database do
     """
   ]
 
+  @create_session_key_type """
+  CREATE TYPE :keyspace.session_key (
+    alg int,
+    k blob
+  );
+  """
+
   def setup_astarte_keyspace do
     astarte_keyspace = Realm.astarte_keyspace_name()
     execute!(astarte_keyspace, @create_keyspace)
@@ -307,6 +314,7 @@ defmodule Astarte.RPC.Helpers.Database do
     realm_keyspace = Realm.keyspace_name(realm_name)
     execute!(realm_keyspace, @create_keyspace)
     execute!(realm_keyspace, @create_capabilities_type)
+    execute!(realm_keyspace, @create_session_key_type)
     execute!(realm_keyspace, @create_devices_table)
     execute!(realm_keyspace, @create_groups_table)
     execute!(realm_keyspace, @create_names_table)

--- a/libs/astarte_test_suite/lib/astarte/test_suite/helpers/realm.ex
+++ b/libs/astarte_test_suite/lib/astarte/test_suite/helpers/realm.ex
@@ -177,7 +177,6 @@ defmodule Astarte.TestSuite.Helpers.Realm do
       last_seen_ip inet,
       attributes map<varchar, varchar>,
       groups map<text, timeuuid>,
-      shared_secret blob,
       PRIMARY KEY (device_id)
     );
     """


### PR DESCRIPTION
If endpoint has encrypted flag set to true, encrypt value before publishing on broker.
Added transport encryption before publishing data on broker.
Changed DB schema to store %Symmetric{} key with algorithm, and updated functions for insert and read the key.