### PR TITLE
fix(dup): restore correct type validation checks for incoming data

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/data_updater/core/data_handler.ex
@@ -500,12 +500,14 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   end
 
   # TODO: We need tests for this function
-  def validate_value_type(expected_type, %DateTime{} = value) do
+  @spec validate_value_type(Mapping.t() | %{String.t() => Mapping.t()}, any()) ::
+          :ok | {:error, atom()}
+  def validate_value_type(%Mapping{value_type: expected_type}, %DateTime{} = value) do
     ValueType.validate_value(expected_type, value)
   end
 
   # From Cyanide 2.0, binaries are decoded as %Cyanide.Binary{}
-  def validate_value_type(expected_type, %Cyanide.Binary{} = value) do
+  def validate_value_type(%Mapping{value_type: expected_type}, %Cyanide.Binary{} = value) do
     %Cyanide.Binary{subtype: _subtype, data: bin} = value
     validate_value_type(expected_type, bin)
   end
@@ -515,10 +517,21 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
     {:error, :unexpected_value_type}
   end
 
-  def validate_value_type(%Mapping{value_type: expected_type}, value) do
-    validate_value_type(expected_type, value)
+  # TODO: we should test for this kind of unexpected messages
+  # We expected an individual value, but we received an aggregated
+  def validate_value_type(%Mapping{} = _expected_types, %{} = _object) do
+    {:error, :unexpected_value_type}
   end
 
