### PR TITLE
fix: route AppEngine room events across replicas

### DIFF
--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/events_dispatcher.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/events_dispatcher.ex
@@ -25,6 +25,9 @@ defmodule Astarte.AppEngine.API.Rooms.EventsDispatcher do
   alias Astarte.AppEngine.API.RPC.DataUpdaterPlant
   alias Astarte.Core.Triggers.SimpleEvents.SimpleEvent
 
+  @room_lookup_attempts 3
+  @room_lookup_retry_interval_ms 100
+
   require Logger
 
   def dispatch(serialized_simple_event) do
@@ -49,8 +52,7 @@ defmodule Astarte.AppEngine.API.Rooms.EventsDispatcher do
       end
 
     with {:room_pid, [{pid, _}]} <-
-           {:room_pid,
-            Registry.lookup(Registry.AstarteRooms, {:parent_trigger_id, parent_trigger_id})},
+           {:room_pid, lookup_room({:parent_trigger_id, parent_trigger_id})},
          :ok <- Room.broadcast_event(pid, simple_trigger_id, device_id, timestamp, event) do
       :ok
     else
@@ -101,6 +103,23 @@ defmodule Astarte.AppEngine.API.Rooms.EventsDispatcher do
         )
 
         {:error, :dispatch_error}
+    end
+  end
+
+  defp lookup_room(parent_trigger_key, attempts \\ @room_lookup_attempts)
+
+  defp lookup_room(parent_trigger_key, 1) do
+    Horde.Registry.lookup(Registry.AstarteRooms, parent_trigger_key)
+  end
+
+  defp lookup_room(parent_trigger_key, attempts) do
+    case Horde.Registry.lookup(Registry.AstarteRooms, parent_trigger_key) do
+      [] ->
+        Process.sleep(@room_lookup_retry_interval_ms)
+        lookup_room(parent_trigger_key, attempts - 1)
+
+      room ->
+        room
     end
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/master_supervisor.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/master_supervisor.ex
@@ -31,7 +31,7 @@ defmodule Astarte.AppEngine.API.Rooms.MasterSupervisor do
 
   def init(_arg) do
     children = [
-      {Registry, keys: :unique, name: Registry.AstarteRooms},
+      {Horde.Registry, keys: :unique, name: Registry.AstarteRooms, members: :auto},
       Astarte.AppEngine.API.Rooms.RoomsSupervisor
     ]
 

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/room.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/room.ex
@@ -59,9 +59,9 @@ defmodule Astarte.AppEngine.API.Rooms.Room do
         # No realm name in args
         {:error, :no_realm_name}
 
-      {:error, {:already_started, pid}} ->
+      {:error, {:already_started, _pid}} ->
         # Already started, we don't care
-        {:ok, pid}
+        :ignore
 
       other ->
         # Relay everything else
@@ -101,7 +101,7 @@ defmodule Astarte.AppEngine.API.Rooms.Room do
     realm = Keyword.get(args, :realm)
     room_uuid = Utils.get_uuid()
 
