### PR TITLE
test(pairing): fix flakiness

### DIFF
--- a/apps/astarte_pairing/test/test_helper.exs
+++ b/apps/astarte_pairing/test/test_helper.exs
@@ -37,4 +37,8 @@ Mimic.copy(Astarte.Secrets)
 Mimic.copy(DateTime)
 Mimic.copy(HTTPoison)
 
+# fix flakiness due to async tests
+Astarte.Secrets.Core.create_nested_namespace(["fdo_owner_keys", "default_instance"])
+Astarte.Secrets.Core.create_nested_namespace(["fdo_owner_keys", "instance"])
+
 ExUnit.start(capture_log: true)


### PR DESCRIPTION
This PR aim to fix a flaky test in Astarte Pairing by adding sequential namespace creation before async tests start to avoid race condition