### PR TITLE
refactor(dup): make HashOk return the associated sequence number

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/control_handler.ex
@@ -401,7 +401,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
   end
 
   defp process_secret_hash(
-         %{encrypted_endpoints_key: {:established, %{shared_secret: shared_secret, alg: alg}}} =
+         %{encrypted_endpoints_key: {:established, %{shared_secret: shared_secret}}} =
            state,
          seq_num,
          secret_hash_msg,
@@ -409,7 +409,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
          _timestamp
        ) do
     state
-    |> confirm_secret_hash(secret_hash_msg, shared_secret, alg)
+    |> confirm_secret_hash(secret_hash_msg, shared_secret)
     |> case do
       {:ok, new_key_state} ->
         final_state = %{
@@ -452,14 +452,14 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     end
   end
 
-  defp process_secret_hash(state, _seq_num, _secret_hash_msg, _payload, _timestamp) do
+  defp process_secret_hash(state, seq_num, _secret_hash_msg, _payload, _timestamp) do
     Logger.warning("[keyAgreement/2] No shared secret established.")
 
     _ =
       send_exchange_failed(
         state.realm,
         state.device_id,
-        0,
+        seq_num,
         :internal_server_error,
         "no shared secret established"
       )
@@ -467,11 +467,11 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     {:ack, :ok, state}
   end
 
-  defp confirm_secret_hash(state, secret_hash_msg, shared_secret, alg) do
+  defp confirm_secret_hash(state, secret_hash_msg, shared_secret) do
     with :ok <- SecretHash.verify(secret_hash_msg, shared_secret),
          {:ok, new_key_state} <-
            HandshakeState.transition(state.encrypted_endpoints_key, :secret_reconfirmed) do
-      case send_hash_ok(state.realm, state.device_id, alg) do
+      case send_hash_ok(state.realm, state.device_id, secret_hash_msg.seq_num) do
         :ok -> {:ok, new_key_state}
         {:error, reason} -> {:error, reason}
       end
@@ -636,11 +636,10 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandler do
     Core.Error.handle_error(context, error)
   end
 
-  defp send_hash_ok(realm, device_id, alg) do
+  defp send_hash_ok(realm, device_id, seq_num) do
     topic = "#{realm}/#{Device.encode_device_id(device_id)}/control/keyAgreement/3"
 
-    hash_ok = %HashOk{key_type: alg}
-    payload = HashOk.cbor_encode(hash_ok)
+    payload = HashOk.cbor_encode(%HashOk{seq_num: seq_num})
 
     publish_start = System.monotonic_time()
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok.ex
@@ -23,28 +23,32 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOk do
   Represents the HashOk (type 3) key-agreement message published on the
   `<realm>/<device>/control/keyAgreement/3` MQTT control topic.
 
-  It carries the internal key-suite atom which is cast to and from an integer
-  for CBOR encoding using `InitExchange.supported_key_suites()`.
+  Sent by either party to acknowledge that a received `SecretHash` (type 2)
+  message matched the locally derived shared secret. It carries the
+  `seq_num` of the `SecretHash` message being acknowledged, so that the
+  counterpart can associate this confirmation with the correct request.
+
+  ## Message structure:
+
+      [
+        seq_num :: uint   # sequence number taken from the associated SecretHash message
+      ]
   """
 
   use TypedStruct
 
   alias __MODULE__, as: HashOk
-  alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.InitExchange
 
   typedstruct enforce: true do
-    @typedoc "HashOk acknowledgement message containing the key-suite algorithm atom."
-    field :key_type, InitExchange.key_suite()
+    @typedoc "HashOk acknowledgement message referencing the associated SecretHash seq_num."
+    field :seq_num, non_neg_integer()
   end
 
   @doc """
   Returns the list representation of a `%HashOk{}` ready for CBOR encoding.
   """
   @spec encode(t()) :: list()
-  def encode(%HashOk{} = msg) do
-    {:ok, key_type_id} = Ecto.Type.dump(InitExchange.supported_key_suites(), msg.key_type)
-    [key_type_id]
-  end
+  def encode(%HashOk{seq_num: seq_num}), do: [seq_num]
 
   @doc """
   CBOR-encodes a `%HashOk{}` for transmission.
@@ -64,11 +68,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOk do
     end
   end
 
-  defp decode([key_type]) when is_integer(key_type) and key_type >= 0 do
-    case Ecto.Type.cast(InitExchange.supported_key_suites(), key_type) do
-      {:ok, suite} -> {:ok, %HashOk{key_type: suite}}
-      _ -> {:error, :invalid_payload}
-    end
+  defp decode([seq_num]) when is_integer(seq_num) and seq_num >= 0 do
+    {:ok, %HashOk{seq_num: seq_num}}
   end
 
   defp decode(_), do: {:error, :invalid_payload}

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/control_handler_test.exs
@@ -894,8 +894,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
         assert topic == "#{state.realm}/#{encoded_device_id}/control/keyAgreement/3"
         assert qos == 2
 
-        # Assert the HashOk payload correctly encoded the algorithm to 1 (x25519)
-        assert {:ok, [1], ""} = CBOR.decode(payload_bytes)
+        # Assert the HashOk payload carries the seq_num (1) of the associated SecretHash
+        assert {:ok, %HashOk{seq_num: 1}} = HashOk.cbor_decode(payload_bytes)
 
         {:ok, %{local_matches: 1, remote_matches: 0}}
       end)
