### PR TITLE
build(e2e): fix docker build

### DIFF
--- a/tools/astarte_e2e/Dockerfile
+++ b/tools/astarte_e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bullseye-20230612-slim AS builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-bookworm-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -36,7 +36,7 @@ COPY tools/astarte_e2e .
 RUN mix do compile, release
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-20230612-slim
+FROM debian:bookworm-20230612-slim
 
 WORKDIR /app
 
@@ -47,7 +47,7 @@ ENV LANG=C.UTF-8
 
 # We need SSL
 RUN apt-get update -y && \
-    apt-get install libssl1.1 ca-certificates -y --no-install-recommends && \
+    apt-get install openssl ca-certificates -y --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
 # We have to redefine this here since it goes out of scope for each build stage


### PR DESCRIPTION
some bullseye packages are now returning 404. use bookworm instead