### PR TITLE
fix: Solve capabilities message stalling queues

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater.ex
@@ -181,7 +181,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater do
 
     with_dup_and_message_tracker(realm, encoded_device_id, fn dup, message_tracker ->
       MessageTracker.track_delivery(message_tracker, message_id, delivery_tag)
-      GenServer.cast(dup, {:handle_capabilities, payload, tracking_id, timestamp})
+      GenServer.cast(dup, {:handle_capabilities, payload, message_id, timestamp})
     end)
   end
 

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/capabilities_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/capabilities_handler.ex
@@ -26,6 +26,8 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.CapabilitiesHandler do
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.Error
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
   alias Astarte.DataUpdaterPlant.DataUpdater.State
+  alias Astarte.DataUpdaterPlant.MessageTracker
+  alias Astarte.DataUpdaterPlant.TimeBasedActions
 
   require Logger
 
@@ -53,9 +55,18 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.CapabilitiesHandler do
 
     case parse_capabilities(payload, state) do
       {:ok, capabilities} ->
+        new_state = TimeBasedActions.execute_time_based_actions(state, timestamp)
+
         Queries.set_device_capabilities(realm, device_id, capabilities)
 
-        %State{state | capabilities: capabilities}
+        MessageTracker.ack_delivery(new_state.message_tracker, message_id)
+
+        received_bytes = byte_size(payload) + byte_size("/capabilities")
+
+        new_state
+        |> Map.update!(:total_received_msgs, &(&1 + 1))
+        |> Map.update!(:total_received_bytes, &(&1 + received_bytes))
+        |> Map.put(:capabilities, capabilities)
 
       {:error, error} ->
         handle_error(state, error, payload, message_id, timestamp)

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/server.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/server.ex
@@ -159,7 +159,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Server do
 
     if MessageTracker.can_process_message(state.message_tracker, message_id) do
       new_state = Impl.handle_capabilities(state, payload, message_id, timestamp)
-      {:no_reply, new_state}
+      {:noreply, new_state}
     else
       {:noreply, state, timeout}
     end

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/capabilities_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/capabilities_handler_test.exs
@@ -28,22 +28,27 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.CapabilitiesHandlerTest do
   alias Astarte.DataUpdaterPlant.DataUpdater
   alias Astarte.DataUpdaterPlant.DataUpdater.Core.CapabilitiesHandler
   alias Astarte.DataUpdaterPlant.DataUpdater.Queries
+  alias Astarte.DataUpdaterPlant.MessageTracker
 
   import Astarte.Helpers.DataUpdater
 
   setup_all %{realm_name: realm_name, device: device} do
-    setup_data_updater(realm_name, device.encoded_id)
+    %{message_tracker: message_tracker} = setup_data_updater(realm_name, device.encoded_id)
     state = DataUpdater.dump_state(realm_name, device.encoded_id)
 
-    %{state: state}
+    %{state: state, message_tracker: message_tracker}
   end
 
   describe "handle_capabilities/4" do
-    property "updates valid capabilities", %{realm_name: realm_name, state: state, device: device} do
+    property "updates valid capabilities", context do
+      %{realm_name: realm_name, state: state, device: device, message_tracker: message_tracker} =
+        context
+
       check all capabilities <- gen_capabilities(),
                 timestamp <- Timestamp.timestamp(),
                 tracking_id <- repeatedly(&gen_tracking_id/0) do
-        {message_id, _} = tracking_id
+        {message_id, delivery_tag} = tracking_id
+        MessageTracker.track_delivery(message_tracker, message_id, delivery_tag)
 
         payload =
           capabilities

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater_test.exs
@@ -26,6 +26,7 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
 
   alias Astarte.Core.CQLUtils
   alias Astarte.Core.Device
+  alias Astarte.Core.Device.Capabilities
   alias Astarte.Core.Mapping.EndpointsAutomaton
   alias Astarte.Core.Triggers.SimpleEvents.DeviceConnectedEvent
   alias Astarte.Core.Triggers.SimpleEvents.DeviceDisconnectedEvent
@@ -1639,6 +1640,55 @@ defmodule Astarte.DataUpdaterPlant.DataUpdaterTest do
 
     assert %State{last_seen_message: ^heartbeat_timestamp} =
              DataUpdater.dump_state(realm, encoded_device_id)
+  end
+
+  test "capability messages are correctly handled", %{
+    realm: realm,
+    helper_name: helper_name
+  } do
+    alias Astarte.DataUpdaterPlant.DataUpdater.State
+
+    AMQPTestHelper.clean_queue(helper_name)
+
+    encoded_device_id =
+      :crypto.strong_rand_bytes(16)
+      |> Base.url_encode64(padding: false)
+
+    {:ok, device_id} = Device.decode_device_id(encoded_device_id)
+
+    DatabaseTestHelper.insert_device(realm, device_id)
+
+    timestamp_us_x_10 = make_timestamp("2017-12-09T14:00:32+00:00")
+
+    # Make sure a process for the device exists
+    DataUpdater.handle_connection(
+      realm,
+      encoded_device_id,
+      "10.0.0.1",
+      gen_tracking_id(),
+      timestamp_us_x_10
+    )
+
+    capabilities_timestamp = make_timestamp("2023-05-12T18:05:32+00:00")
+
+    capabilities_payload =
+      %{
+        "purge_properties_compression_format" => "plaintext"
+      }
+      |> Cyanide.encode!()
+
+    DataUpdater.handle_capabilities(
+      realm,
+      encoded_device_id,
+      capabilities_payload,
+      gen_tracking_id(),
+      capabilities_timestamp
+    )
+
+    assert %State{last_seen_message: ^capabilities_timestamp, capabilities: device_capabilities} =
+             DataUpdater.dump_state(realm, encoded_device_id)
+
+    assert %Capabilities{purge_properties_compression_format: :plaintext} = device_capabilities
   end
 
   setup [:set_mox_from_context, :verify_on_exit!]


### PR DESCRIPTION
the tracking id was passed instead of the message id, creating a cascade
where the expected message id was never handled
