### PR TITLE
fix(dup): force periodic full sweep GC to bound AMQP consumer memory

### DIFF
--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/application.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/application.ex
@@ -43,6 +43,11 @@ defmodule Astarte.DataUpdaterPlant.Application do
     Config.validate!()
     DataAccessConfig.validate!()
 
+    # Force more frequent garbage collections (default fullsweep_after is 65535) so that
+    # data retained by long-lived AMQP consumer processes get reclaimed instead of
+    # accumulating as uncollected garbage.
+    :erlang.system_flag(:fullsweep_after, Config.fullsweep_after!())
+
     children = [
       Astarte.DataUpdaterPlantWeb.Telemetry,
       {Astarte.Events.AMQPEvents.Supervisor, []},

--- a/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
+++ b/apps/astarte_data_updater_plant/lib/astarte_data_updater_plant/config.ex
@@ -241,6 +241,14 @@ defmodule Astarte.DataUpdaterPlant.Config do
           type: Astarte.DataUpdaterPlant.Config.TelemetryType,
           default: :expose
 
+  @envdoc """
+  The number of minor garbage collections a process performs before a full sweep is forced, i.e. Erlang's `fullsweep_after` system flag. AMQP consumer processes handle a high volume of short-lived message payloads; with the VM's default of 65535, a full sweep can be delayed long enough for those binaries to pile up as uncollected garbage. Lowering this value forces more frequent full sweeps.
+  """
+  app_env :fullsweep_after, :astarte_data_updater_plant, :fullsweep_after,
+    os_env: "DATA_UPDATER_PLANT_FULLSWEEP_AFTER",
+    type: :integer,
+    default: 20
+
   # Since we have one channel per queue, this is not configurable
   def amqp_consumer_channels_per_connection_number! do
     ceil(data_queue_total_count!() / amqp_consumer_connection_number!())


### PR DESCRIPTION
Erlang's default fullsweep_after (65535) lets long-lived AMQP consumer processes accumulate uncollected binaries across many minor garvage collections before a full sweep runs, inflating the memory.

This PR aim to add  a configurable, lower fullsweep_after (default 20) via a new DATA_UPDATER_PLANT_FULLSWEEP_AFTER env var at application start so full sweeps happen often enough to reclaim it.