+  def validate_value_type(%Mapping{value_type: expected_type}, value) do
+    if value != nil do
+      ValueType.validate_value(expected_type, value)
+    else
+      :ok
+    end
+  end
+
+  # object interface: validate all the types of the contained mappings
   def validate_value_type(%{} = mappings_by_key, %{} = object) do
     Enum.reduce_while(object, :ok, fn {key, value}, _acc ->
       with {:ok, %Mapping{value_type: expected_type}} <- Map.fetch(mappings_by_key, key),
@@ -539,23 +552,9 @@ defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler do
   end
 
   # TODO: we should test for this kind of unexpected messages
-  # We expected an individual value, but we received an aggregated
-  def validate_value_type(_expected_types, %{} = _object) do
-    {:error, :unexpected_value_type}
-  end
-
-  # TODO: we should test for this kind of unexpected messages
   # We expected an aggregated, but we received an individual
   def validate_value_type(%{} = _expected_types, _object) do
     {:error, :unexpected_value_type}
-  end
-
-  def validate_value_type(expected_type, value) do
-    if value != nil do
-      ValueType.validate_value(expected_type, value)
-    else
-      :ok
-    end
   end
 
   def update_stats(state, interface, major, path, payload) do

--- a/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_test.exs
+++ b/apps/astarte_data_updater_plant/test/astarte_data_updater_plant/data_updater/core/data_handler_test.exs
@@ -1,0 +1,113 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2026 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+defmodule Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandlerTest do
+  use Astarte.Cases.Data, async: true
+  use Astarte.Cases.Device
+  use Astarte.Cases.DataUpdater
+  use ExUnitProperties
+
+  alias Astarte.DataUpdaterPlant.DataUpdater.Core.DataHandler
+
+  import Astarte.InterfaceUpdateGenerators
+
+  @generated_data_points 100
+
+  describe "data_handler/6" do
+    test "correctly receives and validates payloads for all defined value types on individual datastream mappings",
+         context do
+      interface = context.individual_datastream_with_all_endpoint_types
+
+      timestamp = System.system_time(:microsecond) * 10
+      start = System.monotonic_time()
+
+      data_points =
+        gen_context(context.state, interface) |> Enum.take(@generated_data_points)
+
+      for data_point <- data_points do
+        %{
+          state: state,
+          interface: interface_name,
+          path: path,
+          payload: payload
+        } = data_point
+
+        assert {:ack, :ok, _, _} =
+                 DataHandler.handle_data(
+                   state,
+                   interface_name,
+                   path,
+                   payload,
+                   timestamp,
+                   start
+                 )
+      end
+    end
+
+    test "correctly receives and validates payloads for all defined value types on object datastream mappings",
+         context do
+      interface = context.object_datastream_with_all_endpoint_types
+
+      timestamp = System.system_time(:microsecond) * 10
+      start = System.monotonic_time()
+
+      data_points =
+        gen_context(context.state, interface) |> Enum.take(@generated_data_points)
+
+      for data_point <- data_points do
+        %{
+          state: state,
+          interface: interface_name,
+          path: path,
+          payload: payload
+        } = data_point
+
+        assert {:ack, :ok, _, _} =
+                 DataHandler.handle_data(
+                   state,
+                   interface_name,
+                   path,
+                   payload,
+                   timestamp,
+                   start
+                 )
+      end
+    end
+  end
+
+  defp gen_context(state, interface) do
+    gen all update <- valid_mapping_update_for(interface),
+            timestamp <- repeatedly(fn -> DateTime.utc_now(:millisecond) end) do
+      payload =
+        %{
+          "v" => update.value,
+          "t" => timestamp
+        }
+        |> Cyanide.encode!()
+
+      %{
+        state: state,
+        interface: interface.name,
+        path: update.path,
+        payload: payload
+      }
+    end
+  end
+end

--- a/apps/astarte_data_updater_plant/test/support/cases/device.ex
+++ b/apps/astarte_data_updater_plant/test/support/cases/device.ex
@@ -228,6 +228,14 @@ defmodule Astarte.Cases.Device do
       {:properties_server, fn acc -> new_interfaces(properties(:server), acc, :list) end},
       {:server_property_with_all_endpoint_types,
        fn acc -> [new_interfaces(all_endpoint_types(:server, :properties), acc, :single)] end},
+      {:individual_datastream_with_all_endpoint_types,
+       fn acc ->
+         [new_interfaces(all_endpoint_types(:device, :datastream, :individual), acc, :single)]
+       end},
+      {:object_datastream_with_all_endpoint_types,
+       fn acc ->
+         [new_interfaces(all_endpoint_types(:device, :datastream, :object), acc, :single)]
+       end},
       {:fixed_endpoint_interface,
        fn acc -> [new_interfaces(fixed_endpoint_interface(), acc, :single)] end},
       {:other_interfaces,
@@ -246,7 +254,11 @@ defmodule Astarte.Cases.Device do
       interfaces: all_interfaces,
       fixed_endpoint_interface: named_interfaces.fixed_endpoint_interface,
       server_property_with_all_endpoint_types:
-        named_interfaces.server_property_with_all_endpoint_types
+        named_interfaces.server_property_with_all_endpoint_types,
+      individual_datastream_with_all_endpoint_types:
+        named_interfaces.individual_datastream_with_all_endpoint_types,
+      object_datastream_with_all_endpoint_types:
+        named_interfaces.object_datastream_with_all_endpoint_types
     }
   end
 
@@ -277,10 +289,16 @@ defmodule Astarte.Cases.Device do
   end
 
   defp all_endpoint_types(ownership, type) do
+    gen all aggregation <- InterfaceGenerator.aggregation(type),
+            interface <- all_endpoint_types(ownership, type, aggregation) do
+      interface
+    end
+  end
+
+  defp all_endpoint_types(ownership, type, aggregation) do
     gen all name <- InterfaceGenerator.name(),
             major <- InterfaceGenerator.major_version(),
-            aggregation <- InterfaceGenerator.aggregation(type),
-            mappings <- all_endpoint_mappings(type, name, major, aggregation),
+            mappings <- all_endpoint_mappings(type, name, major),
             interface <-
               InterfaceGenerator.interface(
                 name: name,
@@ -294,12 +312,15 @@ defmodule Astarte.Cases.Device do
     end
   end
 
-  defp all_endpoint_mappings(type, name, major, :individual) do
+  defp all_endpoint_mappings(type, name, major) do
     gen all retention <- MappingGenerator.retention(type),
             reliability <- MappingGenerator.reliability(type),
             expiry <- MappingGenerator.expiry(type),
             allow_unset <- MappingGenerator.allow_unset(type),
             explicit_timestamp <- MappingGenerator.explicit_timestamp(type),
+            database_retention_policy <- MappingGenerator.database_retention_policy(type),
+            database_retention_ttl <-
+              MappingGenerator.database_retention_ttl(type, database_retention_policy),
             params = [
               interface_major: major,
               interface_type: type,
@@ -308,7 +329,9 @@ defmodule Astarte.Cases.Device do
               reliability: reliability,
               expiry: expiry,
               allow_unset: allow_unset,
-              explicit_timestamp: explicit_timestamp
+              explicit_timestamp: explicit_timestamp,
+              database_retention_policy: database_retention_policy,
+              database_retention_ttl: database_retention_ttl
             ],
             double_mappings <- mappings(:double, params),
             integer_mappings <- mappings(:integer, params),


### PR DESCRIPTION
A regression was previously introduced on the data type validation for incoming data payloads, allowing some of them to be incorrectly rejected. This commit fixes it.

Added also property-based tests to check for correct handling of incoming data payloads in DUP.

#### What this PR does / why we need it:

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

<!--
This section can be blank if this pull request does not require additional resources.
-->

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Astarte development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.astarte-platform.org/astarte/snapshot/001-dev_guide.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