@@ -1054,7 +1054,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
       expect(VMQPlugin, :publish, fn _topic, payload_bytes, _qos ->
         assert {:ok,
                 %ExchangeFailed{
-                  seq_num: 0,
+                  seq_num: seq_num,
                   reason: :internal_server_error,
                   error_msg: "no shared secret established"
                 }} = ExchangeFailed.cbor_decode(payload_bytes)
@@ -1073,9 +1073,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.ControlHandlerTest do
 
   describe "/keyAgreement/3" do
     setup do
-      valid_hash_ok = %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
+      valid_hash_ok = %HashOk{seq_num: 1}
       valid_hash_ok_payload = HashOk.cbor_encode(valid_hash_ok)
-      invalid_hash_ok_payload = CBOR.encode([99])
+      invalid_hash_ok_payload = CBOR.encode([-1])
 
       %{
         valid_hash_ok_payload: valid_hash_ok_payload,

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/key_agreement/hash_ok_test.exs
@@ -24,42 +24,29 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOkTest do
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOk
 
   describe "encode/1" do
-    test "returns a single-element list with the integer mapped from InitExchange" do
-      # According to InitExchange.supported_key_suites(), p256 is 0, x25519 is 1
-      msg_x25519 = %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}
-      assert HashOk.encode(msg_x25519) == [1]
-
-      msg_p256 = %HashOk{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}
-      assert HashOk.encode(msg_p256) == [0]
+    test "returns a single-element list with the seq_num" do
+      assert HashOk.encode(%HashOk{seq_num: 0}) == [0]
+      assert HashOk.encode(%HashOk{seq_num: 42}) == [42]
     end
   end
 
   describe "cbor_encode/1" do
     test "encodes the struct into a valid CBOR binary" do
-      msg = %HashOk{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}
+      msg = %HashOk{seq_num: 7}
       encoded = HashOk.cbor_encode(msg)
 
       assert is_binary(encoded)
-      assert {:ok, [0], ""} = CBOR.decode(encoded)
+      assert {:ok, [7], ""} = CBOR.decode(encoded)
     end
   end
 
   describe "cbor_decode/1" do
-    test "successfully decodes a valid CBOR payload to the correct atom" do
-      payload_p256 = CBOR.encode([0])
+    test "successfully decodes a valid CBOR payload to the seq_num it carries" do
+      payload_zero = CBOR.encode([0])
+      assert {:ok, %HashOk{seq_num: 0}} = HashOk.cbor_decode(payload_zero)
 
-      assert {:ok, %HashOk{key_type: :ecdh_p256_hkdf_sha256_aes_256_gcm}} =
-               HashOk.cbor_decode(payload_p256)
-
-      payload_x25519 = CBOR.encode([1])
-
-      assert {:ok, %HashOk{key_type: :ecdh_x25519_hkdf_sha256_aes_256_gcm}} =
-               HashOk.cbor_decode(payload_x25519)
-    end
-
-    test "returns error for valid CBOR with unknown algorithm code" do
-      unknown_alg_payload = CBOR.encode([99])
-      assert {:error, :invalid_payload} = HashOk.cbor_decode(unknown_alg_payload)
+      payload_large = CBOR.encode([65_535])
+      assert {:ok, %HashOk{seq_num: 65_535}} = HashOk.cbor_decode(payload_large)
     end
 
     test "returns error for valid CBOR with invalid inner structure" do
@@ -79,6 +66,21 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.KeyAgreement.HashOkTest do
     test "returns error for invalid malformed CBOR binary" do
       invalid_cbor = <<0xFF>>
       assert {:error, :invalid_payload} = HashOk.cbor_decode(invalid_cbor)
+    end
+  end
+
+  describe "cbor_encode/1 and cbor_decode/1 round-trip" do
+    test "round-trips successfully" do
+      original = %HashOk{seq_num: 123}
+
+      assert {:ok, decoded} = original |> HashOk.cbor_encode() |> HashOk.cbor_decode()
+      assert decoded.seq_num == original.seq_num
+    end
+
+    test "round-trips with seq_num 0" do
+      msg = %HashOk{seq_num: 0}
+      assert {:ok, decoded} = msg |> HashOk.cbor_encode() |> HashOk.cbor_decode()
+      assert decoded.seq_num == 0
     end
   end
 end


### PR DESCRIPTION
This PR aim to refactor the HashOk message structure of the Key Agreement protocol so the returned value is the associated SecretHash sequence number