-    {:ok, _} = Registry.register(Registry.AstarteRooms, {:parent_trigger_id, room_uuid}, [])
+    {:ok, _} = Horde.Registry.register(Registry.AstarteRooms, {:parent_trigger_id, room_uuid}, [])
 
     :telemetry.execute(
       [:astarte, :appengine, :channels, :room_opened],
@@ -451,6 +451,6 @@ defmodule Astarte.AppEngine.API.Rooms.Room do
   # Helpers
 
   defp via_tuple(room_name) do
-    {:via, Registry, {Registry.AstarteRooms, room_name}}
+    {:via, Horde.Registry, {Registry.AstarteRooms, room_name}}
   end
 end

--- a/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/rooms_supervisor.ex
+++ b/apps/astarte_appengine_api/lib/astarte_appengine_api/rooms/rooms_supervisor.ex
@@ -32,11 +32,20 @@ defmodule Astarte.AppEngine.API.Rooms.RoomsSupervisor do
   end
 
   def start_room(realm, room_name) do
-    DynamicSupervisor.start_child(__MODULE__, {Room, realm: realm, room_name: room_name})
+    case DynamicSupervisor.start_child(__MODULE__, {Room, realm: realm, room_name: room_name}) do
+      :ignore ->
+        case Horde.Registry.lookup(Registry.AstarteRooms, room_name) do
+          [{pid, _value}] -> {:ok, pid}
+          [] -> {:error, :room_not_registered}
+        end
+
+      result ->
+        result
+    end
   end
 
   def room_started?(room_name) do
-    case Registry.lookup(Registry.AstarteRooms, room_name) do
+    case Horde.Registry.lookup(Registry.AstarteRooms, room_name) do
       [] ->
         false
 

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/channels/rooms_channel_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/channels/rooms_channel_test.exs
@@ -588,10 +588,11 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
       refute_broadcast "new_event", %{"device_id" => @device_id, "event" => _event}
     end
 
-    test "a transient registry miss does not uninstall a live room trigger", %{
-      socket: socket,
-      room_process: room_process
-    } = context do
+    test "a transient registry miss does not uninstall a live room trigger",
+         %{
+           socket: socket,
+           room_process: room_process
+         } = context do
       :ok = Mimic.set_mimic_private(context)
       Mimic.verify_on_exit!(context)
 

--- a/apps/astarte_appengine_api/test/astarte_appengine_api_web/channels/rooms_channel_test.exs
+++ b/apps/astarte_appengine_api/test/astarte_appengine_api_web/channels/rooms_channel_test.exs
@@ -23,6 +23,7 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
   alias Astarte.AppEngine.API.Groups
   alias Astarte.AppEngine.API.Rooms.EventsDispatcher
   alias Astarte.AppEngine.API.Rooms.Room
+  alias Astarte.AppEngine.API.Rooms.RoomsSupervisor
   alias Astarte.AppEngine.API.Utils
   alias Astarte.AppEngine.APIWeb.RoomsChannel
   alias Astarte.AppEngine.APIWeb.UserSocket
@@ -175,6 +176,20 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
       assert {:ok, _reply, socket} = join(socket, "rooms:#{@realm}:#{@authorized_room_name}")
       assert socket.assigns[:room_name] == "#{@realm}:#{@authorized_room_name}"
       assert Room.clients_count("#{@realm}:#{@authorized_room_name}") == 1
+    end
+
+    test "joining the same room resolves one cluster-wide room process", %{socket: first_socket} do
+      room_name = "#{@realm}:#{@authorized_room_name}"
+      token = JWTTestHelper.gen_channels_jwt_all_access_token()
+      {:ok, second_socket} = connect(UserSocket, %{"realm" => @realm, "token" => token})
+
+      assert {:ok, _reply, _first_socket} = join(first_socket, "rooms:#{room_name}")
+      assert {:ok, _reply, _second_socket} = join(second_socket, "rooms:#{room_name}")
+
+      assert [{room_process, _}] = Horde.Registry.lookup(Registry.AstarteRooms, room_name)
+      assert {:ok, ^room_process} = RoomsSupervisor.start_room(@realm, room_name)
+      assert Room.clients_count(room_name) == 2
+      assert Process.alive?(room_process)
     end
   end
 
@@ -573,6 +588,59 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
       refute_broadcast "new_event", %{"device_id" => @device_id, "event" => _event}
     end
 
+    test "a transient registry miss does not uninstall a live room trigger", %{
+      socket: socket,
+      room_process: room_process
+    } = context do
+      :ok = Mimic.set_mimic_private(context)
+      Mimic.verify_on_exit!(context)
+
+      Astarte.AppEngine.API.RPC.DataUpdaterPlant.ClientMock
+      |> allow(self(), room_process)
+      |> expect(:install_volatile_trigger, fn volatile_trigger ->
+        assert %{realm_name: @realm, device_id: @device_id} = volatile_trigger
+        :ok
+      end)
+      |> expect(:delete_volatile_trigger, fn _ -> :ok end)
+
+      watch_payload = %{
+        "device_id" => @device_id,
+        "name" => @name,
+        "simple_trigger" => @data_simple_trigger
+      }
+
+      ref = push(socket, "watch", watch_payload)
+      assert_broadcast("watch_added", _)
+      assert_reply(ref, :ok, %{})
+
+      %{room_uuid: room_uuid, watch_id_to_request: watch_map} = :sys.get_state(room_process)
+      [simple_trigger_id | _] = Map.keys(watch_map)
+      parent_trigger_key = {:parent_trigger_id, room_uuid}
+
+      Mimic.expect(Horde.Registry, :lookup, 2, fn Registry.AstarteRooms, ^parent_trigger_key ->
+        case Process.get(:room_lookup_attempt, 0) do
+          0 ->
+            Process.put(:room_lookup_attempt, 1)
+            []
+
+          1 ->
+            Mimic.call_original(Horde.Registry, :lookup, [
+              Registry.AstarteRooms,
+              parent_trigger_key
+            ])
+        end
+      end)
+
+      serialized_event =
+        %{@simple_event | parent_trigger_id: room_uuid, simple_trigger_id: simple_trigger_id}
+        |> SimpleEvent.encode()
+
+      assert :ok = EventsDispatcher.dispatch(serialized_event)
+      assert_broadcast "new_event", _
+
+      watch_cleanup(socket, @name)
+    end
+
     test "an event for a watched trigger belonging to a room triggers a broadcast", %{
       socket: socket,
       room_process: room_process
@@ -599,11 +667,20 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
 
       [simple_trigger_id | _] = Map.keys(watch_map)
 
+      assert [{^room_process, _}] =
+               Horde.Registry.lookup(
+                 Registry.AstarteRooms,
+                 {:parent_trigger_id, room_uuid}
+               )
+
       existing_room_serialized_event =
         %{@simple_event | parent_trigger_id: room_uuid, simple_trigger_id: simple_trigger_id}
         |> SimpleEvent.encode()
 
-      assert :ok = EventsDispatcher.dispatch(existing_room_serialized_event)
+      dispatcher_task =
+        Task.async(fn -> EventsDispatcher.dispatch(existing_room_serialized_event) end)
+
+      assert :ok = Task.await(dispatcher_task)
 
       timestamp = DateTime.from_unix!(@timestamp, :millisecond)
 
@@ -612,6 +689,8 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
         "timestamp" => ^timestamp,
         "event" => event
       })
+
+      refute_broadcast "new_event", _
 
       assert %{
                "type" => "incoming_data",
@@ -720,7 +799,7 @@ defmodule Astarte.AppEngine.APIWeb.RoomsChannelTest do
   end
 
   defp room_process(room_name) do
-    case Registry.lookup(Registry.AstarteRooms, room_name) do
+    case Horde.Registry.lookup(Registry.AstarteRooms, room_name) do
       [{pid, _opts}] -> pid
     end
   end


### PR DESCRIPTION
#### What this PR does / why we need it:

Replace the local Rooms registry child in `MasterSupervisor` with a unique, auto-membered `Horde.Registry`, retaining its supervision ordering with `RoomsSupervisor`. Update Room registration and `:via` naming, room-existence checks, and event dispatch lookup to consistently use the Horde registry so any AMQP consumer replica can resolve and call the Room process on its owning node. Keep the shared queue and existing volatile-trigger lifecycle: `EventsDispatcher` should still delete a trigger when the cluster-wide lookup proves that no Room owns the parent trigger, and when an existing Room reports that the simple trigger is no longer watched.

AppEngine replicas currently compete on one Rooms AMQP queue, but each replica can only find Room processes in its node-local `Registry.AstarteRooms`. An event consumed on a replica other than the Room owner is therefore classified as targeting a dead room, discarded, and followed by deletion of its still-live volatile trigger. This makes Channels delivery nondeterministic and permanently stops the watch after the first misrouted event. The repository already uses auto-membered Horde registries for cross-node RPC discovery, providing an established cluster-aware registration pattern for Rooms.

Fixes #2077

#### Additional documentation e.g. usage docs, diagrams, reviewer notes, etc.:

---

<details>
<summary><i>Thanks for sending a pull request! If this is your first time, here are some tips for you:</i></summary>

1. You can take a look at our [developer guide] for an introduction on Astarte development!
2. Make sure to read [CONTRIBUTING.md] and [CODE_OF_CONDUCT.md]
3. If the PR is unfinished or you're actively working on it, mark it as draft

When fixing existing issues, use [github's syntax to link your pull request] to it

> `fixes #<issue number>`

We also have a syntax to signal dependencies to other open pull requests

> `depends on #<pr number>`
> `depends on https://github.com/...`

In case of stacked PRs, you may add the PR number in the last commit's title instead:

> ```mermaid
> gitGraph
>     commit id: "Current master"
>     branch feat1
>     checkout feat1
>     commit id: "feat: add something"
>     commit id: "feat: add something else (#100)"
>     branch feat2
>     checkout feat2
>     commit id: "refactor: do something"
>     commit id: "fix: solve issue"
>     commit id: "feat: add a feature (#101)"
>     branch feat3
>     checkout feat3
>     commit id: "feat: feat without pr number"
> ```

</details>

[github's syntax to link your pull request]: https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#about-linked-issues-and-pull-requests
[developer guide]: https://docs.astarte-platform.org/astarte/snapshot/001-dev_guide.html
[CONTRIBUTING.md]: ../CONTRIBUTING.md
[CODE_OF_CONDUCT.md]: ../CODE_OF_CONDUCT.md
